### PR TITLE
Rename setX actions to loadX

### DIFF
--- a/src/App/components/Composer/index.js
+++ b/src/App/components/Composer/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { updateTitle, updateBody } from '../../../actions/composer';
 import { publishStory, initStory } from '../../../actions/stories';
-import { setMessages } from '../../../actions/messages';
+import { loadMessages } from '../../../actions/messages';
 import { uploadMultipleMedia } from '../../../helpers/stories';
 import Textarea from 'react-textarea-autosize';
 
@@ -104,7 +104,7 @@ class Composer extends Component {
       // if everything is filled out
       this.props.dispatch(publishStory(newStoryObj)).then(() => {
         // after the story is created, we need to set messages so that the chat will work right away
-        this.props.dispatch(setMessages());
+        this.props.dispatch(loadMessages());
       });
     } else if (!frequency && title) {
       // if no frequency is chosen

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -6,8 +6,8 @@ import StoryMaster from './components/StoryMaster';
 import DetailView from './components/DetailView';
 import LoadingIndicator from '../shared/loading';
 import { setActiveFrequency } from '../actions/frequencies';
-import { setActiveStory, setStories } from '../actions/stories';
-import { setMessages } from '../actions/messages';
+import { setActiveStory, loadStories } from '../actions/stories';
+import { loadMessages } from '../actions/messages';
 
 class App extends Component {
   componentWillMount() {
@@ -19,24 +19,20 @@ class App extends Component {
 
     if (activeStoryParam) {
       dispatch(setActiveStory(activeStoryParam));
-      dispatch(setMessages());
+      dispatch(loadMessages());
     }
-  }
-
-  shouldComponentUpdate(nextProps, nextState) {
-    return true;
   }
 
   componentWillReceiveProps(nextProps) {
     const { dispatch, params } = this.props;
     if (nextProps.params.frequency !== params.frequency) {
       dispatch(setActiveFrequency(nextProps.params.frequency));
-      dispatch(setStories());
+      dispatch(loadStories());
     }
 
     if (nextProps.params.story !== params.frequency) {
       dispatch(setActiveStory(nextProps.params.story));
-      dispatch(setMessages());
+      dispatch(loadMessages());
     }
   }
 

--- a/src/actions/frequencies.js
+++ b/src/actions/frequencies.js
@@ -51,7 +51,7 @@ export const setActiveFrequency = id => ({
 /*------------------------------------------------------------\*
 *
 
-setFrequencies
+loadFrequencies
 This creates an active listener to the frequencies that are saved in the database.
 
 NOTE: Right now we are returning ALL frequencies. This will need to change
@@ -59,7 +59,7 @@ very soon as we want to respect private frequencies and avoid a noisy new user e
 
 *
 \*------------------------------------------------------------*/
-export const setFrequencies = () => (dispatch, getState) => {
+export const loadFrequencies = () => (dispatch, getState) => {
   let { user } = getState();
   let userFrequencies = user.frequencies;
   if (!user.uid) return;
@@ -91,7 +91,7 @@ We have a two-way relationship between a user and frequencies:
 
 This means that a change in one of these fields requires a change in the other
 
-NOTE: We do not dispatch anything in this action because we have an open listener to any changes in the frequencies that was set in setFrequencies()
+NOTE: We do not dispatch anything in this action because we have an open listener to any changes in the frequencies that was set in loadFrequencies()
 
 *
 \*------------------------------------------------------------*/

--- a/src/actions/messages.js
+++ b/src/actions/messages.js
@@ -34,12 +34,12 @@ export const setup = stateFetch => {
 /*------------------------------------------------------------\*
 *
 
-setMessages
+loadMessages
 Fetches all messages for the active story.
 
 *
 \*------------------------------------------------------------*/
-export const setMessages = () => (dispatch, getState) => {
+export const loadMessages = () => (dispatch, getState) => {
   dispatch({ type: 'LOADING' });
 
   let { stories, database } = setup(getState());

--- a/src/actions/stories.js
+++ b/src/actions/stories.js
@@ -32,14 +32,14 @@ export const setup = stateFetch => {
 /*------------------------------------------------------------\*
 *
 
-setStories
+loadStories
 1. Get all the frequencies the user is subscribed to
 2. Return all the stories on the server for each of those frequencies
 3. Sort and filter all of those stories on the frontend
 
 *
 \*------------------------------------------------------------*/
-export const setStories = () => (dispatch, getState) => {
+export const loadStories = () => (dispatch, getState) => {
   dispatch({ type: 'LOADING' });
   let { user } = setup(getState());
   let userFrequencies = user.frequencies;

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ import { initStore } from './store';
 import * as firebase from 'firebase';
 import FIREBASE_CONFIG from './config/FirebaseConfig';
 import { startListeningToAuth } from './actions/user';
-import { setFrequencies } from './actions/frequencies';
-import { setStories } from './actions/stories';
+import { loadFrequencies } from './actions/frequencies';
+import { loadStories } from './actions/stories';
 import { Body } from './App/style';
 import ModalRoot from './shared/modals/ModalRoot';
 import GalleryRoot from './shared/gallery/GalleryRoot';
@@ -116,7 +116,7 @@ setTimeout(() => {
   // when the app first loads, we'll listen for firebase changes
   store.dispatch(startListeningToAuth()).then(() => {
     // once auth has completed, if the user exists we'll set the frequencies and stories
-    store.dispatch(setFrequencies());
-    store.dispatch(setStories());
+    store.dispatch(loadFrequencies());
+    store.dispatch(loadStories());
   });
 });


### PR DESCRIPTION
In reality those actions are totally async and load X before setting in
the store. This rename better reflects that.

Affects `setFrequencies`, `setStories` and `setMessages`.