### PR TITLE
Mark notifications as seen on icon click

### DIFF
--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -53,8 +53,8 @@ class Navbar extends Component {
     };
   }
 
-  calculateUnseenCounts = props => {
-    const { data: { user }, notificationsQuery, match } = props || this.props;
+  calculateUnseenCounts = () => {
+    const { data: { user }, notificationsQuery, match } = this.props;
     const currentUser = user;
     let notifications =
       currentUser &&


### PR DESCRIPTION
Closes #1108

So I dug into this one and made a small fix to also mark as read on click (which should help with mobile clients). The thing is we're already using local state to manage unread counts, so I'm not sure what's breaking this in prod. Will keep looking into it, but it's impossible to test locally because even with the lowest network speed throttle everything happens instantly.

Regarding the favicon not updating - no idea what's happening here. I tried messing around in the `components/head` file and making explicit changes to display `/favicon.ico` if the unread count was 0. But even when the correct prop was passed in, the favicon only updates after a subsequent page load...