### PR TITLE
Add global toasts component with reducer and actions

### DIFF
--- a/src/actions/toasts.js
+++ b/src/actions/toasts.js
@@ -1,0 +1,30 @@
+// @flow
+type Toasts = 'success' | 'error';
+
+const addToast = (id: number, kind: Toasts, message: string) => {
+  return {
+    type: 'ADD_TOAST',
+    payload: {
+      id,
+      kind,
+      message,
+    },
+  };
+};
+
+const removeToast = (id: number) => {
+  return { type: 'REMOVE_TOAST', id };
+};
+
+let nextToastId = 0;
+export const addToastWithTimeout = (
+  kind: Toasts,
+  message: string
+) => dispatch => {
+  const id = nextToastId++;
+  dispatch(addToast(id, kind, message));
+
+  setTimeout(() => {
+    dispatch(removeToast(id));
+  }, 3000);
+};

--- a/src/api/community.js
+++ b/src/api/community.js
@@ -22,14 +22,7 @@ const CREATE_COMMUNITY_OPTIONS = {
         variables: {
           input,
         },
-      })
-        .then(({ data }) => {
-          return data.createCommunity;
-        })
-        .catch(error => {
-          // TODO: Add dispatch for global errors
-          console.log('error creating community', error);
-        }),
+      }),
   }),
 };
 
@@ -54,14 +47,7 @@ const DELETE_COMMUNITY_OPTIONS = {
         variables: {
           id,
         },
-      })
-        .then(({ data }) => {
-          return data.deleteCommunity;
-        })
-        .catch(error => {
-          // TODO: Add dispatch for global errors
-          console.log('error editing community', error);
-        }),
+      }),
   }),
 };
 
@@ -89,14 +75,7 @@ const EDIT_COMMUNITY_OPTIONS = {
         variables: {
           input,
         },
-      })
-        .then(({ data }) => {
-          return data.editCommunity;
-        })
-        .catch(error => {
-          // TODO: Add dispatch for global errors
-          console.log('error editing community', error);
-        }),
+      }),
   }),
 };
 

--- a/src/components/editForm/community.js
+++ b/src/components/editForm/community.js
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 // $FlowFixMe
 import { withRouter } from 'react-router';
 import { Button, LinkButton } from '../buttons';
+import { addToastWithTimeout } from '../../actions/toasts';
 import { LoadingCard } from '../loading';
 import { Input, UnderlineInput, TextArea } from '../formElements';
 import { StyledCard, Form, FormTitle, Description, Actions } from './style';
@@ -78,8 +79,7 @@ class CommunityWithData extends Component {
         }
       })
       .catch(err => {
-        //TODO: Add dispatch for global error events
-        console.log('err in editCommunity', err);
+        this.props.dispatch(addToastWithTimeout('error', "You can't do that!"));
       });
   };
 
@@ -96,8 +96,7 @@ class CommunityWithData extends Component {
         }
       })
       .catch(err => {
-        // TODO: Throw a global dispatch for error message
-        console.log('err in deleteCommunity', err);
+        this.props.dispatch(addToastWithTimeout('error', "You can't do that!"));
       });
   };
 

--- a/src/components/toasts/index.js
+++ b/src/components/toasts/index.js
@@ -1,0 +1,39 @@
+// @flow
+import React from 'react';
+// $FlowFixMe
+import pure from 'recompose/pure';
+// $FlowFixMe
+import compose from 'recompose/compose';
+// $FlowFixMe
+import { connect } from 'react-redux';
+import { Container, ErrorToast, SuccessToast } from './style';
+
+const ToastsPure = ({ toasts }): React$Element<any> => {
+  if (!toasts) {
+    return <span />;
+  }
+
+  return (
+    <Container>
+      {toasts.map(toast => {
+        switch (toast.kind) {
+          case 'error': {
+            return <ErrorToast key={toast.id}>{toast.message}</ErrorToast>;
+          }
+          case 'success': {
+            return <SuccessToast key={toast.id}>{toast.message}</SuccessToast>;
+          }
+          default: {
+            return <span />;
+          }
+        }
+      })}
+    </Container>
+  );
+};
+
+const Toasts = compose(pure)(ToastsPure);
+const mapStateToProps = state => ({
+  toasts: state.toasts.toasts,
+});
+export default connect(mapStateToProps)(Toasts);

--- a/src/components/toasts/style.js
+++ b/src/components/toasts/style.js
@@ -1,0 +1,59 @@
+// @flow
+// $FlowFixMe
+import styled, { keyframes } from 'styled-components';
+
+export const Container = styled.div`
+  position: fixed;
+  top: 48px;
+  right: 0;
+  padding: 16px;
+  width: 100%;
+  height: 100%;
+  max-width: 256px;
+  background: transparent;
+  pointer-events: none;
+`;
+
+const toastFade = keyframes`
+	0% {
+		opacity: 0;
+    top: 8px;
+	}
+	5% {
+		opacity: 1
+    top: 0;
+	}
+  90% {
+		opacity: 1
+    top: 0;
+	}
+  100% {
+    opacity: 0;
+    top: 0;
+  }
+`;
+
+const Toast = styled.div`
+  border-radius: 8px;
+  padding: 8px 12px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  display: block;
+  margin-bottom: 8px;
+  box-shadow: 0 4px 4px rgba(0,0,0,0.1);
+  opacity: 0;
+  position: relative;
+  animation-duration: 3s;
+	animation-fill-mode: forwards;
+	animation-name: ${toastFade};
+	animation-timing-function: linear;
+`;
+
+export const ErrorToast = styled(Toast)`
+  background: ${props => props.theme.warn.default};
+`;
+
+export const SuccessToast = styled(Toast)`
+  background: ${props => props.theme.success.default};
+`;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import { client } from '../api';
 import users from './users';
 import modals from './modals';
+import toasts from './toasts';
 
 const apollo = client.reducer();
 
 export default combineReducers({
   users,
   modals,
+  toasts,
   apollo,
 });

--- a/src/reducers/toasts.js
+++ b/src/reducers/toasts.js
@@ -1,0 +1,33 @@
+const initialState = {
+  toasts: [],
+};
+
+/*
+Payload shape:
+
+payload: {
+  kind: 'error' | 'success',
+  message: string
+}
+*/
+export default function toasts(state = initialState, action) {
+  switch (action.type) {
+    case 'ADD_TOAST': {
+      return Object.assign({}, state, {
+        ...state,
+        toasts: [...state.toasts, action.payload],
+      });
+    }
+    case 'REMOVE_TOAST': {
+      const toasts = state.toasts.filter(toast => {
+        return toast.id !== action.id;
+      });
+      return Object.assign({}, state, {
+        ...state,
+        toasts,
+      });
+    }
+    default:
+      return state;
+  }
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,6 +8,7 @@ import styled from 'styled-components';
 import createBrowserHistory from 'history/createBrowserHistory';
 import ScrollManager from './components/scrollManager';
 import ModalRoot from './components/modals/modalRoot';
+import Toasts from './components/toasts';
 import DirectMessages from './views/directMessages';
 import Explore from './views/explore';
 import Story from './views/story';
@@ -43,6 +44,7 @@ class Routes extends Component {
             {/* Global navigation, notifications, message notifications, etc */}
             <Route component={Navbar} />
             <Route component={ModalRoot} />
+            <Route component={Toasts} />
 
             {/*
               Switch only renders the first match. Subrouting happens downstream


### PR DESCRIPTION
Hey @mxstbr and @uberbryn - this adds a global 'toasts' component which will be useful for throwing global errors or success messages so we don't have to do a bunch of tedious stuff inside of components. For example, if a user tries to perform an action that they don't have permission for, we can return the error from the backend and trigger a toast without having to worry about the button that was clicked, or where it was clicked, etc.

To do this use `this.props.dispatch(addToastWithTimeout('error', "You can't do that!"));` after importing `{ addToastWithTimeout }` from `actions/toasts`. The arguments are:

```js
type ToastTypes = 'success' | 'error'
addToastWithTimeout(kind: ToastTypes, message: string) {
  ...
}
```

Let me know if you have any questions. This is definitely a v1 implementation, but works for now :)