### PR TITLE
Fix pagination issues

### DIFF
--- a/server/migrations/20170410074258-initial-data.js
+++ b/server/migrations/20170410074258-initial-data.js
@@ -27,6 +27,7 @@ exports.up = function(r, conn) {
               { multi: true }
             )
             .run(conn),
+          r.table('stories').indexCreate('author', r.row('author')).run(conn),
         ])
       )
       .catch(err => {

--- a/server/models/frequency.js
+++ b/server/models/frequency.js
@@ -52,7 +52,7 @@ const getFrequency = ({ id, slug, community }: GetFrequencyArgs) => {
 const getFrequencyMetaData = (id: String) => {
   const getStoryCount = db
     .table('stories')
-    .filter({ frequency: id, published: true })
+    .filter({ frequency: id })
     .count()
     .run();
   const getSubscriberCount = db

--- a/server/models/story.js
+++ b/server/models/story.js
@@ -11,43 +11,19 @@ const getStory = id => {
 };
 
 const getStoriesByFrequency = (frequency, { first, after }) => {
-  const getStories = db
+  return db
     .table('stories')
-    .between(after || db.minval, db.maxval, { leftBound: 'open' })
-    .orderBy(db.desc('modifiedAt'))
-    .filter({ frequency, published: true })
-    .limit(first)
-    .run()
-    .then();
-
-  const getLastStory = db
-    .table('stories')
-    .orderBy('modifiedAt')
-    .filter({ frequency, published: true })
-    .max()
+    .orderBy(db.desc('createdAt'))
+    .filter({ frequency })
     .run();
-
-  return Promise.all([getStories, getLastStory]);
 };
 
 const getStoriesByUser = (uid, { first, after }) => {
-  const getStories = db
+  return db
     .table('stories')
-    .between(after || db.minval, db.maxval, { leftBound: 'open' })
-    .orderBy(db.desc('modifiedAt'))
-    .filter({ author: uid, published: true })
-    .limit(first)
-    .run()
-    .then();
-
-  const getLastStory = db
-    .table('stories')
-    .orderBy('modifiedAt')
-    .filter({ author: uid, published: true })
-    .max()
+    .getAll(uid, { index: 'author' })
+    .orderBy(db.desc('createdAt'))
     .run();
-
-  return Promise.all([getStories, getLastStory]);
 };
 
 const publishStory = (story, user) => {

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -64,14 +64,13 @@ const getAllStories = (frequencies: Array<String>) => {
     .table('stories')
     .orderBy(db.desc('modifiedAt'))
     .filter(story => db.expr(frequencies).contains(story('frequency')))
-    .filter({ published: true })
     .run();
 };
 
 const getUserMetaData = (id: String) => {
   const getStoryCount = db
     .table('stories')
-    .filter({ author: id, published: true })
+    .filter({ author: id })
     .count()
     .run();
 

--- a/server/queries/frequency.js
+++ b/server/queries/frequency.js
@@ -29,21 +29,24 @@ module.exports = {
       { id }: { id: string },
       { first = 10, after }: PaginationOptions
     ) => {
-      const cursorId = decode(after);
-      return getStoriesByFrequency(id, { first, after: cursorId }).then(([
-        stories,
-        lastStory,
-      ]) => ({
-        pageInfo: {
-          hasNextPage: stories.length > 0
-            ? lastStory.id === stories[stories.length - 1].id
-            : lastStory.id === cursorId,
-        },
-        edges: stories.map(story => ({
-          cursor: encode(story.id),
-          node: story,
-        })),
-      }));
+      const cursor = decode(after);
+      return getStoriesByFrequency(id, { first, after: cursor })
+        .then(stories =>
+          paginate(
+            stories,
+            { first, after: cursor },
+            story => story.id === cursor
+          )
+        )
+        .then(result => ({
+          pageInfo: {
+            hasNextPage: result.hasMoreItems,
+          },
+          edges: result.list.map(story => ({
+            cursor: encode(story.id),
+            node: story,
+          })),
+        }));
     },
     community: ({ community }: { community: String }) =>
       getCommunity({ id: community }),

--- a/server/types/Story.js
+++ b/server/types/Story.js
@@ -28,7 +28,6 @@ const Story = /* GraphQL */ `
 		frequency: Frequency!
 		published: Boolean!
 		content: StoryContent!
-		deleted: Boolean
 		locked: Boolean
 		edits: [Edit!]
 		messageConnection(first: Int = 10, after: String): StoryMessagesConnection!

--- a/src/api/fragments/story/storyInfo.js
+++ b/src/api/fragments/story/storyInfo.js
@@ -8,7 +8,6 @@ export const storyInfoFragment = gql`
     createdAt
     modifiedAt
     published
-    deleted
     locked
     content {
       title

--- a/src/components/storyFeed/index.js
+++ b/src/components/storyFeed/index.js
@@ -25,12 +25,16 @@ const displayLoadingState = branch(
   See 'views/community/queries.js' for an example of the prop mapping in action
 */
 const StoryFeedPure = ({
-  data: { stories, loading, fetchMore, error },
+  data: { stories, loading, fetchMore, error, hasNextPage },
   data,
 }) => {
   // TODO: Better error state
-  if (error) {
+  if (error && stories) {
     return <div>Oops, something went wrong</div>;
+  }
+
+  if (error && !stories) {
+    return <div>No stories have been posted yet</div>;
   }
 
   // TODO: better loading state
@@ -44,7 +48,7 @@ const StoryFeedPure = ({
         return <StoryFeedCard key={story.node.id} data={story.node} />;
       })}
 
-      <Button onClick={fetchMore}>Fetch More</Button>
+      {hasNextPage && <Button onClick={fetchMore}>Fetch More</Button>}
     </div>
   );
 };

--- a/src/views/community/queries.js
+++ b/src/views/community/queries.js
@@ -32,6 +32,9 @@ const storiesQueryOptions = {
       loading,
       community,
       stories: community ? community.storyConnection.edges : '',
+      hasNextPage: community
+        ? community.storyConnection.pageInfo.hasNextPage
+        : false,
       fetchMore: () =>
         fetchMore({
           query: LoadMoreStories,
@@ -51,6 +54,10 @@ const storiesQueryOptions = {
                 ...prev.community,
                 storyConnection: {
                   ...prev.community.storyConnection,
+                  pageInfo: {
+                    ...prev.community.storyConnection.pageInfo,
+                    ...fetchMoreResult.community.storyConnection.pageInfo,
+                  },
                   edges: [
                     ...prev.community.storyConnection.edges,
                     ...fetchMoreResult.community.storyConnection.edges,

--- a/src/views/dashboard/queries.js
+++ b/src/views/dashboard/queries.js
@@ -49,6 +49,7 @@ const storiesQueryOptions = {
       loading,
       user,
       stories: user ? user.everything.edges : '',
+      hasNextPage: user ? user.everything.pageInfo.hasNextPage : false,
       fetchMore: () =>
         fetchMore({
           query: LoadMoreStories,
@@ -66,6 +67,10 @@ const storiesQueryOptions = {
                 ...prev.user,
                 everything: {
                   ...prev.user.everything,
+                  pageInfo: {
+                    ...prev.user.everything.pageInfo,
+                    ...fetchMoreResult.user.everything.pageInfo,
+                  },
                   edges: [
                     ...prev.user.everything.edges,
                     ...fetchMoreResult.user.everything.edges,

--- a/src/views/frequency/queries.js
+++ b/src/views/frequency/queries.js
@@ -35,6 +35,9 @@ const storiesQueryOptions = {
       loading,
       frequency,
       stories: frequency ? frequency.storyConnection.edges : '',
+      hasNextPage: frequency
+        ? frequency.storyConnection.pageInfo.hasNextPage
+        : false,
       fetchMore: () =>
         fetchMore({
           query: LoadMoreStories,
@@ -54,6 +57,10 @@ const storiesQueryOptions = {
                 ...prev.frequency,
                 storyConnection: {
                   ...prev.frequency.storyConnection,
+                  pageInfo: {
+                    ...prev.frequency.storyConnection.pageInfo,
+                    ...fetchMoreResult.frequency.storyConnection.pageInfo,
+                  },
                   edges: [
                     ...prev.frequency.storyConnection.edges,
                     ...fetchMoreResult.frequency.storyConnection.edges,

--- a/src/views/user/queries.js
+++ b/src/views/user/queries.js
@@ -26,6 +26,7 @@ const storiesQueryOptions = {
       loading,
       user,
       stories: user ? user.storyConnection.edges : '',
+      hasNextPage: user ? user.storyConnection.pageInfo.hasNextPage : false,
       fetchMore: () =>
         fetchMore({
           query: LoadMoreStories,
@@ -45,6 +46,10 @@ const storiesQueryOptions = {
                 ...prev.user,
                 storyConnection: {
                   ...prev.user.storyConnection,
+                  pageInfo: {
+                    ...prev.user.storyConnection.pageInfo,
+                    ...fetchMoreResult.user.storyConnection.pageInfo,
+                  },
                   edges: [
                     ...prev.user.storyConnection.edges,
                     ...fetchMoreResult.user.storyConnection.edges,


### PR DESCRIPTION
@mxstbr okay, so I spent a while getting reaaally deep in the rethinkdb docs and found that what we're trying to do is...somewhat complex. There were no clear answers for how to easily implement a `between` call the options we want (author id + descending createdAt timestamp).  This is buried in the docs:

> Note: You cannot specify multiple orders in a compound index. See issue [#2306](https://github.com/rethinkdb/rethinkdb/issues/2306) to track progress.

This is a problem because what we're essentially trying to do is get all posts by an author, but in descending order (indexes are created in ascending order. I still gave it a try by creating a compound index like `author, [r.row('author'), r.row('createdAt')]`, but since you can't get the `createdAt` to return in descending order it didn't work properly).

So I worked around a few possible solutions trying various sorts and filters, but then realized that what we're doing is solving a problem that is only a real problem when we hit massive scale. For now, we can reasonably expect a few thousand story records and querying against those will be nothing for the server.

Given this, I took the following approach:
1. Created an index for story `author` (this is optional)
*Note*: I didn't create an index for story `frequency` but we should be consistent either way we go. If we put an index on both `author` and `frequency` it means we can run the `getAll` which might be slightly faster, but honestly given our size it's probably negligible against a standard `filter({ key })` query.
2. The queries return *all* stories for the user and frequency. Which, again, we could reasonably expect to be quite low for a while as we grow.
3. Run those stories through your `paginate` function, which does all the magic of setting the `pageInfo` fields.
4. Make sure we're handling the `hasNextPage` field properly in the initial queries, `fetchMore` queries, and in the story feed component itself.