### PR TITLE
Story permission booleans and resolvers

### DIFF
--- a/server/queries/story.js
+++ b/server/queries/story.js
@@ -3,7 +3,8 @@
 /**
  * Story query resolvers
  */
-const { getFrequency } = require('../models/frequency');
+const { getFrequencies } = require('../models/frequency');
+const { getCommunities } = require('../models/community');
 const { getUsers } = require('../models/user');
 const {
   getMessagesByLocationAndThread,
@@ -50,6 +51,27 @@ module.exports = {
             )
         )
         .then(users => getUsers(users));
+    },
+    isCreator: ({ author }: { author: String }, _: any, { user }: Context) => {
+      return user.uid === author;
+    },
+    isFrequencyOwner: (
+      { frequency }: { frequency: String },
+      _: any,
+      { user }: Context
+    ) => {
+      return getFrequencies([frequency]).then(
+        data => data[0].subscribers.indexOf(user.uid) > -1
+      );
+    },
+    isCommunityOwner: (
+      { community }: { community: String },
+      _: any,
+      { user }: Context
+    ) => {
+      return getCommunities([community]).then(
+        data => data[0].members.indexOf(user.uid) > -1
+      );
     },
     messageConnection: (
       { id }: { id: String },

--- a/server/types/Story.js
+++ b/server/types/Story.js
@@ -30,6 +30,9 @@ const Story = /* GraphQL */ `
 		published: Boolean!
 		content: StoryContent!
 		locked: Boolean
+		isCreator: Boolean
+    isFrequencyOwner: Boolean
+    isCommunityOwner: Boolean
 		edits: [Edit!]
 		participants: [User]
 		messageConnection(first: Int = 10, after: String): StoryMessagesConnection!

--- a/src/api/fragments/story/storyInfo.js
+++ b/src/api/fragments/story/storyInfo.js
@@ -9,6 +9,9 @@ export const storyInfoFragment = gql`
     modifiedAt
     published
     locked
+    isCreator
+    isFrequencyOwner
+    isCommunityOwner
     participants {
       ...userInfo
     }


### PR DESCRIPTION
Heads up @uberbryn - went ahead and added some backend graphql resolvers on the story type that will get us some permission info making our client-side story component much easier to reason about. You'll get this back from the `...storyInfo` fragment:

<img width="1031" alt="screenshot 2017-05-10 17 59 53" src="https://cloud.githubusercontent.com/assets/1923260/25927425/cba7758a-35aa-11e7-9d62-d292cdfef833.png">

Lmk if you have any troubles.