### PR TITLE
Fixes reactions

### DIFF
--- a/server/types/Reaction.js
+++ b/server/types/Reaction.js
@@ -22,7 +22,7 @@ const Reaction = /* GraphQL */ `
 
 	extend type Mutation {
 		# Returns true if toggling completed successfully
-		toggleReaction(reaction: ReactionInput!): Reaction
+		toggleReaction(reaction: ReactionInput!): Message
 	}
 `;
 

--- a/src/views/directMessages/mutations.js
+++ b/src/views/directMessages/mutations.js
@@ -1,9 +1,7 @@
 // @flow
 // $FlowFixMe
 import { graphql, gql } from 'react-apollo';
-import {
-  reactionInfoFragment,
-} from '../../api/fragments/reaction/reactionInfo';
+import { messageInfoFragment } from '../../api/fragments/message/messageInfo';
 
 /*
   Toggles a reaction on a specific message. The reaction object is created
@@ -17,11 +15,11 @@ import {
 const TOGGLE_REACTION_MUTATION = gql`
   mutation toggleReaction($reaction: ReactionInput!) {
     toggleReaction(reaction: $reaction) {
-      ...reactionInfo
+      ...messageInfo
       __typename
     }
   }
-  ${reactionInfoFragment}
+  ${messageInfoFragment}
 `;
 const TOGGLE_REACTION_OPTIONS = {
   props: ({ ownProps, mutate }) => ({
@@ -32,78 +30,6 @@ const TOGGLE_REACTION_OPTIONS = {
       mutate({
         variables: {
           reaction,
-        },
-        optimisticResponse: {
-          __typename: 'Mutation',
-          toggleReaction: {
-            id: Math.random() * -10000,
-            type: 'like',
-            user: {
-              id: ownProps.currentUser.id,
-              __typename: 'User',
-            },
-            __typename: 'Reaction',
-          },
-        },
-        updateQueries: {
-          getDirectMessageThreadMessages: (prev, { mutationResult }) => {
-            const newReaction = mutationResult.data.toggleReaction;
-
-            return Object.assign({}, prev, {
-              ...prev,
-              directMessageThread: {
-                ...prev.directMessageThread,
-                messageConnection: {
-                  ...prev.directMessageThread.messageConnection,
-                  edges: prev.directMessageThread.messageConnection.edges.map(
-                    edge => {
-                      // make sure we're modifying the correct message
-                      if (edge.node.id !== reaction.message) return edge;
-
-                      // if no reactions exist yet, add one immediately for the
-                      // current user
-                      if (edge.node.reactions.length === 0) {
-                        return {
-                          ...edge,
-                          node: {
-                            ...edge.node,
-                            reactions: [...edge.node.reactions, newReaction],
-                          },
-                        };
-                      }
-
-                      // if the current user has already reacted, remove their
-                      // reaction from the array
-                      if (
-                        edge.node.reactions.find(r => {
-                          return r.user.id === newReaction.user.id;
-                        })
-                      ) {
-                        return {
-                          ...edge,
-                          node: {
-                            ...edge.node,
-                            reactions: edge.node.reactions.filter(r => {
-                              return r.user.id !== newReaction.user.id;
-                            }),
-                          },
-                        };
-                      }
-
-                      // otherwise add the reaction
-                      return {
-                        ...edge,
-                        node: {
-                          ...edge.node,
-                          reactions: [...edge.node.reactions, newReaction],
-                        },
-                      };
-                    }
-                  ),
-                },
-              },
-            });
-          },
         },
       }),
   }),

--- a/src/views/thread/mutations.js
+++ b/src/views/thread/mutations.js
@@ -4,6 +4,7 @@ import { graphql, gql } from 'react-apollo';
 import {
   reactionInfoFragment,
 } from '../../api/fragments/reaction/reactionInfo';
+import { messageInfoFragment } from '../../api/fragments/message/messageInfo';
 
 /*
   Send an id and boolean value to set a thread to be locked or unlocked.
@@ -47,11 +48,11 @@ export const setThreadLockMutation = graphql(
 const TOGGLE_REACTION_MUTATION = gql`
   mutation toggleReaction($reaction: ReactionInput!) {
     toggleReaction(reaction: $reaction) {
-      ...reactionInfo
+      ...messageInfo
       __typename
     }
   }
-  ${reactionInfoFragment}
+  ${messageInfoFragment}
 `;
 const TOGGLE_REACTION_OPTIONS = {
   props: ({ ownProps, mutate }) => ({
@@ -63,82 +64,7 @@ const TOGGLE_REACTION_OPTIONS = {
         variables: {
           reaction,
         },
-        optimisticResponse: {
-          __typename: 'Mutation',
-          toggleReaction: {
-            id: Math.random() * -10000,
-            type: 'like',
-            user: {
-              id: ownProps.currentUser.id,
-              __typename: 'User',
-            },
-            __typename: 'Reaction',
-          },
-        },
-        // update: (store, { data: { toggleReaction }}) => {
-        //   const data = store.readQuery({ query: GET_THREAD_MESSAGES_QUERY })
-        //   console.log('updating', data)
-        // }
       }),
-    //   updateQueries: {
-    //     getThreadMessages: (prev, { mutationResult }) => {
-    //       const newReaction = mutationResult.data.toggleReaction;
-    //       console.log('in the reaction update', prev, newReaction)
-    //       return Object.assign({}, prev, {
-    //         ...prev,
-    //         thread: {
-    //           ...prev.thread,
-    //           messageConnection: {
-    //             ...prev.thread.messageConnection,
-    //             edges: prev.thread.messageConnection.edges.map(edge => {
-    //               // make sure we're modifying the correct message
-    //               if (edge.node.id !== reaction.message) return edge;
-    //
-    //               // if no reactions exist yet, add one immediately for the
-    //               // current user
-    //               if (edge.node.reactions.length === 0) {
-    //                 return {
-    //                   ...edge,
-    //                   node: {
-    //                     ...edge.node,
-    //                     reactions: [...edge.node.reactions, newReaction],
-    //                   },
-    //                 };
-    //               }
-    //
-    //               // if the current user has already reacted, remove their
-    //               // reaction from the array
-    //               if (
-    //                 edge.node.reactions.find(r => {
-    //                   return r.user.id === newReaction.user.id;
-    //                 })
-    //               ) {
-    //                 return {
-    //                   ...edge,
-    //                   node: {
-    //                     ...edge.node,
-    //                     reactions: edge.node.reactions.filter(r => {
-    //                       return r.user.id !== newReaction.user.id;
-    //                     }),
-    //                   },
-    //                 };
-    //               }
-    //
-    //               // otherwise add the reaction
-    //               return {
-    //                 ...edge,
-    //                 node: {
-    //                   ...edge.node,
-    //                   reactions: [...edge.node.reactions, newReaction],
-    //                 },
-    //               };
-    //             }),
-    //           },
-    //         },
-    //       });
-    //     },
-    //   },
-    // }),
   }),
 };
 export const toggleReactionMutation = graphql(


### PR DESCRIPTION
Reactions broke somewhere along the way, but in the meantime I've learned a bit more about how Apollo works and managed to find a much easier fix (although to be fair, this version of reactions still waits for the network request to complete before toggling the reaction on/off, which might feel slow on bad networks...this will be a polish task in the future).

The key here was to return the *message object* itself, and not the *reaction object* - in this way, Apollo is able to automatically update the store with the newly returned message and handles the UI changes automatically. Magic!