### PR TITLE
Fix queries to use fragments in order to avoid Apollo reducer errors

### DIFF
--- a/server/migrations/seed/default.js
+++ b/server/migrations/seed/default.js
@@ -34,7 +34,7 @@ const DEFAULT_COMMUNITIES = [
     createdAt: new Date(),
     name: 'Spectrum',
     slug: 'spectrum',
-    default: 'The future of community.',
+    description: 'The future of community.',
     members: [DEFAULT_USERS.map(({ uid }) => uid)],
   },
 ];

--- a/src/api/fragments/user/userEverything.js
+++ b/src/api/fragments/user/userEverything.js
@@ -1,0 +1,40 @@
+import { gql } from 'react-apollo';
+import { storyInfoFragment } from '../story/storyInfo';
+import { messageInfoFragment } from '../message/messageInfo';
+import { frequencyInfoFragment } from '../frequency/frequencyInfo';
+import { communityInfoFragment } from '../community/communityInfo';
+
+export const userEverythingFragment = gql`
+  fragment userEverything on User {
+    everything(first: 10, after: $after){
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+      }
+      edges {
+        cursor
+        node {
+          ...storyInfo
+          messageCount
+          messageConnection {
+            edges {
+              node {
+                ...messageInfo
+              }
+            }
+          }
+          frequency {
+            ...frequencyInfo
+            community {
+              ...communityInfo
+            }
+          }
+        }
+      }
+    }
+  }
+  ${storyInfoFragment}
+  ${messageInfoFragment}
+  ${frequencyInfoFragment}
+  ${communityInfoFragment}
+`;

--- a/src/components/storyFeedCard/index.js
+++ b/src/components/storyFeedCard/index.js
@@ -52,7 +52,6 @@ const StoryFeedCardPure = (props: Object): React$Element<any> => {
   const messageAvatars = list => {
     return list.map((edge, i) => {
       const participant = edge.node.sender;
-      console.log('participant: ', participant);
       return (
         <Participant src={participant.photoURL} role="presentation" key={i} />
       );

--- a/src/views/dashboard/index.js
+++ b/src/views/dashboard/index.js
@@ -27,11 +27,21 @@ const CurrentUserProfile = compose(getCurrentUserProfile)(UserProfile);
 
 const CommunitiesListCard = compose(getCurrentUserCommunities)(ListCard);
 
-const DashboardPure = ({ data: { user }, dispatch }) => {
+const DashboardPure = ({ data: { user, error }, data, dispatch }) => {
   // save user data to localstorage, which will also dispatch an action to put
   // the user into the redux store
   if (user) {
     dispatch(saveUserDataToLocalStorage(user));
+  }
+
+  if (error) {
+    return (
+      <AppViewWrapper>
+        <Column type="primary" alignItems="center">
+          Error loading home page
+        </Column>
+      </AppViewWrapper>
+    );
   }
 
   return (

--- a/src/views/dashboard/queries.js
+++ b/src/views/dashboard/queries.js
@@ -6,6 +6,9 @@ import update from 'immutability-helper';
 import { encode } from '../../helpers/utils';
 import { userInfoFragment } from '../../api/fragments/user/userInfo';
 import {
+  userEverythingFragment,
+} from '../../api/fragments/user/userEverything';
+import {
   userCommunitiesFragment,
 } from '../../api/fragments/user/userCommunities';
 import { userMetaDataFragment } from '../../api/fragments/user/userMetaData';
@@ -14,31 +17,12 @@ const LoadMoreStories = gql`
   query loadMoreEverythingStories($after: String) {
     user: currentUser {
       ...userInfo
-      everything(first: 10, after: $after){
-  			pageInfo {
-  			  hasNextPage
-  			  hasPreviousPage
-  			}
-        edges {
-          cursor
-          node {
-            id
-            createdAt
-            content {
-              title
-              description
-            }
-            author {
-              displayName
-            }
-            messageCount
-          }
-        }
-      }
       ...userCommunities
+      ...userEverything
     }
   }
   ${userInfoFragment}
+  ${userEverythingFragment}
   ${userCommunitiesFragment}
 `;
 
@@ -113,50 +97,15 @@ const storiesQueryOptions = {
 
 export const getEverythingStories = graphql(
   gql`
-  query getEverythingStories {
+  query getEverythingStories($after: String) {
     user: currentUser {
       ...userInfo
-      everything(first: 10){
-  			pageInfo {
-  			  hasNextPage
-  			  hasPreviousPage
-  			}
-        edges {
-          cursor
-          node {
-            id
-            createdAt
-            content {
-              title
-              description
-            }
-            author {
-              displayName
-              photoURL
-            }
-            messageConnection {
-              edges {
-                node {
-                  sender {
-                    photoURL
-                  }
-                }
-              }
-            }
-            messageCount
-            frequency {
-              name
-              community {
-                name
-              }
-            }
-          }
-        }
-      }
       ...userCommunities
+      ...userEverything
     }
   }
   ${userInfoFragment}
+  ${userEverythingFragment}
   ${userCommunitiesFragment}
 `,
   storiesQueryOptions

--- a/src/views/explore/queries.js
+++ b/src/views/explore/queries.js
@@ -1,5 +1,12 @@
 //@flow
+// $FlowFixMe
 import { graphql, gql } from 'react-apollo';
+import {
+  frequencyInfoFragment,
+} from '../../api/fragments/frequency/frequencyInfo';
+import {
+  communityInfoFragment,
+} from '../../api/fragments/community/communityInfo';
 
 export const getUserSubscriptions = graphql(
   gql`
@@ -12,7 +19,7 @@ export const getUserSubscriptions = graphql(
           }
           edges {
             node {
-              id
+              ...communityInfo
             }
           }
         }
@@ -23,12 +30,14 @@ export const getUserSubscriptions = graphql(
           }
           edges {
             node {
-              id
+              ...frequencyInfo
             }
           }
         }
       }
 		}
+    ${frequencyInfoFragment}
+    ${communityInfoFragment}
 	`
 );
 
@@ -36,20 +45,17 @@ export const getFrequency = graphql(
   gql`
 		query frequency($id: ID!) {
 			frequency(id: $id) {
-        id
-        name
-        slug
+        ...frequencyInfo
         community {
-          id
-          name
-          slug
+          ...communityInfo
         }
-        description
         metaData {
           subscribers
         }
       }
     }
+    ${frequencyInfoFragment}
+    ${communityInfoFragment}
 	`,
   {
     options: ({ id }) => ({
@@ -75,14 +81,13 @@ export const getCommunity = graphql(
   gql`
 		query community($id: ID!) {
 			community(id: $id) {
-        id
-        name
-        slug
+        ...communityInfo
         metaData {
           members
         }
       }
     }
+    ${communityInfoFragment}
 	`,
   {
     options: ({ id }) => ({
@@ -108,18 +113,17 @@ export const getTopFrequencies = graphql(
   gql`
 		{
 		  topFrequencies {
-        id
-        name
-        slug
+        ...frequencyInfo
         community {
-          name
+          ...communityInfo
         }
-        description
         metaData {
           subscribers
         }
       }
     }
+    ${frequencyInfoFragment}
+    ${communityInfoFragment}
 	`,
   {
     props: ({ data: { error, loading, topFrequencies } }) => ({


### PR DESCRIPTION
Adding fragments into all our queries that I can find - it's important to do this because if we don't have an id returned for each record, it messes with the Apollo reducers and causes the app to crash. Since each `fooInfoFragment` returns an id, we can avoid this problem by always using the fragments.

**Note: We're having some really bad performance issues if you load the explore page then immediately click to the home page.** I imagine this has something to do with us kicking off so many network requests and just dumping a boatload of shit into the store...our 'everything' query is *really* deep and brings back a really hefty payload. Just getting my last 10 stories is a 65k json payload.

Not sure how best to approach this - maybe there are some things we can do in the backend to make this more efficient, or also just making our requests clientside trigger in sequence instead of all at once. 

cc @mxstbr @uberbryn  for us to start thinking about performance best practices on the frontend. I can try and reach out to the Apollo folks as well.