### PR TITLE
Fix ShareCard looking like it's selectable

### DIFF
--- a/src/App/components/ShareCard/index.js
+++ b/src/App/components/ShareCard/index.js
@@ -8,14 +8,15 @@ const ShareCard = props => {
   };
 
   return (
-    <StoryWrapper>
+    <StoryWrapper static>
 
       <Body>
         <Title>Get the conversation started.</Title>
 
         <Desc>Share your new frequency with the world!</Desc>
         <Input
-          onFocus={e => handleFocus(e)}
+          onClick={handleFocus}
+          onFocus={handleFocus}
           readOnly
           value={`https://spectrum.chat/${props.data.id}`}
         />

--- a/src/App/components/StoryCard/style.js
+++ b/src/App/components/StoryCard/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Shadow, H4, H5 } from '../../../shared/Globals';
 
 export const StoryWrapper = styled.div`
@@ -17,14 +17,15 @@ export const StoryWrapper = styled.div`
     ? `-16px 0 0 -8px ${props.theme.brand.default}`
     : `0px 0 0 0px transparent`};
 
-	&:hover {
-		box-shadow: ${Shadow.high}, inset ${props =>
-  props.selected
-    ? `-24px 0 0 -8px ${props.theme.brand.default}`
-    : `-16px 0 0 -8px ${props.theme.border.default}`};
-		transition: all 0.2s ease-out;
-		cursor: pointer;
-	}
+	${props => !props.static && css`
+		&:hover {
+			box-shadow: ${Shadow.high}, inset ${props.selected
+	    ? `-24px 0 0 -8px ${props.theme.brand.default}`
+	    : `-16px 0 0 -8px ${props.theme.border.default}`};
+			transition: all 0.2s ease-out;
+			cursor: pointer;
+		}
+	`}
 `;
 
 export const StoryBody = styled.div`


### PR DESCRIPTION
The ShareCard would have the same hover styling as the selectable cards
without being actually selectable. This fixes it by introducing a
`static` prop to the `StoryWrapper` which prevents this behaviour.