### PR TITLE
Double check all delete actions

### DIFF
--- a/server/models/frequency.js
+++ b/server/models/frequency.js
@@ -35,7 +35,11 @@ const getFrequencyBySlug = (slug: string, community: string) => {
     })
     .filter(frequency => db.not(frequency.hasFields('deleted')))
     .run()
-    .then(result => result && result[0].left);
+    .then(result => {
+      if (result && result[0]) {
+        return result[0].left;
+      }
+    });
 };
 
 type GetFrequencyByIdArgs = {

--- a/server/mutations/frequency.js
+++ b/server/mutations/frequency.js
@@ -75,13 +75,6 @@ module.exports = {
               return new Error("Frequency doesn't exist");
             }
 
-            // if the user doesn't own the frequency
-            if (!(frequency.owners.indexOf(user.uid) > -1)) {
-              return new Error(
-                "You don't have permission to make changes to this frequency"
-              );
-            }
-
             // get the community parent of the frequency being deleted
             const communities = getCommunities([frequency.community]);
 
@@ -91,20 +84,22 @@ module.exports = {
             // select the community
             const community = communities[0];
 
-            // if user is doesn't own the community
+            // determine the role in the frequency and community
+            const isCommunityOwner = community.owners.indexOf(user.uid) > -1;
+            const isFrequencyOwner = frequency.owners.indexOf(user.uid) > -1;
 
             // NOTE: This will need to change in the future if we have the concept
             // of moderator-owner frequencies where the community owner is not
             // listed as an owner of the frequency. In today's code we mirror
             // the owners at time of frequency creation
-            if (!(community.owners.indexOf(user.uid) > -1)) {
+            if (isCommunityOwner || isFrequencyOwner) {
+              // all checks passed
+              return deleteFrequency(id);
+            } else {
               return new Error(
                 "You don't have permission to make changes to this frequency"
               );
             }
-
-            // all checks passed
-            return deleteFrequency(id);
           })
       );
     },

--- a/src/api/story.js
+++ b/src/api/story.js
@@ -1,0 +1,26 @@
+// @flow
+// $FlowFixMe
+import { graphql, gql } from 'react-apollo';
+
+/*
+  Delete a story
+*/
+const DELETE_STORY_MUTATION = gql`
+  mutation deleteStory($id: ID!) {
+    deleteStory(id: $id)
+  }
+`;
+const DELETE_STORY_OPTIONS = {
+  props: ({ id, mutate }) => ({
+    deleteStory: id =>
+      mutate({
+        variables: {
+          id,
+        },
+      }),
+  }),
+};
+export const deleteStoryMutation = graphql(
+  DELETE_STORY_MUTATION,
+  DELETE_STORY_OPTIONS
+);

--- a/src/components/editForm/community.js
+++ b/src/components/editForm/community.js
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { Button, LinkButton } from '../buttons';
 import { addToastWithTimeout } from '../../actions/toasts';
+import { openModal } from '../../actions/modals';
 import { Input, UnderlineInput, TextArea } from '../formElements';
 import {
   StyledCard,
@@ -37,6 +38,7 @@ class CommunityWithData extends Component {
       website: community.website,
       image: community.photoURL,
       file: null,
+      communityData: community,
     };
   }
 
@@ -115,28 +117,36 @@ class CommunityWithData extends Component {
       });
   };
 
-  triggerDeleteCommunity = e => {
+  triggerDeleteCommunity = (e, id) => {
     e.preventDefault();
-    const { community, deleteCommunity, history } = this.props;
+    const { name, communityData } = this.state;
+    const message = (
+      <div>
+        <p>Are you sure you want to delete your community, <b>{name}</b>?</p>
+        {' '}
+        <p>
+          <b>{communityData.metaData.members} members</b>
+          {' '}
+          will be removed from the community and the
+          {' '}
+          <b>{communityData.metaData.frequencies} frequencies</b>
+          {' '}
+          you've created will be deleted.
+        </p>
+        <p>
+          All stories, messages, reactions, and media shared in your community will be deleted.
+        </p>
+        <p>This cannot be undone.</p>
+      </div>
+    );
 
-    deleteCommunity(community.id)
-      .then(({ data: { deleteCommunity } }) => {
-        if (deleteCommunity) {
-          // community was successfully deleted
-          history.push(`/`);
-          this.props.dispatch(
-            addToastWithTimeout('neutral', 'Community deleted.')
-          );
-        }
+    return this.props.dispatch(
+      openModal('DELETE_DOUBLE_CHECK_MODAL', {
+        id,
+        entity: 'community',
+        message,
       })
-      .catch(err => {
-        this.props.dispatch(
-          addToastWithTimeout(
-            'error',
-            `Something went wrong and we weren't able to delete this community. ${err}`
-          )
-        );
-      });
+    );
   };
 
   render() {
@@ -198,7 +208,7 @@ class CommunityWithData extends Component {
           <Actions>
             <LinkButton
               color={'warn.alt'}
-              onClick={this.triggerDeleteCommunity}
+              onClick={e => this.triggerDeleteCommunity(e, community.id)}
             >
               Delete Community
             </LinkButton>

--- a/src/components/editForm/frequency.js
+++ b/src/components/editForm/frequency.js
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 // $FlowFixMe
 import { withRouter } from 'react-router';
 import { Button, LinkButton } from '../buttons';
+import { openModal } from '../../actions/modals';
 import { Input, UnderlineInput, TextArea } from '../formElements';
 import { addToastWithTimeout } from '../../actions/toasts';
 import {
@@ -34,6 +35,7 @@ class FrequencyWithData extends Component {
       slug: frequency.slug,
       description: frequency.description,
       id: frequency.id,
+      frequencyData: frequency,
     };
   }
 
@@ -84,29 +86,45 @@ class FrequencyWithData extends Component {
       });
   };
 
-  triggerDeleteFrequency = e => {
+  triggerDeleteFrequency = (e, id) => {
     e.preventDefault();
+    const { name, frequencyData } = this.state;
+    const message = (
+      <div>
+        <p>
+          Are you sure you want to delete your frequency,
+          {' '}
+          <b>{name}</b>
+          {' '}
+          (in the
+          {' '}
+          <b>{frequencyData.community.name}</b>
+          {' '}
+          community)?
+        </p>
+        {' '}
+        <p>
+          The
+          {' '}
+          <b>{frequencyData.metaData.stories} stories</b>
+          {' '}
+          posted in this frequency will be deleted.
+        </p>
+        <p>
+          All messages, reactions, and media shared in this frequency will be deleted.
+        </p>
+        <p>This cannot be undone.</p>
+      </div>
+    );
 
-    const {
-      frequency,
-      frequency: { community },
-      deleteFrequency,
-      history,
-    } = this.props;
-
-    deleteFrequency(frequency.id)
-      .then(({ data: { deleteFrequency } }) => {
-        if (deleteFrequency === true) {
-          // frequency was successfully deleted
-          history.push(`/${community.slug}`);
-          this.props.dispatch(
-            addToastWithTimeout('success', 'Frequency successfully deleted.')
-          );
-        }
+    return this.props.dispatch(
+      openModal('DELETE_DOUBLE_CHECK_MODAL', {
+        id,
+        entity: 'frequency',
+        message,
+        redirect: `/${frequencyData.community.slug}`,
       })
-      .catch(err => {
-        this.props.dispatch(addToastWithTimeout('error', err));
-      });
+    );
   };
 
   render() {
@@ -154,7 +172,7 @@ class FrequencyWithData extends Component {
             ? <Actions>
                 <LinkButton
                   color={'warn.alt'}
-                  onClick={this.triggerDeleteFrequency}
+                  onClick={e => this.triggerDeleteFrequency(e, frequency.id)}
                 >
                   Delete Frequency
                 </LinkButton>

--- a/src/components/modals/CreateCommunityModal/index.js
+++ b/src/components/modals/CreateCommunityModal/index.js
@@ -21,8 +21,6 @@ class CreateCommunityModal extends Component {
   constructor(props) {
     super(props);
 
-    console.log(props);
-
     this.state = {
       name: props.modalProps.name || '',
       slug: '',

--- a/src/components/modals/DeleteDoubleCheckModal/index.js
+++ b/src/components/modals/DeleteDoubleCheckModal/index.js
@@ -1,0 +1,159 @@
+// @flow
+import React, { Component } from 'react';
+// $FlowFixMe
+import { connect } from 'react-redux';
+// $FlowFixMe
+import Modal from 'react-modal';
+// $FlowFixMe
+import compose from 'recompose/compose';
+// $FlowFixMe
+import { withRouter } from 'react-router';
+import ModalContainer from '../modalContainer';
+import { LinkButton, Button } from '../../buttons';
+import { modalStyles } from '../styles';
+import { closeModal } from '../../../actions/modals';
+import { addToastWithTimeout } from '../../../actions/toasts';
+import { deleteCommunityMutation } from '../../../api/community';
+import { deleteFrequencyMutation } from '../../../api/frequency';
+import { deleteStoryMutation } from '../../../api/story';
+import { Actions, Message } from './style';
+
+/*
+  Generic component that should be used to confirm any 'delete' action.
+  Takes modalProps as an object with four fields:
+
+  entity => represents the table for lookup in the backend. Currently can
+  be either 'story', 'frequency', or 'community'
+
+  id => id of the entity to be deleted
+
+  message => components can construct a custom confirmation message
+
+  redirect => optional => string which represents the path a user should return
+  too after deleting a thing (e.g. '/foo/bar')
+*/
+class DeleteDoubleCheckModal extends Component {
+  close = () => {
+    this.props.dispatch(closeModal());
+  };
+
+  triggerDelete = () => {
+    const {
+      modalProps: { id, entity, redirect },
+      deleteCommunity,
+      deleteStory,
+      deleteFrequency,
+      dispatch,
+      history,
+    } = this.props;
+
+    switch (entity) {
+      case 'story': {
+        return deleteStory(id)
+          .then(({ data: { deleteStory } }) => {
+            if (deleteStory) {
+              history.push(redirect ? redirect : '/');
+              dispatch(addToastWithTimeout('neutral', 'Story deleted.'));
+              this.close();
+            }
+          })
+          .catch(err => {
+            dispatch(
+              addToastWithTimeout(
+                'error',
+                `Something went wrong and we weren't able to delete this story. ${err}`
+              )
+            );
+          });
+      }
+      case 'frequency': {
+        return deleteFrequency(id)
+          .then(({ data: { deleteFrequency } }) => {
+            if (deleteFrequency) {
+              history.push(redirect ? redirect : '/');
+              dispatch(addToastWithTimeout('neutral', 'Frequency deleted.'));
+              this.close();
+            }
+          })
+          .catch(err => {
+            dispatch(
+              addToastWithTimeout(
+                'error',
+                `Something went wrong and we weren't able to delete this frequency. ${err}`
+              )
+            );
+          });
+      }
+      case 'community': {
+        return deleteCommunity(id)
+          .then(({ data: { deleteCommunity } }) => {
+            if (deleteCommunity) {
+              history.push(redirect ? redirect : '/');
+              dispatch(addToastWithTimeout('neutral', 'Community deleted.'));
+              this.close();
+            }
+          })
+          .catch(err => {
+            dispatch(
+              addToastWithTimeout(
+                'error',
+                `Something went wrong and we weren't able to delete this community. ${err}`
+              )
+            );
+          });
+      }
+      default: {
+        return dispatch(
+          addToastWithTimeout(
+            'error',
+            'Unable to figure out what you wanted to delete. Whoops!'
+          )
+        );
+      }
+    }
+  };
+
+  render() {
+    const { isOpen, modalProps: { message } } = this.props;
+    const styles = modalStyles();
+
+    return (
+      <Modal
+        isOpen={isOpen}
+        contentLabel={'Are you sure?'}
+        onRequestClose={this.close}
+        shouldCloseOnOverlayClick={true}
+        style={styles}
+        closeTimeoutMS={330}
+      >
+        {/*
+          We pass the closeModal dispatch into the container to attach
+          the action to the 'close' icon in the top right corner of all modals
+        */}
+        <ModalContainer title={'Are you sure?'} closeModal={this.close}>
+          <Message>{message ? message : 'Are you sure?'}</Message>
+
+          <Actions>
+            <LinkButton onClick={this.close} color={'warn.alt'}>
+              Cancel
+            </LinkButton>
+            <Button color="warn" onClick={this.triggerDelete}>Delete</Button>
+          </Actions>
+        </ModalContainer>
+      </Modal>
+    );
+  }
+}
+
+const DeleteDoubleCheckModalWithMutations = compose(
+  deleteCommunityMutation,
+  deleteFrequencyMutation,
+  deleteStoryMutation,
+  withRouter
+)(DeleteDoubleCheckModal);
+
+const mapStateToProps = state => ({
+  isOpen: state.modals.isOpen,
+  modalProps: state.modals.modalProps,
+});
+export default connect(mapStateToProps)(DeleteDoubleCheckModalWithMutations);

--- a/src/components/modals/DeleteDoubleCheckModal/style.js
+++ b/src/components/modals/DeleteDoubleCheckModal/style.js
@@ -1,0 +1,27 @@
+// @flow
+// $FlowFixMe
+import styled from 'styled-components';
+import { FlexRow } from '../../globals';
+
+export const Actions = styled(FlexRow)`
+  margin-top: 24px;
+  padding: 0 24px 24px;
+  justify-content: flex-end;
+
+  button + button {
+    margin-left: 8px;
+  }
+`;
+
+export const Message = styled.div`
+  line-height: 1.4;
+  margin: 8px 24px;
+
+  p {
+    margin-top: 8px;
+  }
+
+  b {
+    font-weight: 700;
+  }
+`;

--- a/src/components/modals/modalRoot.js
+++ b/src/components/modals/modalRoot.js
@@ -5,11 +5,13 @@ import { connect } from 'react-redux';
 import UserProfileModal from './UserProfileModal';
 import CreateCommunityModal from './CreateCommunityModal';
 import CreateFrequencyModal from './CreateFrequencyModal';
+import DeleteDoubleCheckModal from './DeleteDoubleCheckModal';
 
 const MODAL_COMPONENTS = {
   USER_PROFILE_MODAL: UserProfileModal,
   CREATE_COMMUNITY_MODAL: CreateCommunityModal,
   CREATE_FREQUENCY_MODAL: CreateFrequencyModal,
+  DELETE_DOUBLE_CHECK_MODAL: DeleteDoubleCheckModal,
 };
 
 /*

--- a/src/views/story/mutations.js
+++ b/src/views/story/mutations.js
@@ -37,29 +37,6 @@ export const setStoryLockMutation = graphql(
 );
 
 /*
-  Delete a story
-*/
-const DELETE_STORY_MUTATION = gql`
-  mutation deleteStory($id: ID!) {
-    deleteStory(id: $id)
-  }
-`;
-const DELETE_STORY_OPTIONS = {
-  props: ({ mutate }) => ({
-    deleteStory: ({ id }) =>
-      mutate({
-        variables: {
-          id,
-        },
-      }),
-  }),
-};
-export const deleteStoryMutation = graphql(
-  DELETE_STORY_MUTATION,
-  DELETE_STORY_OPTIONS
-);
-
-/*
   Sends a message to a story (location is 'messages', which means we are
   in a story).
 


### PR DESCRIPTION
cc @mxstbr @uberbryn –

This provides a generic 'double check' modal for all delete actions. It takes props that tell us what thing is being deleted in the backend. From the client side this makes our lives easier because we can easily trigger any delete confirmation with a resource, custom message, and custom redirect.

Take a look at the code for implementation details on story, frequency, and community. Hope it all makes sense :)