### PR TITLE
Fix server async flow to handle leaving the last channel in a community

### DIFF
--- a/server/models/community.js
+++ b/server/models/community.js
@@ -470,8 +470,6 @@ const userIsMemberOfAnyChannelInCommunity = (
     .pluck('isMember')
     .run()
     .then(channels => {
-      // if the channels length is one, it means we are evaulating a user who is leaving the last channel in a community. we return false to trigger a function which will also leave the community
-      if (channels.length <= 1) return false;
       // if any of the channels return true for isMember, we return true
       return channels.some(channel => channel.isMember);
     });

--- a/server/mutations/channel.js
+++ b/server/mutations/channel.js
@@ -316,23 +316,25 @@ module.exports = {
             currentUser.id
           );
 
-          // check to see if the user is a member of any other channels
-          // in that community. if they are, we can return. if they are
-          // not a member of any other channels in that community then we
-          // know that this is the *last* channel they are leaving and they
-          // should also be removed from the parent community itself
-          const isMemberOfAnotherChannel = userIsMemberOfAnyChannelInCommunity(
-            channelToEvaluate.communityId,
-            currentUser.id
-          );
-
           return (
-            Promise.all([
-              channelToEvaluate,
-              removeRelationship,
-              isMemberOfAnotherChannel,
-            ])
-              .then(([channelToEvaluate, remove, isMemberOfAnotherChannel]) => {
+            Promise.all([channelToEvaluate, removeRelationship])
+              .then(([channelToEvaluate, remove]) => {
+                // check to see if the user is a member of any other channels
+                // in that community. if they are, we can return. if they are
+                // not a member of any other channels in that community then we
+                // know that this is the *last* channel they are leaving and they
+                // should also be removed from the parent community itself
+                const isMemberOfAnotherChannel = userIsMemberOfAnyChannelInCommunity(
+                  channelToEvaluate.communityId,
+                  currentUser.id
+                );
+
+                return Promise.all([
+                  channelToEvaluate,
+                  isMemberOfAnotherChannel,
+                ]);
+              })
+              .then(([channelToEvaluate, isMemberOfAnotherChannel]) => {
                 // if they are a member of another channel, we can continue
                 if (isMemberOfAnotherChannel) {
                   return Promise.all([channelToEvaluate]);


### PR DESCRIPTION
I had a bad async flow that would always be off-by-one when checking to see if a user should leave a community while leaving a channel (should trigger if the user is leaving the *last* channel in a community).

This just reorders the flow and seems to be working to make sure we handle leaving channels/communities properly.

Closes #1009 