### PR TITLE
Slate Editor v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,8 @@
     "sanitize-html": "^1.14.1",
     "serve": "latest",
     "session-rethinkdb": "^2.0.0",
+    "slate": "^0.20.1",
+    "slate-markdown": "^0.0.6",
     "slugg": "^1.1.0",
     "stripe": "^4.15.0",
     "styled-components": "^1.3.1",

--- a/server/index.js
+++ b/server/index.js
@@ -130,6 +130,11 @@ const server = createServer(app);
 const subscriptionsServer = new SubscriptionServer(
   {
     subscriptionManager,
+    onConnect: connectionParams => {
+      return {
+        loaders: createLoaders(),
+      };
+    },
   },
   {
     server,

--- a/server/migrations/20170410074258-initial-data.js
+++ b/server/migrations/20170410074258-initial-data.js
@@ -109,11 +109,6 @@ exports.down = function(r, conn) {
     r.tableDrop('notifications').run(conn),
     r.tableDrop('usersCommunities').run(conn),
     r.tableDrop('usersChannels').run(conn),
-    r.tableDrop('direct_message_groups').run(conn),
-    r.tableDrop('directMessageGroups').run(conn),
-    r.tableDrop('frequencies').run(conn),
-    r.tableDrop('stories').run(conn),
-    r.tableDrop('direct_messages').run(conn),
   ]).catch(err => {
     console.log(err);
   });

--- a/server/types/Thread.js
+++ b/server/types/Thread.js
@@ -21,6 +21,10 @@ const Thread = /* GraphQL */ `
 		content: ThreadContent!
 	}
 
+	enum ThreadType {
+		SLATE
+	}
+
 	type Thread {
 		id: ID!
 		createdAt: Date!
@@ -33,6 +37,7 @@ const Thread = /* GraphQL */ `
 		content: ThreadContent!
 		isLocked: Boolean
 		isCreator: Boolean
+		type: ThreadType
 		edits: [Edit!]
 		participants: [User]
 		messageConnection(first: Int = 10, after: String): ThreadMessagesConnection!
@@ -53,6 +58,7 @@ const Thread = /* GraphQL */ `
 	input ThreadInput {
 		channelId: ID!
 		communityId: ID!
+		type: ThreadType
 		content: ThreadContentInput!
 	}
 

--- a/src/api/fragments/thread/threadInfo.js
+++ b/src/api/fragments/thread/threadInfo.js
@@ -10,6 +10,7 @@ export const threadInfoFragment = gql`
     isPublished
     isLocked
     isCreator
+		type
     participants {
       ...userInfo
     }

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import styled from 'styled-components';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // // $FlowFixMe
@@ -7,6 +8,7 @@ import withState from 'recompose/withState';
 // // $FlowFixMe
 import withHandlers from 'recompose/withHandlers';
 import Icon from '../icons';
+import Editor, { toPlainText, fromPlainText } from '../../components/editor';
 import {
   Form,
   Input,
@@ -18,10 +20,15 @@ import {
 } from './style';
 import { sendMessageMutation } from '../../api/message';
 
+const InputEditor = styled(Editor)`
+  width: 100%;
+  height: 100%;
+`;
+
 const ChatInputWithMutation = ({
   thread,
   sendMessage,
-  value,
+  state,
   onChange,
   clear,
   createThread,
@@ -36,7 +43,7 @@ const ChatInputWithMutation = ({
     // in views/directMessages/containers/newThread.js
     if (thread === 'newDirectMessageThread') {
       return createThread({
-        messageBody: value,
+        messageBody: toPlainText(state),
         messageType: 'text',
       });
     }
@@ -48,7 +55,7 @@ const ChatInputWithMutation = ({
       messageType: 'text',
       threadType: 'story',
       content: {
-        body: value,
+        body: toPlainText(state),
       },
     })
       .then(() => {
@@ -92,13 +99,12 @@ const ChatInputWithMutation = ({
         tipLocation="top-right"
       />
       <Form>
-        <Input
+        <InputEditor
           ref="textInput"
           placeholder="Your message here..."
-          type="text"
-          value={value}
+          state={state}
           onChange={onChange}
-          onKeyUp={handleKeyPress}
+          markdown={false}
           onFocus={onFocus}
           onBlur={onBlur}
         />
@@ -110,10 +116,10 @@ const ChatInputWithMutation = ({
 
 const ChatInput = compose(
   sendMessageMutation,
-  withState('value', 'changeValue', ''),
+  withState('state', 'changeState', fromPlainText('')),
   withHandlers({
-    onChange: ({ changeValue }) => e => changeValue(e.target.value),
-    clear: ({ changeValue }) => () => changeValue(''),
+    onChange: ({ changeState }) => state => changeState(state),
+    clear: ({ changeState }) => () => changeState(fromPlainText('')),
   })
 )(ChatInputWithMutation);
 

--- a/src/components/editor/index.js
+++ b/src/components/editor/index.js
@@ -1,0 +1,74 @@
+// @flow
+import React, { Component } from 'react';
+import { Editor as SlateEditor, Raw, Plain } from 'slate';
+import type { SlatePlugin } from 'slate-mentions/src/types';
+import MarkdownPlugin from 'slate-markdown';
+
+const ENTER = 13;
+
+const initialState = Plain.deserialize('');
+
+type EditorProps = {
+  markdown?: boolean,
+  state?: Object,
+  onChange?: Function,
+  onEnter?: Function,
+};
+
+class Editor extends Component {
+  props: EditorProps;
+
+  state: {
+    state: Object,
+    plugins: Array<SlatePlugin | false>,
+  };
+
+  constructor(props: EditorProps) {
+    super(props);
+    this.state = {
+      state: initialState,
+      plugins: [props.markdown !== false && MarkdownPlugin()],
+    };
+  }
+
+  onChange = (state: Object) => {
+    this.setState({ state });
+  };
+
+  onKeyDown = e => {
+    if (e.which === ENTER) {
+      this.props.onEnter && this.props.onEnter(e);
+    }
+  };
+
+  render() {
+    const {
+      state = this.state.state,
+      onChange = this.onChange,
+      onEnter,
+      // Don't pass these two down to the SlateEditor
+      markdown,
+      ...rest
+    } = this.props;
+
+    return (
+      <SlateEditor
+        state={state}
+        onChange={onChange}
+        onKeyDown={onEnter && this.onKeyDown}
+        plugins={this.state.plugins}
+        {...rest}
+      />
+    );
+  }
+}
+
+const toJSON = (state: Object) => Raw.serialize(state, { terse: true });
+const toState = (json: Object) => Raw.deserialize(json, { terse: true });
+
+const toPlainText = (state: Object) => Plain.serialize(state);
+const fromPlainText = (string: string) => Plain.deserialize(string);
+
+export { toJSON, toState, toPlainText, fromPlainText };
+
+export default Editor;

--- a/src/components/markdown/index.js
+++ b/src/components/markdown/index.js
@@ -1,0 +1,121 @@
+import React from 'react';
+import { injectGlobal } from 'styled-components';
+import MD from 'react-remarkable';
+
+let injected = false;
+class Markdown extends React.Component {
+  state = {
+    hljs: false,
+  };
+
+  componentWillMount() {
+    // Inject highlight.js theme
+    if (!injected) {
+      // eslint-disable-next-line no-unused-expressions
+      injectGlobal`
+        .hljs {
+        display: block;
+        background: white;
+        padding: 0.5em;
+        color: #333333;
+        overflow-x: auto;
+        }
+
+        .hljs-comment,
+        .hljs-meta {
+        color: #969896;
+        }
+
+        .hljs-string,
+        .hljs-variable,
+        .hljs-template-variable,
+        .hljs-strong,
+        .hljs-emphasis,
+        .hljs-quote {
+        color: #df5000;
+        }
+
+        .hljs-keyword,
+        .hljs-selector-tag,
+        .hljs-type {
+        color: #a71d5d;
+        }
+
+        .hljs-literal,
+        .hljs-symbol,
+        .hljs-bullet,
+        .hljs-attribute {
+        color: #0086b3;
+        }
+
+        .hljs-section,
+        .hljs-name {
+        color: #63a35c;
+        }
+
+        .hljs-tag {
+        color: #333333;
+        }
+
+        .hljs-title,
+        .hljs-attr,
+        .hljs-selector-id,
+        .hljs-selector-class,
+        .hljs-selector-attr,
+        .hljs-selector-pseudo {
+        color: #795da3;
+        }
+
+        .hljs-addition {
+        color: #55a532;
+        background-color: #eaffea;
+        }
+
+        .hljs-deletion {
+        color: #bd2c00;
+        background-color: #ffecec;
+        }
+
+        .hljs-link {
+        text-decoration: underline;
+        }
+      `;
+      injected = true;
+    }
+    // Load highlight.js when it's necessary, but not before
+    System.import('highlight.js').then(module => {
+      this.setState({
+        hljs: module,
+      });
+    });
+  }
+  render() {
+    const { hljs } = this.state;
+    return (
+      <MD
+        options={{
+          html: true,
+          linkify: true,
+          highlight: function(str, lang) {
+            // If highlight.js isn't loaded yet don't highlight
+            if (!hljs) return '';
+            if (lang && hljs.getLanguage(lang)) {
+              try {
+                return hljs.highlight(lang, str).value;
+              } catch (err) {}
+            }
+
+            try {
+              return hljs.highlightAuto(str).value;
+            } catch (err) {}
+
+            return ''; // use external default escaping
+          },
+        }}
+        source={this.props.children}
+      />
+    );
+  }
+}
+
+export default Markdown;

--- a/src/components/threadComposer/index.js
+++ b/src/components/threadComposer/index.js
@@ -16,6 +16,7 @@ import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { Button } from '../buttons';
 import { addToastWithTimeout } from '../../actions/toasts';
+import Editor, { fromPlainText, toJSON } from '../editor';
 import Icon from '../icons';
 import { LoadingComposer } from '../loading';
 import { getComposerCommunitiesAndChannels } from './queries';
@@ -107,7 +108,7 @@ class ThreadComposerWithData extends Component {
     this.state = {
       isOpen: false,
       title: '',
-      body: '',
+      body: fromPlainText(''),
       availableCommunities,
       availableChannels,
       activeCommunity,
@@ -123,10 +124,9 @@ class ThreadComposerWithData extends Component {
     });
   };
 
-  changeBody = e => {
-    const body = e.target.value;
+  changeBody = state => {
     this.setState({
-      body,
+      body: state,
     });
   };
 
@@ -184,7 +184,7 @@ class ThreadComposerWithData extends Component {
     const communityId = activeCommunity;
     const content = {
       title,
-      body,
+      body: JSON.stringify(toJSON(body)),
     };
 
     // this.props.mutate comes from a higher order component defined at the
@@ -195,6 +195,7 @@ class ThreadComposerWithData extends Component {
           thread: {
             channelId,
             communityId,
+            type: 'SLATE',
             content,
           },
         },
@@ -257,14 +258,12 @@ class ThreadComposerWithData extends Component {
               autoFocus
             />
 
-            <Textarea
+            <Editor
               onChange={this.changeBody}
-              value={this.state.body}
+              state={this.state.body}
               style={ThreadDescription}
               ref="bodyTextarea"
-              placeholder={
-                'Write more thoughts here, add photos, and anything else!'
-              }
+              placeholder="Write more thoughts here, add photos, and anything else!"
             />
 
             <Actions>

--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -15,6 +15,7 @@ import { deleteThreadMutation } from '../../../api/thread';
 import Icon from '../../../components/icons';
 import Flyout from '../../../components/flyout';
 import { IconButton } from '../../../components/buttons';
+import { toPlainText, toState } from '../../../components/editor';
 import {
   ThreadWrapper,
   ThreadHeading,
@@ -85,6 +86,11 @@ const ThreadDetailPure = ({
     return dispatch(openModal('USER_PROFILE_MODAL', { user }));
   };
 
+  let body = thread.content.body;
+  if (thread.type === 'SLATE') {
+    body = toPlainText(toState(JSON.parse(body)));
+  }
+
   return (
     <ThreadWrapper>
       <ContextRow>
@@ -119,8 +125,7 @@ const ThreadDetailPure = ({
       <ThreadHeading>
         {thread.content.title}
       </ThreadHeading>
-      {!!thread.content.body &&
-        <ThreadContent>{thread.content.body}</ThreadContent>}
+      {!!thread.content.body && <ThreadContent>{body}</ThreadContent>}
     </ThreadWrapper>
   );
 };

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Card from '../../components/card';
+import Markdown from '../../components/markdown';
 import { FlexCol, FlexRow, H1, Transition } from '../../components/globals';
 
 export const Container = styled(Card)`
@@ -67,7 +68,7 @@ export const Byline = styled.span`
   color: ${({ theme }) => theme.brand.alt};
 `;
 
-export const ThreadContent = styled.div`
+export const ThreadContent = styled(Markdown)`
   margin-top: 16px;
   font-size: 16px;
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1751,6 +1751,14 @@ cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
 
+clipboard@^1.5.5:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.6.1.tgz#65c5b654812466b0faab82dc6ba0f1d2f8e4be53"
+  dependencies:
+    good-listener "^1.2.0"
+    select "^1.1.2"
+    tiny-emitter "^1.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -2362,7 +2370,7 @@ debug@2.6.1:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.3, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0:
+debug@2.6.3, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.3.2, debug@^2.6.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
@@ -2433,6 +2441,10 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
+delegate@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.1.2.tgz#1e1bc6f5cadda6cb6cbf7e6d05d0bcdd5712aebe"
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -2496,6 +2508,10 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+direction@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/direction/-/direction-0.1.5.tgz#ce5d797f97e26f8be7beff53f7dc40e1c1a9ec4c"
 
 discontinuous-range@1.0.0:
   version "1.0.0"
@@ -2768,7 +2784,7 @@ es6-iterator@2:
     es5-ext "^0.10.7"
     es6-symbol "3"
 
-es6-map@^0.1.3:
+es6-map@^0.1.3, es6-map@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.4.tgz#a34b147be224773a4d7da8072794cefa3632b897"
   dependencies:
@@ -2964,6 +2980,10 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "~4.1.0"
     object-assign "^4.0.1"
+
+esrever@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/esrever/-/esrever-0.2.0.tgz#96e9d28f4f1b1a76784cd5d490eaae010e7407b8"
 
 estraverse@^1.9.1:
   version "1.9.3"
@@ -3616,6 +3636,10 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-document@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/get-document/-/get-document-1.0.0.tgz#4821bce66f1c24cb0331602be6cb6b12c4f01c4b"
+
 get-stdin@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
@@ -3623,6 +3647,12 @@ get-stdin@5.0.1:
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-window@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-window/-/get-window-1.1.1.tgz#0750f8970c88a54ac1294deb97add9568b3db594"
+  dependencies:
+    get-document "1"
 
 getpass@^0.1.1:
   version "0.1.6"
@@ -3708,6 +3738,12 @@ gm@~1.16.0:
     debug "0.7.0"
     stream-to-buffer "~0.0.1"
     through "~2.3.1"
+
+good-listener@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
 
 got@^3.2.0:
   version "3.3.1"
@@ -4139,6 +4175,10 @@ immutability-helper@^2.2.0:
   dependencies:
     invariant "^2.2.0"
 
+immutable@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -4298,6 +4338,10 @@ is-dotfile@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
 
+is-empty@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-empty/-/is-empty-1.2.0.tgz#de9bb5b278738a05a0b09a57e1fb4d4a341a9f6b"
+
 is-equal-shallow@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz#2238098fc221de0bcfa5d9eac4c45d638aa1c534"
@@ -4347,6 +4391,10 @@ is-glob@^3.1.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
   dependencies:
     is-extglob "^2.1.0"
+
+is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
 
 is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.15.0"
@@ -4462,6 +4510,10 @@ is-url@^1.2.1:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-window@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-window/-/is-window-1.0.2.tgz#2c896ca53db97de45d3c33133a65d8c9f563480d"
 
 isarray@0.0.1:
   version "0.0.1"
@@ -4974,6 +5026,10 @@ jws@^3.0.0, jws@^3.1.3:
     base64url "^2.0.0"
     jwa "^1.1.4"
     safe-buffer "^5.0.1"
+
+keycode@^2.1.2:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.9.tgz#964a23c54e4889405b4861a5c9f0480d45141dfa"
 
 kind-of@^3.0.2:
   version "3.1.0"
@@ -6851,6 +6907,12 @@ pretty-format@^19.0.0:
   dependencies:
     ansi-styles "^3.0.0"
 
+prismjs@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.6.0.tgz#118d95fb7a66dba2272e343b345f5236659db365"
+  optionalDependencies:
+    clipboard "^1.5.5"
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -7121,6 +7183,12 @@ react-motion@^0.4.2, react-motion@^0.4.8:
     performance-now "^0.2.0"
     prop-types "^15.5.8"
     raf "^3.1.0"
+
+react-portal@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.1.0.tgz#865c44fb72a1da106c649206936559ce891ee899"
+  dependencies:
+    prop-types "^15.5.8"
 
 react-redux@^5.0.2:
   version "5.0.2"
@@ -7827,6 +7895,14 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+
+selection-is-backward@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/selection-is-backward/-/selection-is-backward-1.0.0.tgz#97a54633188a511aba6419fc5c1fa91b467e6be1"
+
 semver-diff@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
@@ -7991,6 +8067,32 @@ signal-exit@^3.0.0:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slate-markdown@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/slate-markdown/-/slate-markdown-0.0.6.tgz#b0d5bd582991e23292280b3c8e56c4fae7d9df43"
+  dependencies:
+    prismjs "^1.6.0"
+
+slate@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.20.1.tgz#d60842c0aa32c1c08e1a2e439ca091ba73e85bdb"
+  dependencies:
+    cheerio "^0.22.0"
+    debug "^2.3.2"
+    direction "^0.1.5"
+    es6-map "^0.1.4"
+    esrever "^0.2.0"
+    get-window "^1.1.1"
+    immutable "^3.8.1"
+    is-empty "^1.0.0"
+    is-in-browser "^1.1.3"
+    is-window "^1.0.2"
+    keycode "^2.1.2"
+    prop-types "^15.5.8"
+    react-portal "^3.1.0"
+    selection-is-backward "^1.0.0"
+    type-of "^2.0.1"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -8496,6 +8598,10 @@ timers-browserify@^2.0.2:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-emitter@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-1.2.0.tgz#6dc845052cb08ebefc1874723b58f24a648c3b6f"
+
 tinycolor@0.x:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/tinycolor/-/tinycolor-0.0.1.tgz#320b5a52d83abb5978d81a3e887d4aefb15a6164"
@@ -8602,6 +8708,10 @@ type-is@~1.6.14:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.13"
+
+type-of@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
This is a port of #679 to work with all the improvements we made since. This turned out to be way easier than to fix all the conflicts in #679! (which I tried at first without any luck)

This changes the schema of a thread by adding a `type` field to it which can either be `"SLATE"` (for all new threads) or nothing for all existing ones. We store the `JSON.stringified` slate state in the db so that we can (in the future) render mentions, links etc as actual React components.