### PR TITLE
Filter deleted stories from frequency.stories

### DIFF
--- a/src/Root.js
+++ b/src/Root.js
@@ -74,7 +74,20 @@ class Root extends Component {
         .then(frequencies => {
           dispatch({
             type: 'SET_FREQUENCIES',
-            frequencies,
+            frequencies: frequencies.map(frequency => {
+              return {
+                ...frequency,
+                // Filter deleted stories from frequency
+                stories: Object.keys(frequency.stories).reduce((
+                  list,
+                  storyId,
+                ) => {
+                  if (!frequency.stories[storyId].deleted)
+                    list[storyId] = frequency.stories[storyId];
+                  return list;
+                }, {}),
+              };
+            }),
           });
         });
     });

--- a/src/actions/frequencies.js
+++ b/src/actions/frequencies.js
@@ -59,11 +59,20 @@ export const setActiveFrequency = frequency => (dispatch, getState) => {
   // Get the frequency
   getFrequency({ slug: lowerCaseFrequency })
     .then(data => {
+      const freq = {
+        ...data,
+        // Filter deleted stories from frequency
+        stories: Object.keys(data.stories).reduce((list, storyId) => {
+          if (!data.stories[storyId].deleted)
+            list[storyId] = data.stories[storyId];
+          return list;
+        }, {}),
+      };
       dispatch({
         type: 'ADD_FREQUENCY',
-        frequency: data,
+        frequency: freq,
       });
-      return data;
+      return freq;
     })
     .then(data => {
       const freqs = getState().user.frequencies;
@@ -180,7 +189,15 @@ export const subscribeFrequency = (slug, redirect) => (dispatch, getState) => {
       dispatch({
         type: 'SUBSCRIBE_FREQUENCY',
         uid,
-        frequency,
+        frequency: {
+          ...frequency,
+          // Filter deleted stories from frequency
+          stories: Object.keys(frequency.stories).reduce((list, storyId) => {
+            if (!frequency.stories[storyId].deleted)
+              list[storyId] = frequency.stories[storyId];
+            return list;
+          }, {}),
+        },
       });
     })
     .catch(err => {


### PR DESCRIPTION
Rather than putting deleted story ids even in our store we already filter them when we load a frequency.

NOTE: This is necessary to merge before we land #528