### PR TITLE
Switch to Space Program micro-open-graph instance

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -180,9 +180,7 @@ export const throttle = (func, threshhold, scope) => {
 };
 
 export const getLinkPreviewFromUrl = url =>
-  fetch(
-    `https://micro-open-graph-phbmtaqieu.now.sh/?url=${url}`
-  ).then(response => {
+  fetch(`https://links.spectrum.chat/?url=${url}`).then(response => {
     return response.json();
   });
 


### PR DESCRIPTION
I deployed a `micro-open-graph` instance with our Zeit team and aliased it to `links.spectrum.chat`! That means we'll be able to update in the future without code changes, and it looks much better.

Closes #920