### PR TITLE
Protect settings views from non-owners

### DIFF
--- a/server/queries/story.js
+++ b/server/queries/story.js
@@ -53,6 +53,7 @@ module.exports = {
         .then(users => getUsers(users));
     },
     isCreator: ({ author }: { author: String }, _: any, { user }: Context) => {
+      if (!author) return false;
       return user.uid === author;
     },
     isFrequencyOwner: (
@@ -60,6 +61,7 @@ module.exports = {
       _: any,
       { user }: Context
     ) => {
+      if (!frequency) return false;
       return getFrequencies([frequency]).then(
         data => data[0].subscribers.indexOf(user.uid) > -1
       );
@@ -69,6 +71,7 @@ module.exports = {
       _: any,
       { user }: Context
     ) => {
+      if (!community) return false;
       return getCommunities([community]).then(
         data => data[0].members.indexOf(user.uid) > -1
       );

--- a/src/components/editForm/community.js
+++ b/src/components/editForm/community.js
@@ -5,16 +5,11 @@ import compose from 'recompose/compose';
 //$FlowFixMe
 import pure from 'recompose/pure';
 //$FlowFixMe
-import renderComponent from 'recompose/renderComponent';
-//$FlowFixMe
-import branch from 'recompose/branch';
-//$FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
 import { withRouter } from 'react-router';
 import { Button, LinkButton } from '../buttons';
 import { addToastWithTimeout } from '../../actions/toasts';
-import { LoadingCard } from '../loading';
 import { Input, UnderlineInput, TextArea } from '../formElements';
 import {
   StyledCard,
@@ -29,16 +24,11 @@ import {
   deleteCommunityMutation,
 } from '../../api/community';
 
-const displayLoadingState = branch(
-  props => props.data.loading,
-  renderComponent(LoadingCard)
-);
-
 class CommunityWithData extends Component {
   constructor(props) {
     super(props);
 
-    const { data: { community } } = this.props;
+    const { community } = this.props;
     this.state = {
       name: community.name,
       slug: community.slug,
@@ -120,7 +110,7 @@ class CommunityWithData extends Component {
   triggerDeleteCommunity = e => {
     e.preventDefault();
 
-    const { data: { community }, deleteCommunity, history } = this.props;
+    const { community, deleteCommunity, history } = this.props;
 
     deleteCommunity(community.id)
       .then(community => {
@@ -136,7 +126,7 @@ class CommunityWithData extends Component {
 
   render() {
     const { name, slug, description, image, website } = this.state;
-    const { data: { community } } = this.props;
+    const { community } = this.props;
 
     if (!community) {
       return (
@@ -207,7 +197,6 @@ class CommunityWithData extends Component {
 const Community = compose(
   deleteCommunityMutation,
   editCommunityMutation,
-  displayLoadingState,
   withRouter,
   pure
 )(CommunityWithData);

--- a/src/components/editForm/frequency.js
+++ b/src/components/editForm/frequency.js
@@ -5,15 +5,10 @@ import compose from 'recompose/compose';
 //$FlowFixMe
 import pure from 'recompose/pure';
 //$FlowFixMe
-import renderComponent from 'recompose/renderComponent';
-//$FlowFixMe
-import branch from 'recompose/branch';
-//$FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
 import { withRouter } from 'react-router';
 import { Button, LinkButton } from '../buttons';
-import { LoadingCard } from '../loading';
 import { Input, UnderlineInput, TextArea } from '../formElements';
 import {
   StyledCard,
@@ -28,16 +23,11 @@ import {
   deleteFrequencyMutation,
 } from '../../api/frequency';
 
-const displayLoadingState = branch(
-  props => props.data.loading,
-  renderComponent(LoadingCard)
-);
-
 class FrequencyWithData extends Component {
   constructor(props) {
     super(props);
 
-    const { data: { frequency } } = this.props;
+    const { frequency } = this.props;
     this.state = {
       name: frequency.name,
       slug: frequency.slug,
@@ -70,7 +60,7 @@ class FrequencyWithData extends Component {
   save = e => {
     e.preventDefault();
     const { name, slug, description, id } = this.state;
-    const { data: { frequency: { community } } } = this.props;
+    const { frequency: { community } } = this.props;
     const input = {
       name,
       slug,
@@ -95,7 +85,8 @@ class FrequencyWithData extends Component {
     e.preventDefault();
 
     const {
-      data: { frequency, frequency: { community } },
+      frequency,
+      frequency: { community },
       deleteFrequency,
       history,
     } = this.props;
@@ -115,7 +106,7 @@ class FrequencyWithData extends Component {
 
   render() {
     const { name, slug, description } = this.state;
-    const { data: { frequency } } = this.props;
+    const { frequency } = this.props;
 
     if (!frequency) {
       return (
@@ -175,7 +166,6 @@ class FrequencyWithData extends Component {
 const Frequency = compose(
   deleteFrequencyMutation,
   editFrequencyMutation,
-  displayLoadingState,
   withRouter,
   pure
 )(FrequencyWithData);

--- a/src/components/editForm/style.js
+++ b/src/components/editForm/style.js
@@ -11,6 +11,7 @@ export const Form = styled.form`
   flex-direction: column;
   align-self: stretch;
   flex: 1 0 100%;
+  max-width: 100%;
 `;
 
 export const FormTitle = styled.h1`

--- a/src/components/modals/CreateCommunityModal/index.js
+++ b/src/components/modals/CreateCommunityModal/index.js
@@ -86,7 +86,7 @@ class CreateCommunityModal extends Component {
     this.props
       .createCommunity(input)
       .then(community => {
-        this.props.history.push(`/${community.slug}`);
+        this.props.history.push(`/${slug}`);
         this.close();
         this.props.dispatch(
           addToastWithTimeout('success', 'Community created!')

--- a/src/components/toasts/style.js
+++ b/src/components/toasts/style.js
@@ -12,6 +12,7 @@ export const Container = styled.div`
   max-width: 256px;
   background: transparent;
   pointer-events: none;
+  z-index: 1000;
 `;
 
 const toastFade = keyframes`

--- a/src/views/communitySettings/index.js
+++ b/src/views/communitySettings/index.js
@@ -4,24 +4,34 @@ import React from 'react';
 import compose from 'recompose/compose';
 //$FlowFixMe
 import pure from 'recompose/pure';
-
+// $FlowFixMe
+import { connect } from 'react-redux';
 import { getThisCommunity, getFrequenciesByCommunity } from './queries';
-
+import { addToastWithTimeout } from '../../actions/toasts';
+import { displayLoadingCard } from '../../components/loading';
 import AppViewWrapper from '../../components/appViewWrapper';
 import Column from '../../components/column';
 import ListCard from './components/listCard';
 
 import { CommunityEditForm } from '../../components/editForm';
-
-const ThisCommunityEditForm = compose(getThisCommunity)(CommunityEditForm);
 const FrequencyListCard = compose(getFrequenciesByCommunity)(ListCard);
 
-const SettingsPure = ({ match }) => {
+const SettingsPure = ({ match, data, history, dispatch }) => {
   const communitySlug = match.params.communitySlug;
+
+  if (!data.community.isOwner) {
+    history.push('/');
+    dispatch(addToastWithTimeout('error', "You can't do that!"));
+  }
+
+  if (data.error) {
+    return <div>Error</div>;
+  }
+
   return (
     <AppViewWrapper>
       <Column type="secondary">
-        <ThisCommunityEditForm slug={communitySlug} />
+        <CommunityEditForm community={data.community} />
       </Column>
       <Column type="primary">
         <FrequencyListCard slug={communitySlug} />
@@ -30,5 +40,7 @@ const SettingsPure = ({ match }) => {
   );
 };
 
-const communitySettings = compose(pure)(SettingsPure);
-export default communitySettings;
+const CommunitySettings = compose(getThisCommunity, displayLoadingCard, pure)(
+  SettingsPure
+);
+export default connect()(CommunitySettings);

--- a/src/views/communitySettings/queries.js
+++ b/src/views/communitySettings/queries.js
@@ -17,7 +17,14 @@ export const getThisCommunity = graphql(
       }
 		}
     ${communityInfoFragment}
-	`
+	`,
+  {
+    options: props => ({
+      variables: {
+        slug: props.match.params.communitySlug,
+      },
+    }),
+  }
 );
 
 export const getFrequenciesByCommunity = graphql(

--- a/src/views/frequencySettings/index.js
+++ b/src/views/frequencySettings/index.js
@@ -4,28 +4,37 @@ import React from 'react';
 import compose from 'recompose/compose';
 //$FlowFixMe
 import pure from 'recompose/pure';
-
+//$FlowFixMe
+import { connect } from 'react-redux';
 import { getThisFrequency } from './queries';
-
+import { addToastWithTimeout } from '../../actions/toasts';
 import AppViewWrapper from '../../components/appViewWrapper';
 import Column from '../../components/column';
-
+import { displayLoadingCard } from '../../components/loading';
 import { FrequencyEditForm } from '../../components/editForm';
 
-const ThisFrequencyEditForm = compose(getThisFrequency)(FrequencyEditForm);
+const SettingsPure = ({ match, data, dispatch, history }) => {
+  console.log(data);
+  if (data.error) {
+    return <div>error</div>;
+  }
 
-const SettingsPure = ({ match }) => {
-  const communitySlug = match.params.communitySlug;
-  const frequencySlug = match.params.frequencySlug;
+  if (!data.frequency.isOwner) {
+    history.push('/');
+    dispatch(addToastWithTimeout('error', "You can't do that!"));
+  }
+
   return (
     <AppViewWrapper>
       <Column type="secondary">
-        <ThisFrequencyEditForm slug={frequencySlug} community={communitySlug} />
+        <FrequencyEditForm frequency={data.frequency} />
       </Column>
       <Column type="primary" />
     </AppViewWrapper>
   );
 };
 
-const frequencySettings = compose(pure)(SettingsPure);
-export default frequencySettings;
+const FrequencySettings = compose(getThisFrequency, displayLoadingCard, pure)(
+  SettingsPure
+);
+export default connect()(FrequencySettings);

--- a/src/views/frequencySettings/queries.js
+++ b/src/views/frequencySettings/queries.js
@@ -23,5 +23,13 @@ export const getThisFrequency = graphql(
     ${frequencyInfoFragment}
     ${communityInfoFragment}
     ${frequencyMetaDataFragment}
-	`
+	`,
+  {
+    options: ({ match }) => ({
+      variables: {
+        slug: match.params.frequencySlug,
+        community: match.params.communitySlug,
+      },
+    }),
+  }
 );


### PR DESCRIPTION
@uberbryn this adds a slight bit of jank to the settings page for now, but I've protected the routes by wrapping them in the first `getCommunity` and `getFrequency` queries, which returns an `isOwner` field - if the user isn't an owner, we push them to the home page and show an error toast.

Of course we're also protecting any edits from occurring on the backend as well, but this will at least be a small hurdle for anyone trying to make unauthorized edits clientside.