### PR TITLE
Hotfix: Link previews

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -292,7 +292,7 @@ export const truncate = (str, length) => {
 };
 
 export const getLinkPreviewFromUrl = url => fetch(
-  `https://micro-open-graph-xiuqvckswd.now.sh/?url=${url}`,
+  `https://micro-open-graph-phbmtaqieu.now.sh/?url=${url}`,
 ).then(response => {
   return response.json();
 });


### PR DESCRIPTION
Needed to do a new deploy with the CORS stuff enabled. For some reason the old URL didn't have the CORS fix?

@uberbryn can you do another deploy with our proper account so we have higher quotas please? Running `now mxstbr/micro-open-graph` should be good enough, and then take that URL and replace the one I just replaced with your one.