### PR TITLE
Refactor the app initialisation flow

### DIFF
--- a/src/App/index.js
+++ b/src/App/index.js
@@ -1,44 +1,18 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import NavMaster from './components/NavMaster';
 import { Body } from './style';
 import StoryMaster from './components/StoryMaster';
 import DetailView from './components/DetailView';
 import LoadingIndicator from '../shared/loading';
-import { setActiveFrequency } from '../actions/frequencies';
-import { setActiveStory, loadStories } from '../actions/stories';
-import { loadMessages } from '../actions/messages';
+import ModalRoot from '../shared/modals/ModalRoot';
+import GalleryRoot from '../shared/gallery/GalleryRoot';
 
 class App extends Component {
-  componentWillMount() {
-    const { dispatch, params } = this.props;
-
-    const activeFrequencyParam = params.frequency || 'all';
-    const activeStoryParam = params.story || '';
-    dispatch(setActiveFrequency(activeFrequencyParam));
-
-    if (activeStoryParam) {
-      dispatch(setActiveStory(activeStoryParam));
-      dispatch(loadMessages());
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { dispatch, params } = this.props;
-    if (nextProps.params.frequency !== params.frequency) {
-      dispatch(setActiveFrequency(nextProps.params.frequency));
-      dispatch(loadStories());
-    }
-
-    if (nextProps.params.story !== params.frequency) {
-      dispatch(setActiveStory(nextProps.params.story));
-      dispatch(loadMessages());
-    }
-  }
-
   render() {
     return (
       <Body>
+        <ModalRoot />
+        <GalleryRoot />
         <LoadingIndicator />
         <NavMaster />
         <StoryMaster />
@@ -48,4 +22,4 @@ class App extends Component {
   }
 }
 
-export default connect()(App);
+export default App;

--- a/src/Root.js
+++ b/src/Root.js
@@ -1,0 +1,78 @@
+/**
+ * The <Root /> component takes care of initially authenticating the user, showing the homepage or the app
+ * and syncing the frequency and story from the URL to the Redux state. (including loading their data)
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import * as firebase from 'firebase';
+import { setInitialData } from './actions/loading';
+import { setActiveFrequency, loadFrequencies } from './actions/frequencies';
+import { setActiveStory, loadStories } from './actions/stories';
+import { loadMessages } from './actions/messages';
+import { asyncComponent } from './helpers/utils';
+import LoadingIndicator from './shared/loading/global';
+
+// Codesplit the App and the Homepage to only load what we need based on which route we're on
+const App = asyncComponent(() =>
+  System.import('./App').then(module => module.default));
+const Homepage = asyncComponent(() =>
+  System.import('./Homepage').then(module => module.default));
+
+class Root extends Component {
+  componentWillMount() {
+    // On the initial render of the app we authenticate the user
+    const { dispatch, params } = this.props;
+    firebase.auth().onAuthStateChanged(user => {
+      if (!user)
+        return dispatch({
+          type: 'USER_NOT_AUTHENTICATED',
+        });
+      let users = firebase.database().ref('users');
+
+      // we know the user exists, so lets fetch their data by matching the uid
+      users.orderByChild('uid').equalTo(user.uid).on('value', snapshot => {
+        // once we've retreived our user, we can dispatch to redux and store their info in state
+        const userData = snapshot.val()[user.uid];
+        dispatch(
+          setInitialData(
+            userData,
+            params.frequency || 'all',
+            params.story || '',
+          ),
+        );
+        dispatch(loadFrequencies());
+        dispatch(loadStories());
+      });
+    });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { dispatch, params } = this.props;
+    // If the frequency changes sync the active frequency to the store and load the stories
+    if (nextProps.params.frequency !== params.frequency) {
+      dispatch(setActiveFrequency(nextProps.params.frequency));
+      dispatch(loadStories());
+    }
+
+    // If the story changes sync the active story to the store and load the messages
+    if (nextProps.params.story !== params.frequency) {
+      dispatch(setActiveStory(nextProps.params.story));
+      dispatch(loadMessages());
+    }
+  }
+
+  render() {
+    const { user, frequencies, params } = this.props;
+    if (!user.loaded) return <LoadingIndicator />;
+    if (!user.uid && params.frequency === undefined)
+      return <Homepage />;
+    if (user.loginError) return <p>Login error</p>;
+    if (!frequencies.loaded) return <LoadingIndicator />;
+    return <App />;
+  }
+}
+
+export default connect(state => ({
+  user: state.user || {},
+  frequencies: state.frequencies || {},
+}))(Root);

--- a/src/actions/frequencies.js
+++ b/src/actions/frequencies.js
@@ -43,9 +43,9 @@ always has permissions to see/interact with frequencies safely.
 
 *
 \*------------------------------------------------------------*/
-export const setActiveFrequency = id => ({
+export const setActiveFrequency = frequency => ({
   type: 'SET_ACTIVE_FREQUENCY',
-  id,
+  frequency,
 });
 
 /*------------------------------------------------------------\*

--- a/src/actions/loading.js
+++ b/src/actions/loading.js
@@ -5,3 +5,10 @@ export const loading = () => ({
 export const stopLoading = () => ({
   type: 'STOP_LOADING',
 });
+
+export const setInitialData = (user, frequency, story) => ({
+  type: 'SET_INITIAL_DATA',
+  user,
+  frequency,
+  story,
+});

--- a/src/actions/stories.js
+++ b/src/actions/stories.js
@@ -181,9 +181,9 @@ export const initStory = () => (dispatch, getState) => {
   });
 };
 
-export const setActiveStory = id => ({
+export const setActiveStory = story => ({
   type: 'SET_ACTIVE_STORY',
-  id,
+  story,
 });
 
 export const deleteStory = id => (dispatch, getState) => {

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -69,54 +69,6 @@ export const login = () => dispatch => {
 /*------------------------------------------------------------\*
 *
 
-startListeningToAuth
-We listen for any changes to the auth, including the first render of the app
-at which point we're validating the cookies on the browser with Firebase.
-
-This function continues to run and will acknowledge logouts and user deletion
-from the backend.
-
-*
-\*------------------------------------------------------------*/
-export const startListeningToAuth = () => dispatch => {
-  dispatch({ type: 'LOADING' });
-  return new Promise((resolve, reject) => {
-    firebase.auth().onAuthStateChanged(user => {
-      if (!user)
-        return dispatch({
-          type: 'SHOW_MARKETING_PAGE',
-        });
-      // if the user exists, we can boot up the app
-      dispatch({
-        type: 'STOP_LOADING',
-      });
-
-      if (user) {
-        let database = firebase.database();
-        let usersRef = database.ref('users');
-
-        // we know the user exists, so lets fetch their data by matching the uid
-        usersRef.orderByChild('uid').equalTo(user.uid).on('value', snapshot => {
-          let userObject = snapshot.val();
-          userObject = userObject[user.uid]; // get the first user returned, which should be the current user
-
-          // resolve so that the app can now fetch frequencies and stories
-          resolve(userObject);
-
-          // once we've retreived our user, we can dispatch to redux and store their info in state
-          dispatch({
-            type: 'SET_USER',
-            user: userObject,
-          });
-        });
-      }
-    });
-  });
-};
-
-/*------------------------------------------------------------\*
-*
-
 signOut
 Ensures we clear the browser's cookies, unauth on the backend, and reset our redux
 store by triggering a refresh after clearing out localstorage

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,5 +1,6 @@
 import * as firebase from 'firebase';
 import React from 'react';
+import LoadingIndicator from '../shared/loading/global';
 
 export const hashToArray = hash => {
   let array = [];
@@ -92,7 +93,7 @@ export const asyncComponent = getComponent => {
       if (Component) {
         return <Component {...this.props} />;
       }
-      return <p>Loading...</p>;
+      return <LoadingIndicator />;
     }
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,7 @@ import { startListeningToAuth } from './actions/user';
 import { loadFrequencies } from './actions/frequencies';
 import { loadStories } from './actions/stories';
 import { Body } from './App/style';
-import ModalRoot from './shared/modals/ModalRoot';
-import GalleryRoot from './shared/gallery/GalleryRoot';
+import Root from './Root';
 import { asyncComponent } from './helpers/utils';
 import { loadState, saveState } from './helpers/localStorage';
 
@@ -75,48 +74,17 @@ const theme = {
   },
 };
 
-// Let webpack know the App component should be put into its own bundle (code splitting)
-const App = asyncComponent(() =>
-  System.import('./App').then(module => module.default));
-const Homepage = asyncComponent(() =>
-  System.import('./Homepage').then(module => module.default));
-
-// Rendered at the root of the page, renders the homepage or the App based on the login state
-const Root = ({ notregistered, uid, loginError }) => {
-  if (!notregistered && !uid && !loginError) return <p>Loading...</p>;
-  if (notregistered) return <Homepage />;
-  if (uid) return <App params={{}} />;
-  return <p>Error</p>;
-};
-
-const ConnectedRoot = connect(state => ({
-  notregistered: state.user.notregistered,
-  uid: state.user.uid,
-  loginError: state.user.loginError,
-}))(Root);
-
 render(
   <Provider store={store}>
     <BrowserRouter>
       <ThemeProvider theme={theme}>
         <Body>
-          <ModalRoot />
-          <GalleryRoot />
-          <Match exactly pattern="/" component={ConnectedRoot} />
-          <Match exactly pattern="/:frequency" component={App} />
-          <Match exactly pattern="/:frequency/:story" component={App} />
+          <Match exactly pattern="/" component={Root} />
+          <Match exactly pattern="/:frequency" component={Root} />
+          <Match exactly pattern="/:frequency/:story" component={Root} />
         </Body>
       </ThemeProvider>
     </BrowserRouter>
   </Provider>,
   document.querySelector('#root'),
 );
-
-setTimeout(() => {
-  // when the app first loads, we'll listen for firebase changes
-  store.dispatch(startListeningToAuth()).then(() => {
-    // once auth has completed, if the user exists we'll set the frequencies and stories
-    store.dispatch(loadFrequencies());
-    store.dispatch(loadStories());
-  });
-});

--- a/src/reducers/frequencies.js
+++ b/src/reducers/frequencies.js
@@ -1,6 +1,7 @@
 const initialState = {
   frequencies: [],
   active: null,
+  loaded: false,
 };
 
 export default function root(state = initialState, action) {
@@ -13,10 +14,12 @@ export default function root(state = initialState, action) {
     case 'SET_FREQUENCIES':
       return Object.assign({}, state, {
         frequencies: action.frequencies,
+        loaded: true,
       });
+    case 'SET_INITIAL_DATA':
     case 'SET_ACTIVE_FREQUENCY':
       return Object.assign({}, state, {
-        active: action.id,
+        active: action.frequency,
       });
     default:
       return state;

--- a/src/reducers/stories.js
+++ b/src/reducers/stories.js
@@ -14,9 +14,10 @@ export default function root(state = initialState, action) {
         stories: state.stories.concat([action.story]),
         active: action.story.id,
       });
+    case 'SET_INITIAL_DATA':
     case 'SET_ACTIVE_STORY':
       return Object.assign({}, state, {
-        active: action.id,
+        active: action.story,
       });
     case 'DELETE_STORY':
       const stories = state.stories

--- a/src/reducers/user.js
+++ b/src/reducers/user.js
@@ -4,7 +4,7 @@ const initialState = {
   displayName: null,
   photoURL: null,
   frequencies: null,
-  notregistered: null,
+  loaded: false,
 };
 
 export default function root(state = initialState, action) {
@@ -12,18 +12,21 @@ export default function root(state = initialState, action) {
     case 'LOGIN_SIGNUP_ERROR':
       return Object.assign({}, state, {
         loginError: action.message,
+        loaded: true,
       });
+    case 'SET_INITIAL_DATA':
     case 'SET_USER':
       return Object.assign({}, state, {
         uid: action.user.uid,
         photoURL: action.user.photoURL,
         displayName: action.user.displayName,
         frequencies: action.user.frequencies,
-        notregistered: false,
+        loaded: true,
       });
-    case 'SHOW_MARKETING_PAGE':
-      return Object.assign({}, state, {
-        notregistered: true,
+    case 'USER_NOT_AUTHENTICATED':
+      // Reset the state
+      return Object.assign({}, initialState, {
+        loaded: true,
       });
     default:
       return state;

--- a/src/shared/loading/global.js
+++ b/src/shared/loading/global.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const GlobalLoadingIndicator = () => {
+	return (
+		<p>Loading...</p>
+	)
+}
+
+export default GlobalLoadingIndicator;


### PR DESCRIPTION
I've moved all the initialisation stuff and the URL management to a new `Root` component that chooses what to render.

Now instead of manually doing the `setTimeout` with the `startListeningToAuth` "action" (which isn't even an action) the `Root` component takes care of all of that. This means everything now happens in React instead of some random JS, which feels... better, for the lack of a more fitting work.

Whatcha think? This is the fourth or fifth iteration of this refactor (I tried a bunch of stuff today before arriving at this), and definitely feels good. 