### PR TITLE
Disallow empty frequency name

### DIFF
--- a/src/App/components/NavMaster/index.js
+++ b/src/App/components/NavMaster/index.js
@@ -60,7 +60,9 @@ class NavigationMaster extends Component {
 
   addFrequency = e => {
     e.preventDefault();
-    this.props.dispatch(actions.addFrequency(this.state.frequencyName));
+    const frequencyName = this.state.frequencyName.trim();
+    if (frequencyName === '') return;
+    this.props.dispatch(actions.addFrequency(frequencyName));
     this.setState({
       frequencyName: '',
     });


### PR DESCRIPTION
Note: We need to enforce this on the backend as well, otherwise people
can work around this by manually submitting a POST request.