### PR TITLE
Fix thread creation

### DIFF
--- a/server/types/Thread.js
+++ b/server/types/Thread.js
@@ -33,7 +33,7 @@ const Thread = /* GraphQL */ `
 	type Thread {
 		id: ID!
 		createdAt: Date!
-		modifiedAt: Date!
+		modifiedAt: Date
 		channel: Channel!
 		community: Community!
 		channelPermissions: ChannelPermissions!


### PR DESCRIPTION
`modifiedAt` was marked as a non-nullable field but when we create a
thread we set `modifiedAt` to, you guessed it, `null`.

I assume `modifiedAt` should be `null` when the thread hasn't been
modified, so I instead made the field in the schema nullable.

Closes #835

/cc @brianlovin