### PR TITLE
Fix messages disappearing after a while

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -38,11 +38,6 @@ class Root extends Component {
           type: 'USER_NOT_AUTHENTICATED',
         });
 
-      // temporarily force-clear the messages so that it doesn't bloat the store
-      dispatch({
-        type: 'CLEAR_MESSAGES',
-      });
-
       // set this uid in google analytics
       track('user', 'authed', null);
       set(user.uid);


### PR DESCRIPTION
Firebase calls this callback in an interval, so every now and then I'll
be reading some messages and suddenly all of them are gone.

We don't need this code anymore now that we selectively store the state,
so this should be fine.