### PR TITLE
Store username from Twitter on user creation if old data exists

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -71,7 +71,14 @@ const createOrFindUser = (user: Object): Promise<Object> => {
     : getUserByProviderId(user.providerId);
   return promise
     .then(storedUser => {
-      if (storedUser) return Promise.resolve(storedUser);
+      if (storedUser) {
+        if (!storedUser.username && user.username) {
+          return setUsername(storedUser.id, user.username).then(newStoredUser =>
+            Promise.resolve(newStoredUser)
+          );
+        }
+        return Promise.resolve(storedUser);
+      }
 
       return storeUser(user);
     })
@@ -81,6 +88,20 @@ const createOrFindUser = (user: Object): Promise<Object> => {
       }
       return storeUser(user);
     });
+};
+
+const setUsername = (id: string, username: string) => {
+  return db
+    .table('users')
+    .get(id)
+    .update(
+      {
+        username,
+      },
+      { returnChanges: true }
+    )
+    .run()
+    .then(result => result.changes[0].new_val);
 };
 
 const getEverything = (userId: string): Promise<Array<any>> => {


### PR DESCRIPTION
If an old user with the same `providerId` signs in we get their data. If they don't have a `username` set we set it to the one from Twitter! :tada:

Related to #810, might not close it though depending on what @brianlovin thinks.