### PR TITLE
Filter private channels from channel list

### DIFF
--- a/server/models/channel.js
+++ b/server/models/channel.js
@@ -9,7 +9,9 @@ const getChannelsByCommunity = (
   return db
     .table('channels')
     .getAll(communityId, { index: 'communityId' })
-    .filter(channel => db.not(channel.hasFields('deletedAt')))
+    .filter(channel =>
+      db.not(channel.hasFields('deletedAt')).and(db.not(channel('isPrivate')))
+    )
     .run();
 };
 


### PR DESCRIPTION
This means private channels won't show up anywhere in the UI, you can only find them by knowing the URL/by clicking through from a thread. (right now they show up in the channels list)

This isn't very smart, it should show it in the list if the current user is a member of that channel, but I couldn't figure out a way to do that. Any ideas @brianlovin?

Closes #872

> I also think this might need more complex behaviour maybe in the future, where a channel can either be private and/or hidden. Private just means the content and members are hidden but you can find it and request to join, where hidden means you can't find it if you don't know it exists.