### PR TITLE
Fix contextual scroll to bottom for new dm threads

### DIFF
--- a/src/views/directMessages/components/messages.js
+++ b/src/views/directMessages/components/messages.js
@@ -37,12 +37,13 @@ class MessagesWithData extends Component {
     }
   };
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prev) {
     this.subscribe();
+    const { contextualScrollToBottom, data } = this.props;
 
     // force scroll to bottom when a message is sent in the same thread
-    if (prevProps.data.messages !== this.props.data.messages) {
-      this.props.contextualScrollToBottom();
+    if (prev.data.messages !== data.messages && contextualScrollToBottom) {
+      contextualScrollToBottom();
     }
   }
 


### PR DESCRIPTION
The new DM thread screen doesn't pass the `contextualScrollToBottom`
prop, so this throws an error.

Fixed by simply checking if it exists.

Closes #977, fixes https://sentry.io/space-program/spectrum/issues/289055277/