### PR TITLE
Refactor shape of messages in store

### DIFF
--- a/src/App/components/ChatDetail/index.js
+++ b/src/App/components/ChatDetail/index.js
@@ -70,7 +70,7 @@ const mapStateToProps = state => {
   return {
     user: state.user,
     stories: state.stories,
-    messages: state.messages.messages,
+    messages: state.messages.messages[state.stories.active],
   };
 };
 

--- a/src/reducers/messages.js
+++ b/src/reducers/messages.js
@@ -1,25 +1,15 @@
 const initialState = {
-  messages: [],
+  messages: {},
 };
 
 export default function root(state = initialState, action) {
   switch (action.type) {
     case 'SET_MESSAGES':
       return Object.assign({}, state, {
-        messages: action.messages,
-      });
-    case 'SET_ACTIVE_STORY':
-    case 'CLEAR_MESSAGE':
-    case 'CLEAR_STORY':
-      return Object.assign({}, state, {
-        messages: '',
-      });
-    case 'SEND_MESSAGE':
-      let newMessages = state.messages;
-      console.log('new messages are: ', newMessages);
-      newMessages.push(action.message);
-      return Object.assign({}, state, {
-        messages: newMessages,
+        messages: {
+          ...state.messages,
+          [action.story]: action.messages,
+        }
       });
     default:
       return state;


### PR DESCRIPTION
By storing messages under the key of the story they belong to we can keep all messages around, even when the story isn't open.

Apart from leading to performance improvements (since old messages are already in the store we can immediately show them) this also means we can get rid of manual message clearing (all messages are always around, but only the ones of the active story are shown—no need to clear anything) and will allow us to move towards centralised database listening. (ref #130)

This is now similar to how we handle frequencies<->stories, where all the stories for all frequencies are always in the state and then filtered based on the open frequency.