### PR TITLE
Persiste redux state, clear stories and messages on navigation

### DIFF
--- a/src/App/components/ChatView/index.js
+++ b/src/App/components/ChatView/index.js
@@ -5,19 +5,19 @@ import { ScrollBody } from './style';
 
 class ChatView extends Component{
   render() {
-
 		return (
       <ScrollBody>
-        { this.props.messages !== null &&
-          this.props.messages.map((group, i) => {
-            return (
-              <ul key={i} style={{marginBottom: '2rem'}}>
-                {group.map((message, i) => {
-                  return <li key={i}>{message.message}</li>
-                })}
-              </ul>
-            )
-          })
+        { this.props.messages && this.props.messages.length > 0
+          ? this.props.messages.map((group, i) => {
+              return (
+                <ul key={i} style={{marginBottom: '2rem'}}>
+                  {group.map((message, i) => {
+                    return <li key={i}>{message.message}</li>
+                  })}
+                </ul>
+              )
+            })
+          : ''
         } 
       </ScrollBody>
 	  );

--- a/src/App/components/NavBar/index.js
+++ b/src/App/components/NavBar/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { addFrequency, setActiveFrequency } from '../../../actions/frequencies'
 import { setStories } from '../../../actions/stories'
+import { setMessages } from '../../../actions/messages'
 import { signOut, login } from '../../../actions/user'
 import { Column, Avatar, Header, MetaWrapper, Form, Input, Button, Name, MetaLink, FreqList, FreqActive, Freq, FreqLabel, FreqIcon, Footer, FooterLogo, FooterMeta } from './style';
 import { AvatarMask } from './svg';
@@ -34,6 +35,7 @@ class NavBar extends Component{
   setActiveFrequency = (e) => {
     this.props.dispatch(setActiveFrequency(e.target.id))
     this.props.dispatch(setStories())
+    this.props.dispatch(setMessages(''))
   }
 
   addFrequency = (e) => {

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -5,6 +5,7 @@ import StoryMaster from './components/StoryMaster';
 import DetailView from './components/DetailView';
 import { Provider } from 'react-redux'
 import { initStore } from '../store'
+import { loadState, saveState } from '../helpers/localStorage'
 // import ListDetail from './components/ListDetail';
 import * as firebase from 'firebase';
 import { setUser } from '../actions/user';
@@ -23,7 +24,13 @@ export default class App extends Component {
     super()
     firebase.initializeApp(fbconfig);
 
-    this.store = initStore({})
+    const localStorageState = loadState()
+    this.store = initStore(localStorageState)
+
+    this.store.subscribe(() => {
+      saveState(this.store.getState())
+    })
+
     this.store.dispatch(setUser()) // on first load, set the user
     this.store.dispatch(setFrequencies()) // on first load, get frequences from the server
   }

--- a/src/actions/frequencies.js
+++ b/src/actions/frequencies.js
@@ -12,14 +12,6 @@ export const setFrequencies = () => (dispatch) => {
 	  	type: 'SET_FREQUENCIES',
 	  	frequencies: frequencies
 	  })
-
-    if (frequencies[0]) {
-	    // when we first set the freqeuencies, make the first one in the list active by default
-		  dispatch({
-				type: 'SET_ACTIVE_FREQUENCY',
-				id: frequencies[0].id
-			})
-		}
   })
 }
 

--- a/src/actions/messages.js
+++ b/src/actions/messages.js
@@ -5,6 +5,17 @@ export const setMessages = (id) => (dispatch, getState) => {
 	let messages = firebase.database().ref('messages')
 
   messages.orderByChild('storyId').equalTo(id).on('value', function(snapshot){
+    // if there are no messages available in the story, or no story is selected, clear the messages state
+    console.log('messages are: ', snapshot.val())
+    if (!snapshot.val()) {
+      dispatch({
+        type: 'SET_MESSAGES',
+        messages: []
+      })
+
+      return
+    };
+
     const messages = hashToArray(snapshot.val())
     const sortedMessages = sortAndGroupBubbles(messages)
     dispatch({

--- a/src/actions/stories.js
+++ b/src/actions/stories.js
@@ -7,10 +7,25 @@ export const setStories = () => (dispatch, getState) => {
 
   stories.orderByChild('frequency').equalTo(activeFrequency).on('value', function(snapshot){
     const snapval = snapshot.val();
-    if (!snapval) return true;
+
+    // if there aren't stories for this frequency, clear the stories from state
+    if (!snapval) {
+      dispatch({
+        type: 'SET_STORIES',
+        stories: []
+      })
+
+      dispatch({
+        type: 'SET_ACTIVE_STORY',
+        id: ''
+      })
+
+      return
+    };
     // test to see if this is a snapshot of the full list
     let key = Object.keys(snapshot.val())[0];
     const stories = hashToArray(snapshot.val())
+    console.log('stories being set are: ', stories)
     if (snapshot.val()[key].creator){
       dispatch({
         type: 'SET_STORIES',
@@ -93,5 +108,10 @@ export const setActiveStory = (id) => (dispatch) => {
   dispatch({
     type: 'SET_ACTIVE_STORY',
     id
+  })
+
+  dispatch({
+    type: 'SET_MESSAGES',
+    mesages: ''
   })
 }

--- a/src/helpers/localStorage.js
+++ b/src/helpers/localStorage.js
@@ -1,0 +1,20 @@
+export const loadState = () => {
+	try {
+		const serializedState = localStorage.getItem('state')
+		if (serializedState === null) {
+			return undefined
+		}
+		return JSON.parse(serializedState)
+	} catch (err) {
+		return undefined
+	}
+}
+
+export const saveState = (state) => {
+	try {
+		const serializedState = JSON.stringify(state)
+		localStorage.setItem('state', serializedState)
+	} catch (err) {
+		// errors here
+	}
+}

--- a/src/store.js
+++ b/src/store.js
@@ -7,7 +7,13 @@ const composeEnhancers = (typeof window !== 'undefined' && window.__REDUX_DEVTOO
 
 // init the store with the thunkMiddleware which allows us to make async actions play nicely with the store
 export const initStore = (initialState) => {
-  return createStore(reducers, initialState, composeEnhancers(
-		applyMiddleware(thunkMiddleware)
-	))
+	if (initialState) {
+	  return createStore(reducers, initialState, composeEnhancers(
+			applyMiddleware(thunkMiddleware)
+		))
+	} else {		
+		return createStore(reducers, {}, composeEnhancers(
+			applyMiddleware(thunkMiddleware)
+		))
+	}
 }


### PR DESCRIPTION
Hey @jcutrell and @uberbryn –

This branch does two things:
1. We sync our redux state at all times with localStorage. Each time an action is dispatched, the store subscribes to a 'saveState()' function. What this means is that when a returning user loads spectrum, data will populate almost instantly from localstorage while our background api calls to firebase fetch new data.

2. I also added some dispatches so that when a user swaps frequencies we clear the stories column and we clear the chat. Let's play around and see how this decision feels from a user experience perspective.

@jcutrell – one thing I'm worried about is how some of our actions cascade around and it's hard to keep track of the flow of state. For example, when I create a new frequency we make a few dispatches to create, set stories, and set messages. Not sure if there's better logic here, so totally open to suggestions :)