### PR TITLE
Fix threads without attachments

### DIFF
--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -59,7 +59,7 @@ class ThreadDetailPure extends Component {
 
     const { thread } = props;
 
-    let rawLinkPreview = thread.attachments.length > 0
+    let rawLinkPreview = thread.attachments && thread.attachments.length > 0
       ? thread.attachments.filter(
           attachment => attachment.attachmentType === 'linkPreview'
         )[0]


### PR DESCRIPTION
`attachments` can also be `null` in some cases, which breaks this code. Closes #843