### PR TITLE
Fix thread composer behavior

### DIFF
--- a/src/components/threadComposer/queries.js
+++ b/src/components/threadComposer/queries.js
@@ -37,6 +37,7 @@ query getComposerCommunitiesAndChannels {
         node {
           id
           name
+          slug
           community {
             id
           }


### PR DESCRIPTION
Fixes a bug where it wasn't selecting the right channel in the composer when viewing a channel profile.

Fixes a bug where navigating between channels wouldn't update the activechannel in the composer.

Fixes a bug where if no channels are found (i.e. bad data in the db) it won't crash the composer