### PR TITLE
Top coms fix

### DIFF
--- a/server/models/community.js
+++ b/server/models/community.js
@@ -551,13 +551,13 @@ const getTopCommunities = (amount: number): Array<Object> => {
         .sort((x, y) => {
           return y.count - x.count;
         })
-        .map(community => community.id);
+        .map(community => community.id)
+        .slice(0, 11);
 
       return db
         .table('communities')
         .getAll(...sortedCommunities)
         .filter(community => db.not(community.hasFields('deletedAt')))
-        .limit(10)
         .run();
     });
 };


### PR DESCRIPTION
Rethinkdb doesn't return documents in the order of the array - which I should have known. So now I'm doing a slice to make sure only the top 10 communities are returned and then ensuring no deleted ones get through.