### PR TITLE
Add dirty dot to frequencies with new stories

### DIFF
--- a/src/App/components/NavMaster/index.js
+++ b/src/App/components/NavMaster/index.js
@@ -23,7 +23,10 @@ import {
   FooterLogo,
   FooterP,
   Button,
+  FreqText,
+  DirtyDot,
 } from './style';
+import { ACTIVITY_TYPES, OBJECT_TYPES } from '../../../db/types';
 
 class NavigationMaster extends Component {
   constructor() {
@@ -103,29 +106,37 @@ class NavigationMaster extends Component {
                   active={this.props.frequencies.active === 'everything'}
                   onClick={this.hideNav}
                 >
-                  <FreqIcon src="/img/everything-icon.svg" />
-                  <FreqLabel>{user.uid ? 'Everything' : 'Home'}</FreqLabel>
+                  <FreqText>
+                    <FreqIcon src="/img/everything-icon.svg" />
+                    <FreqLabel>{user.uid ? 'Everything' : 'Home'}</FreqLabel>
+                  </FreqText>
                 </Freq>
               </Link>
             : <div>
                 <Link to={`/~spectrum`}>
                   <Freq onClick={this.hideNav}>
-                    <FreqGlyph>~</FreqGlyph>
-                    <FreqLabel>Spectrum</FreqLabel>
+                    <FreqText>
+                      <FreqGlyph>~</FreqGlyph>
+                      <FreqLabel>Spectrum</FreqLabel>
+                    </FreqText>
                   </Freq>
                 </Link>
 
                 <Link to={`/~discover`}>
                   <Freq onClick={this.hideNav}>
-                    <FreqGlyph>~</FreqGlyph>
-                    <FreqLabel>Discover</FreqLabel>
+                    <FreqText>
+                      <FreqGlyph>~</FreqGlyph>
+                      <FreqLabel>Discover</FreqLabel>
+                    </FreqText>
                   </Freq>
                 </Link>
 
                 <Link to={`/~hugs-n-bugs`}>
                   <Freq onClick={this.hideNav}>
-                    <FreqGlyph>~</FreqGlyph>
-                    <FreqLabel>Hugs n Bugs</FreqLabel>
+                    <FreqText>
+                      <FreqGlyph>~</FreqGlyph>
+                      <FreqLabel>Hugs n Bugs</FreqLabel>
+                    </FreqText>
                   </Freq>
                 </Link>
               </div>}
@@ -140,9 +151,17 @@ class NavigationMaster extends Component {
               </Freq>
             </Link>*/
           }
+
           {user.uid &&
             frequencies &&
             frequencies.map((frequency, i) => {
+              // If there's any unread notification for this frequency
+              // show a dirty dot
+              const notif = this.props.notifications.find(
+                notification =>
+                  notification.objectId === frequency.id &&
+                  notification.objectType === OBJECT_TYPES.FREQUENCY,
+              );
               return (
                 <Link to={`/~${frequency.slug || frequency.id}`} key={i}>
                   <Freq
@@ -152,8 +171,11 @@ class NavigationMaster extends Component {
                     }
                     onClick={this.hideNav}
                   >
-                    <FreqGlyph>~</FreqGlyph>
-                    <FreqLabel>{frequency.name}</FreqLabel>
+                    <FreqText>
+                      <FreqGlyph>~</FreqGlyph>
+                      <FreqLabel>{frequency.name}</FreqLabel>
+                    </FreqText>
+                    {notif && !notif.read && <DirtyDot />}
                   </Freq>
                 </Link>
               );
@@ -187,6 +209,7 @@ const mapStateToProps = state => ({
   user: state.user,
   frequencies: state.frequencies,
   ui: state.ui,
+  notifications: state.notifications.notifications,
 });
 
 export default connect(mapStateToProps)(NavigationMaster);

--- a/src/App/components/NavMaster/style.js
+++ b/src/App/components/NavMaster/style.js
@@ -99,9 +99,9 @@ export const FreqList = styled.div`
 export const Freq = styled.div`
   display: flex;
   flex: 0 0 48px;
-  padding: 0.5rem;
-  padding-left: 1rem;
+  padding: 0.5rem 1rem;
   align-items: center;
+  justify-content: space-between;
   background-color: ${props =>
   props.active ? props.theme.brand.default : props.theme.bg.reverse};
   background-image: ${props =>
@@ -115,6 +115,11 @@ export const Freq = styled.div`
     background-color: ${props =>
   props.active ? props.theme.brand.default : '#2E313F'};
   }
+`;
+
+export const FreqText = styled.div`
+  display: flex;
+  align-items: center;
 `;
 
 export const FreqLabel = styled.span`
@@ -207,4 +212,11 @@ export const Button = styled.button`
     top: 1px;
     transition: all 0s;
   }
+`;
+
+export const DirtyDot = styled.div`
+  border-radius: 50%;
+  background-color: ${({ theme }) => theme.warn.default};
+  width: 10px;
+  height: 10px;
 `;

--- a/src/actions/frequencies.js
+++ b/src/actions/frequencies.js
@@ -10,6 +10,7 @@ import {
   getFrequency,
 } from '../db/frequencies';
 import { getStories, getAllStories } from '../db/stories';
+import { markStoriesRead } from '../db/notifications';
 
 export const setActiveFrequency = frequency => (dispatch, getState) => {
   dispatch({
@@ -23,10 +24,10 @@ export const setActiveFrequency = frequency => (dispatch, getState) => {
   }
 
   dispatch({ type: 'LOADING' });
+  const { user: { uid } } = getState();
   // Everything
   if (frequency === 'everything') {
     // If there's no UID yet we might need to show the homepage, so don't do anything
-    const { user: { uid } } = getState();
     if (!uid) return;
     track('everything', 'viewed', null);
     // Get all the stories from all the frequencies
@@ -58,6 +59,7 @@ export const setActiveFrequency = frequency => (dispatch, getState) => {
       // If it's a private frequency, don't even get any stories
       if (data && data.settings.private && (!freqs || !freqs[data.id]))
         return [];
+      markStoriesRead(data.id, uid);
       return getStories({ frequencySlug: frequency });
     })
     .then(stories => {

--- a/src/db/notifications.js
+++ b/src/db/notifications.js
@@ -1,4 +1,5 @@
 import * as firebase from 'firebase';
+import { ACTIVITY_TYPES } from './types';
 
 /**
  * Create notifications for a bunch of users
@@ -52,7 +53,7 @@ export const listenToNotifications = (userId, cb) => {
 };
 
 /**
- * Mark notifications of a story read
+ * Mark messages of a story read
  */
 export const markMessagesRead = (storyId, userId) => new Promise(resolve => {
   const db = firebase.database();
@@ -66,6 +67,28 @@ export const markMessagesRead = (storyId, userId) => new Promise(resolve => {
       if (!storyNotifications) return;
       let updates = {};
       Object.keys(storyNotifications).forEach(id => {
+        updates[`${id}/read`] = true;
+      });
+      resolve(db.ref(`notifications/${userId}`).update(updates));
+    });
+});
+
+/**
+ * Mark stories of a frequency read
+ */
+export const markStoriesRead = (frequencyId, userId) => new Promise(resolve => {
+  const db = firebase.database();
+
+  db
+    .ref(`notifications/${userId}`)
+    .orderByChild('objectId')
+    .equalTo(frequencyId)
+    .once('value', snapshot => {
+      const notifications = snapshot.val();
+      if (!notifications || notifications.length === 0) return;
+      let updates = {};
+      Object.keys(notifications).forEach(id => {
+        if (notifications[id].activityType !== ACTIVITY_TYPES.NEW_STORY) return;
         updates[`${id}/read`] = true;
       });
       resolve(db.ref(`notifications/${userId}`).update(updates));


### PR DESCRIPTION
Based on the notifications we show a dirty dot next to frequencies that aren't active to indicate new stories being posted.

![screen shot 2017-03-09 at 15 11 04](https://cloud.githubusercontent.com/assets/7525670/23753833/2f23a97c-04db-11e7-89fe-fff10e7afe5f.png)

NOTE: Currently this only appears for new stories, but not for new messages in stories you're subscribed to. Will try to figure that out!

Closes #107