### PR TITLE
Change frequency paths to /~frequency

### DIFF
--- a/src/App/components/NavMaster/index.js
+++ b/src/App/components/NavMaster/index.js
@@ -103,7 +103,7 @@ class NavigationMaster extends Component {
           {frequencies &&
             frequencies.map((frequency, i) => {
               return (
-                <Link to={`/${frequency.id}`} key={i}>
+                <Link to={`/~${frequency.id}`} key={i}>
                   <Freq active={frequency.id === activeFrequency}>
                     <FreqGlyph>~</FreqGlyph>
                     <FreqLabel>{frequency.name}</FreqLabel>

--- a/src/App/components/ShareCard/index.js
+++ b/src/App/components/ShareCard/index.js
@@ -17,14 +17,14 @@ const ShareCard = props => {
         <Input
           onFocus={e => handleFocus(e)}
           readOnly
-          value={`https://spectrum.chat/${props.data.id}`}
+          value={`https://spectrum.chat/~${props.data.id}`}
         />
         <ButtonWrapper>
           <Button
             type={'twitter'}
             target="_blank"
             href={
-              `https://twitter.com/share?text=${props.data.name}&url=https://spectrum.chat/${props.data.id}&via=withspectrum`
+              `https://twitter.com/share?text=${props.data.name}&url=https://spectrum.chat/~${props.data.id}&via=withspectrum`
             }
           >
             Share on Twitter
@@ -33,7 +33,7 @@ const ShareCard = props => {
             type={'facebook'}
             target="_blank"
             href={
-              `https://www.facebook.com/sharer/sharer.php?u=https://spectrum.chat/${props.data.id}`
+              `https://www.facebook.com/sharer/sharer.php?u=https://spectrum.chat/~${props.data.id}`
             }
           >
             Post to Facebook

--- a/src/App/components/StoryCard/index.js
+++ b/src/App/components/StoryCard/index.js
@@ -108,11 +108,11 @@ class Story extends Component {
           {story.content.media && story.content.media !== ''
             ? <Media src={story.content.media} onClick={this.showGallery} />
             : ''}
-          <Link to={`/${story.frequency}`}>
+          <Link to={`/~${story.frequency}`}>
             <MetaFreq>{
                   this.props.frequencies.active === 'all' ?
                     `~${storyFrequencyName}`
-                  : 
+                  :
                     ``
                 }
             </MetaFreq>

--- a/src/App/components/StoryMaster/index.js
+++ b/src/App/components/StoryMaster/index.js
@@ -60,7 +60,6 @@ class StoryMaster extends Component {
       );
     }
 
-    let urlBase = frequencies.active === 'all' ? 'all' : frequencies.active;
     let usersPermissionOnFrequency = helpers.getFrequencyPermission(
       user,
       frequencies.active,
@@ -200,7 +199,7 @@ class StoryMaster extends Component {
               // slice and reverse makes sure our stories show up in revers chron order
               sortedStories.slice().reverse().map((story, i) => {
                 return (
-                  <Link to={`/${urlBase}/${story.id}`} key={i}>
+                  <Link to={`/~${frequencies.active}/${story.id}`} key={i}>
                     <StoryCard data={story} key={i} />
                   </Link>
                 );

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ let store;
 if (process.env.NODE_ENV === 'production') {
   let localStorageState = helpers.loadState();
   store = initStore(localStorageState);
-  
+
   // sync the store with localstorage
   store.subscribe(() => {
     helpers.saveState(store.getState())
@@ -82,8 +82,8 @@ const Root = () => {
             <ModalRoot />
             <GalleryRoot />
             <Match exactly pattern="/" component={App} />
-            <Match exactly pattern="/:frequency" component={App} />
-            <Match exactly pattern="/:frequency/:story" component={App} />
+            <Match exactly pattern="/~:frequency" component={App} />
+            <Match exactly pattern="/~:frequency/:story" component={App} />
           </Body>
         </ThemeProvider>
       </BrowserRouter>


### PR DESCRIPTION
Note: This currently looks a bit crap because all our frequncy and story IDs start with a dash. (e.g. `/~-KDFasd924`) Can we change that in firebase? If we're going to have vanity URLs anyway we don't have to fix the IDs since then it's going to look like `/~hugs-and-bugs`.

Closes #149

> I might've missed some links, so if you find a broken link down the line just submit a followup PR.