### PR TITLE
Make loading indicator show based on stack

### DIFF
--- a/src/actions/frequencies.js
+++ b/src/actions/frequencies.js
@@ -90,6 +90,7 @@ export const createFrequency = data => (dispatch, getState) => {
     })
     .catch(err => {
       dispatch({ type: 'HIDE_MODAL' });
+      dispatch({ type: 'STOP_LOADING' });
       console.log(err);
     });
 };
@@ -108,6 +109,7 @@ export const editFrequency = data => (dispatch, getState) => {
     })
     .catch(err => {
       console.log(err);
+      dispatch({ type: 'STOP_LOADING' });
     });
 };
 
@@ -121,6 +123,7 @@ export const deleteFrequency = id => (dispatch, getState) => {
     })
     .catch(err => {
       dispatch({ type: 'HIDE_MODAL' });
+      dispatch({ type: 'STOP_LOADING' });
       console.log(err);
     });
 };

--- a/src/actions/stories.js
+++ b/src/actions/stories.js
@@ -44,6 +44,9 @@ export const publishStory = ({ frequencyId, title, description }) => (
       dispatch(setActiveStory(storyKey));
     })
     .catch(err => {
+      dispatch({
+        type: 'STOP_LOADING',
+      });
       console.log(err);
     });
 };
@@ -92,7 +95,11 @@ export const setActiveStory = story => (dispatch, getState) => {
   promise
     .then(getMessages(story))
     .then(messages => {
-      if (messages) dispatch({ type: 'ADD_MESSAGES', messages });
+      if (messages) {
+        dispatch({ type: 'ADD_MESSAGES', messages });
+      } else {
+        dispatch({ type: 'STOP_LOADING' });
+      }
     })
     .catch(err => {
       console.log(err);

--- a/src/actions/user.js
+++ b/src/actions/user.js
@@ -29,13 +29,14 @@ export const login = () => dispatch => {
       track('user', 'logged in', null);
       set(user.uid);
 
+      dispatch({ type: 'STOP_LOADING' });
+
       // create the user in the db
       createUser(user);
     })
     .catch(err => {
-      if (err) {
-        console.log('Error logging in: ', err);
-      }
+      dispatch({ type: 'STOP_LOADING' });
+      console.log('Error logging in: ', err);
     });
 };
 
@@ -62,9 +63,7 @@ export const signOut = () => dispatch => {
     window.location.href = '/';
   }, err => {
     // if something funky goes wrong during signout, throw an error and clear localStorage for good measure
-    if (err) {
-      localStorage.removeItem('state');
-      console.log('Error signing out: ', err);
-    }
+    localStorage.removeItem('state');
+    console.log('Error signing out: ', err);
   });
 };

--- a/src/reducers/loading.js
+++ b/src/reducers/loading.js
@@ -1,5 +1,6 @@
 const initialState = {
   active: false,
+  stacks: 0,
 };
 
 export default function loading(state = initialState, action) {
@@ -7,26 +8,28 @@ export default function loading(state = initialState, action) {
     case 'LOADING':
       return {
         active: true,
+        stacks: state.stacks + 1,
       };
-    case 'STOP_LOADING':
-    case 'SET_FREQUENCIES':
-    case 'ADD_FREQUENCY':
-    case 'CREATE_FREQUENCY':
-    case 'EDIT_FREQUENCY':
-    case 'UNSUBSCRIBE_FREQUENCY':
-    case 'CREATE_STORY':
-    case 'DELETE_STORY':
-    case 'ADD_STORIES':
-    case 'TOGGLE_STORY_LOCK':
-    case 'SHOW_GALLERY':
     case 'ADD_MESSAGES':
-    case 'SET_USER':
+    case 'ADD_STORIES':
     case 'CHANGE_GALLERY_INDEX':
+    case 'CREATE_FREQUENCY':
+    case 'CREATE_STORY':
+    case 'DELETE_FREQUENCY':
+    case 'DELETE_STORY':
+    case 'EDIT_FREQUENCY':
     case 'HIDE_GALLERY':
     case 'HIDE_MODAL':
-    case 'DELETE_FREQUENCY':
+    case 'SET_FREQUENCIES':
+    case 'SET_USER':
+    case 'SHOW_GALLERY':
+    case 'STOP_LOADING':
+    case 'TOGGLE_STORY_LOCK':
+    case 'UNSUBSCRIBE_FREQUENCY':
+      const stacks = state.stacks - 1;
       return {
-        active: false,
+        active: stacks <= 0 ? false : true,
+        stacks: stacks <= 0 ? 0 : stacks,
       };
     default:
       return state;


### PR DESCRIPTION
This means that we keep track of how many things want to show a loading
indicator, and only hide it when all of those have reported back that we
can hide it. This makes for a nicer experience, because the loading
indicator doesn't disappear until _everything_ has loaded.

Also fixes a bug where the loading indicator would stay on indefinitely
after switching to a story one has seen before. Closes #267