### PR TITLE
Only show redux devtools outside of production

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -2,8 +2,10 @@ import { createStore, compose, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import reducers from './reducers';
 
-// this enables the chrome devtools for redux
-const composeEnhancers = typeof window !== 'undefined' &&
+// this enables the chrome devtools for redux only in development
+const composeEnhancers = 
+  process.env.NODE_ENV !== 'production' &&
+  typeof window !== 'undefined' &&
   window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ||
   compose;
 


### PR DESCRIPTION
Fixes #85 