### PR TITLE
pseudo delete frequencies

### DIFF
--- a/src/actions/frequencies.js
+++ b/src/actions/frequencies.js
@@ -79,9 +79,8 @@ export const deleteFrequency = id => (dispatch, getState) => {
   removeFrequency(id)
     .then(() => {
       track('frequency', 'deleted', null);
-
+      history.push('/~hugs-n-bugs');
       dispatch({ type: 'DELETE_FREQUENCY', id });
-      history.push('/');
     })
     .catch(err => {
       dispatch({ type: 'HIDE_MODAL' });

--- a/src/db/frequencies.js
+++ b/src/db/frequencies.js
@@ -96,10 +96,17 @@ export const removeFrequency = id => new Promise((resolve, reject) => {
     .then(snapshot => {
       const users = snapshot.val();
       Object.keys(users).forEach(userId => {
+        //=> delete the frequency from every user who was a member
         db.ref(`/users/${userId}/public/frequencies/${id}`).remove();
       });
-      db.ref(`/frequencies/${id}`).remove();
       // TODO: Delete all stories associated with a frequency?
+    })
+    .then(() => {
+      db.ref().update({
+        [`frequencies/${id}/slug`]: id, //=> reset the slug to be the id, so that future frequencies can use the slug
+      });
+    })
+    .then(() => {
       resolve();
     })
     .catch(reject);

--- a/src/reducers/frequencies.js
+++ b/src/reducers/frequencies.js
@@ -38,7 +38,7 @@ export default function root(state = initialState, action) {
         .filter(frequency => frequency.id !== action.id);
       return Object.assign({}, state, {
         frequencies,
-        active: 'everything',
+        active: 'hugs-n-bugs',
       });
     }
     case 'SET_FREQUENCIES':


### PR DESCRIPTION
Since we can't top-level write on a frequency, we have to pseudo-delete or archive the frequency while still ensure privacy and security.

This attempts to do this by:

1. Removing the frequency from every member
2. Removing the frequency from the user's local store
3. Unlocking the frequency's slug so that future freqs can use it