### PR TITLE
Fix thread ordering

### DIFF
--- a/server/models/thread.js
+++ b/server/models/thread.js
@@ -159,6 +159,7 @@ export const publishThread = (
       Object.assign({}, thread, {
         creatorId: userId,
         createdAt: new Date(),
+        lastActive: new Date(),
         modifiedAt: null,
         isPublished: true,
         isLocked: false,


### PR DESCRIPTION
I'll also go through and add `lastActive` on all old threads that only have `createdAt` with this script:

```JS
r.db('spectrum').table('threads').filter(r.row.hasFields('lastActive').not()).update({
  lastActive: r.row('createdAt')
})
```

Closes #1069