### PR TITLE
Refactor all the things

### DIFF
--- a/src/App/components/NavMaster/index.js
+++ b/src/App/components/NavMaster/index.js
@@ -66,9 +66,11 @@ class NavigationMaster extends Component {
   };
 
   render() {
-    const frequencies = this.props.frequencies.frequencies;
-    const activeFrequency = this.props.frequencies.active;
     const user = this.props.user;
+    const frequencies = this.props.frequencies.frequencies.filter(
+      frequency => frequency.users[user.uid],
+    );
+    const activeFrequency = this.props.frequencies.active;
     // const myFrequencies = helpers.getMyFrequencies(frequencies, user)
     // const publicFrequencies = helpers.getPublicFrequencies(frequencies, user)
 

--- a/src/App/components/ShareCard/index.js
+++ b/src/App/components/ShareCard/index.js
@@ -18,14 +18,14 @@ const ShareCard = props => {
           onClick={handleFocus}
           onFocus={handleFocus}
           readOnly
-          value={`https://spectrum.chat/~${props.data.slug}`}
+          value={`https://spectrum.chat/~${props.slug}`}
         />
         <ButtonWrapper>
           <Button
             type={'twitter'}
             target="_blank"
             href={
-              `https://twitter.com/share?text=${props.data.name}&url=https://spectrum.chat/~${props.data.slug}&via=withspectrum`
+              `https://twitter.com/share?text=${props.name}&url=https://spectrum.chat/~${props.slug}&via=withspectrum`
             }
           >
             Share on Twitter
@@ -34,7 +34,7 @@ const ShareCard = props => {
             type={'facebook'}
             target="_blank"
             href={
-              `https://www.facebook.com/sharer/sharer.php?u=https://spectrum.chat/~${props.data.slug}`
+              `https://www.facebook.com/sharer/sharer.php?u=https://spectrum.chat/~${props.slug}`
             }
           >
             Post to Facebook

--- a/src/App/components/StoryMaster/index.js
+++ b/src/App/components/StoryMaster/index.js
@@ -23,7 +23,8 @@ import {
   getFrequencyPermission,
   getCurrentFrequency,
 } from '../../../helpers/frequencies';
-import { Lock, Unlock, NewPost, ClosePost } from '../../../shared/Icons';
+import { sortArrayByKey } from '../../../helpers/utils';
+import { Lock, NewPost, ClosePost } from '../../../shared/Icons';
 import StoryCard from '../StoryCard';
 import ShareCard from '../ShareCard';
 
@@ -49,193 +50,99 @@ class StoryMaster extends Component {
     this.props.dispatch(login());
   };
 
-  sortArrayByKey = (array, key) => {
-    return array.sort((a, b) => {
-      let x = a[key];
-      let y = b[key];
-
-      return x < y ? -1 : x > y ? 1 : 0;
-    });
-  };
-
   editFrequency = () => {
-    let currentFrequency = getCurrentFrequency(
+    let frequencyData = getCurrentFrequency(
       this.props.frequencies.active,
       this.props.frequencies.frequencies,
     );
 
-    this.props.dispatch(showModal('FREQUENCY_EDIT_MODAL', currentFrequency));
+    this.props.dispatch(showModal('FREQUENCY_EDIT_MODAL', frequencyData));
   };
 
   render() {
-    let { user, stories, frequencies, composer } = this.props;
-    let sortedStories = this.sortArrayByKey(stories.stories, 'timestamp');
+    const { user, stories, frequencies, composer } = this.props;
 
-    let currentFrequency = getCurrentFrequency(
+    const frequencyData = getCurrentFrequency(
       frequencies.active,
       frequencies.frequencies,
     );
 
-    if (frequencies.active !== 'everything') {
-      sortedStories = sortedStories.filter(
-        story => story.frequency === currentFrequency.id,
-      );
-    }
-
-    let urlBase = frequencies.active === 'everything'
-      ? '~everything'
-      : `~${frequencies.active}`;
-    let usersPermissionOnFrequency = getFrequencyPermission(
+    const isEverything = frequencies.active === 'everything';
+    const isPrivate = frequencyData && frequencyData.settings.private;
+    const role = getFrequencyPermission(
       user,
       frequencies.active,
       frequencies.frequencies,
     );
+    const hidden = !role && isPrivate;
 
-    const currentFrequencyPrivacy = currentFrequency
-      ? currentFrequency.settings.private
-      : '';
+    if (!isEverything && hidden) return <Lock />;
 
-    let subscribeButton = (usersFrequencies, activeFrequency) => {
-      let keys = Object.keys(usersFrequencies);
+    // Show stories in reverse chronological order
+    let sortedStories = sortArrayByKey(
+      stories.stories.slice(),
+      'timestamp',
+    ).reverse();
 
-      if (usersPermissionOnFrequency === 'owner') {
-        return;
-      } else if (
-        currentFrequencyPrivacy && usersPermissionOnFrequency === undefined
-      ) {
-        return;
-      } else if (
-        !usersFrequencies &&
-        activeFrequency !== 'everything' &&
-        activeFrequency !== null
-      ) {
-        return <JoinBtn onClick={this.subscribeFrequency}>Join</JoinBtn>;
-      } else if (activeFrequency === 'everything' || activeFrequency === null) {
-        return '';
-      } else if (keys.indexOf(activeFrequency) > -1) {
-        return (
-          <JoinBtn member onClick={this.unsubscribeFrequency}>Leave</JoinBtn>
-        );
-      } else if (!activeFrequency) {
-        return '';
-      } else {
-        return <JoinBtn onClick={this.subscribeFrequency}>Join</JoinBtn>;
-      }
-    };
+    if (frequencyData && !isEverything) {
+      sortedStories = sortedStories.filter(
+        story => story.frequency === frequencyData.id,
+      );
+    }
 
-    let addStoryButton = (usersFrequencies, activeFrequency) => {
-      let keys = Object.keys(usersFrequencies);
-
-      if (!usersFrequencies) {
-        return '';
-      } else if (activeFrequency === 'everything') {
-        return (
-          <TipButton
-            onClick={this.toggleComposer}
-            tipText="New Story"
-            tipLocation="bottom"
-          >
-            {composer.isOpen
-              ? <ClosePost color="warn" />
-              : <NewPost color="brand" stayActive />}
-          </TipButton>
-        );
-      } else if (keys.indexOf(currentFrequency.id) > -1) {
-        return (
-          <TipButton
-            onClick={this.toggleComposer}
-            tipText="New Story"
-            tipLocation="bottom"
-          >
-            {composer.isOpen
-              ? <ClosePost color="warn" />
-              : <NewPost color="brand" stayActive />}
-          </TipButton>
-        );
-      } else {
-        return '';
-      }
-    };
-
-    const canViewStories = () => {
-      if (currentFrequencyPrivacy && usersPermissionOnFrequency !== undefined) {
-        return true;
-      } else if (
-        currentFrequencyPrivacy && usersPermissionOnFrequency === undefined
-      ) {
-        return false;
-      } else {
-        return true;
-      }
-    };
-    const canView = canViewStories();
-
-    const getPrivacyButton = usersPermissionOnFrequency => {
-      switch (usersPermissionOnFrequency) {
-        case 'owner':
-          return (
+    return (
+      <Column>
+        <Header visible={user.uid}>
+          {(isEverything || role) &&
+            <TipButton
+              onClick={this.toggleComposer}
+              tipText="New Story"
+              tipLocation="bottom"
+            >
+              {composer.isOpen
+                ? <ClosePost color="warn" />
+                : <NewPost color="brand" stayActive />}
+            </TipButton>}
+          {!(isEverything || role === 'owner' || hidden) &&
+            (role
+              ? <JoinBtn member onClick={this.unsubscribeFrequency}>
+                  Leave
+                </JoinBtn>
+              : <JoinBtn onClick={this.subscribeFrequency}>Join</JoinBtn>)}
+          {role === 'owner' &&
             <TipButton
               onClick={this.editFrequency}
               tipText="Frequency Settings"
               tipLocation="bottom"
             >
               <Lock />
-            </TipButton>
-          );
-        case 'subscriber':
-          return;
-        default:
-          return;
-      }
-    };
+            </TipButton>}
+        </Header>
 
-    const privacyButton = getPrivacyButton(usersPermissionOnFrequency);
+        <ScrollBody>
+          <Overlay active={composer.isOpen} />
+          {!user.uid &&
+            <LoginWrapper onClick={this.login}>
+              <LoginText>Sign in to join the conversation.</LoginText>
+              <LoginButton>Sign in with Twitter</LoginButton>
+            </LoginWrapper>}
 
-    if (canView) {
-      return (
-        <Column>
+          {isEverything || frequencyData
+            ? sortedStories.map((story, i) => (
+                <StoryCard
+                  urlBase={`~${frequencies.active}`}
+                  data={story}
+                  key={`story-${i}`}
+                />
+              ))
+            : ''}
 
-          {this.props.user.uid &&
-            <Header>
-              {addStoryButton(
-                this.props.user.frequencies,
-                this.props.frequencies.active,
-              )}
-              {subscribeButton(
-                this.props.user.frequencies,
-                this.props.frequencies.active,
-              )}
-              {frequencies.active === 'everything' ? '' : privacyButton}
-            </Header>}
-
-          <ScrollBody>
-            <Overlay active={composer.isOpen} />
-            {!this.props.user.uid /* if a user doesn't exist, show a login at the top of the story master */ &&
-              <LoginWrapper onClick={this.login}>
-                <LoginText>Sign in to join the conversation.</LoginText>
-                <LoginButton>Sign in with Twitter</LoginButton>
-              </LoginWrapper>}
-
-            {stories.stories.length > 0 &&
-              // slice and reverse makes sure our stories show up in revers chron order
-              sortedStories.slice().reverse().map((story, i) => {
-                return <StoryCard urlBase={urlBase} data={story} key={i} />;
-              })}
-
-            {currentFrequency &&
-              frequencies.active &&
-              frequencies.active !== 'everything'
-              ? <ShareCard data={currentFrequency} />
-              : ''}
-
-            {this.props.user.uid &&
-              <NewPost onClick={this.toggleComposer} tooltip={'New Story'} />}
-          </ScrollBody>
-        </Column>
-      );
-    } else {
-      return <Lock />;
-    }
+          {!isEverything &&
+            frequencyData &&
+            <ShareCard slug={frequencies.active} name={frequencyData.name} />}
+        </ScrollBody>
+      </Column>
+    );
   }
 }
 

--- a/src/App/components/StoryMaster/style.js
+++ b/src/App/components/StoryMaster/style.js
@@ -46,7 +46,7 @@ export const Overlay = styled.div`
 `;
 
 export const Header = styled.div`
-	display: flex;
+	display: ${props => props.visible ? 'flex' : 'none'};
 	flex-direction: row-reverse;
 	flex: 0 0 48px;
 	width: 100%;

--- a/src/actions/stories.js
+++ b/src/actions/stories.js
@@ -32,64 +32,6 @@ export const setup = stateFetch => {
 /*------------------------------------------------------------\*
 *
 
-loadStories
-1. Get all the frequencies the user is subscribed to
-2. Return all the stories on the server for each of those frequencies
-3. Sort and filter all of those stories on the frontend
-
-*
-\*------------------------------------------------------------*/
-export const loadStories = () => (dispatch, getState) => {
-  dispatch({ type: 'LOADING' });
-  let { user } = setup(getState());
-  let userFrequencies = user.frequencies;
-
-  if (!user.uid) return;
-
-  let mapStoryGroupsToArray = storyGroups => {
-    return new Promise((resolve, reject) => {
-      let storiesArray = [];
-
-      // for each group of stories (grouped by frequency ID)
-      storyGroups.map(group => {
-        // loop through each story in that group
-        for (let i in group) {
-          // and push it to our return array
-          storiesArray.push(group[i]);
-        }
-      });
-
-      // once this is done, we can resolve the promise with our flattened array
-      resolve(storiesArray);
-    });
-  };
-
-  fetchStoriesForFrequencies(userFrequencies)
-    .then(storiesGroupedByFrequency => {
-      /*  this returns an array of arrays
-        it looks like this:
-        [
-          frequencyIdA: [{story}, {story}, ...],
-          frequencyIdB: [{story}, {story}, ...]
-        ]
-
-        Because of this structure, we need to iterate through this nested array and destructure it into one flat array containing all the stories
-    */
-      return mapStoryGroupsToArray(storiesGroupedByFrequency);
-    })
-    .then(stories => {
-      // we now have all the stories fetched from each frequency the user is a member of in a flattened array. We can send this to the ui and filter by frequency based on active frequency
-
-      dispatch({
-        type: 'SET_STORIES',
-        stories,
-      });
-    });
-};
-
-/*------------------------------------------------------------\*
-*
-
 createStory
 
 

--- a/src/helpers/frequencies.js
+++ b/src/helpers/frequencies.js
@@ -1,33 +1,26 @@
 export const getFrequencyPermission = (user, activeFrequency, frequencies) => {
-  if (!user.uid) {
+  const { uid } = user;
+  if (!uid || activeFrequency === 'everything') {
     return;
   }
-  let uid = user.uid;
-  if (activeFrequency !== 'everything') {
-    // we wont' even show this if you're viewing everything, so skip
-    let frequencyToEval = frequencies.filter(freq => {
-      return freq.slug === activeFrequency;
-    });
 
-    let frequencyUsers = frequencyToEval[0].users;
-    if (frequencyUsers[uid]) {
-      // make sure this user is viewing a frequency they have joined
-      let usersPerm = frequencyUsers[uid].permission;
-      return usersPerm;
-    } else {
-      return; // the user isn't even part of the frequency
-    }
-  } else {
-    return;
-  }
+  let frequencyToEval = frequencies.filter(freq => {
+    return freq.slug === activeFrequency;
+  });
+
+  if (frequencyToEval.length < 1) return;
+  let frequencyUsers = frequencyToEval[0].users;
+  // make sure this user is viewing a frequency they have joined
+  if (!frequencyUsers[uid]) return;
+  let usersPerm = frequencyUsers[uid].permission;
+  return usersPerm;
 };
 
 export const getCurrentFrequency = (activeFrequency, frequencies) => {
   if (activeFrequency === 'everything') {
     return;
   }
-  let obj = frequencies.filter(freq => {
-    return freq.slug === activeFrequency || freq.id === activeFrequency;
-  });
-  return obj[0];
+  return frequencies.find(
+    freq => freq.slug === activeFrequency || freq.id === activeFrequency,
+  );
 };

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -157,3 +157,12 @@ const regex = new RegExp(
 );
 
 export const onlyContainsEmoji = text => regex.test(text);
+
+export const sortArrayByKey = (array, key) => {
+  return array.sort((a, b) => {
+    let x = a[key];
+    let y = b[key];
+
+    return x < y ? -1 : x > y ? 1 : 0;
+  });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,6 @@ import { initStore } from './store';
 import * as firebase from 'firebase';
 import FIREBASE_CONFIG from './config/FirebaseConfig';
 import { startListeningToAuth } from './actions/user';
-import { loadFrequencies } from './actions/frequencies';
-import { loadStories } from './actions/stories';
 import { Body } from './App/style';
 import Root from './Root';
 import { asyncComponent } from './helpers/utils';


### PR DESCRIPTION
- Completely refactor StoryMaster
- Make viewing and joining unjoined frequencies possible (still requires a page refresh for now, but at least it now works!)
- Refactor the way we fetch stories and frequencies

Previously we only fetched a users frequencies and the associated stories, but that means we can't show unjoined frequencies, as the data won't be there.

This PR makes it so that all frequencies and stories are fetched and cached. We need to change this to fetch frequencies on the fly when they are opened, but that can happen down the line for now.

This generally refactors a bunch of stuff and improves the data flow throughout the app.

Closes #183 (no longer relevant, this is working fine now), closes #179, closes #130