### PR TITLE
Sort notifications by modified at in all views

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -173,7 +173,8 @@ export function timeDifferenceShort(current: Date, previous: Date) {
 export const debounce = (func, wait, immediate) => {
   let timeout;
   return () => {
-    let context = this, args = arguments;
+    let context = this,
+      args = arguments;
     let later = () => {
       timeout = null;
       if (!immediate) func.apply(context, args);
@@ -191,7 +192,8 @@ export const throttle = (func, threshhold, scope) => {
   return function() {
     let context = scope || this;
 
-    let now = +new Date(), args = arguments;
+    let now = +new Date(),
+      args = arguments;
     if (last && now < last + threshhold) {
       // hold on to it
       clearTimeout(deferTimer);
@@ -237,4 +239,14 @@ export const addProtocolToString = string => {
     // otherwise it doesn't start with a protocol, prepend http
     return `http://${string}`;
   }
+};
+
+export const sortByDate = (array, key, order) => {
+  return array.sort((a, b) => {
+    const x = new Date(a[key]).getTime();
+    const y = new Date(b[key]).getTime();
+    // desc = older to newest from top to bottom
+    const val = order === 'desc' ? y - x : x - y;
+    return val;
+  });
 };

--- a/src/views/notifications/components/newThreadNotification.js
+++ b/src/views/notifications/components/newThreadNotification.js
@@ -5,6 +5,7 @@ import compose from 'recompose/compose';
 // $FlowFixMe
 import pure from 'recompose/pure';
 import { getThreadById } from '../../../api/thread';
+import { sortByDate } from '../../../helpers/utils';
 import { displayLoadingCard } from '../../../components/loading';
 import { parseNotificationDate, parseContext } from '../utils';
 import Icon from '../../../components/icons';
@@ -18,6 +19,21 @@ import {
   ContentWash,
 } from '../style';
 
+const sortThreads = (entities, currentUser) => {
+  // filter out the current user's threads
+  let threads = entities.filter(
+    thread => thread.payload.creatorId !== currentUser.id
+  );
+
+  // create an array of payloads
+  threads = threads && threads.map(thread => thread.payload);
+
+  // sort the threads by created at date
+  threads = threads && sortByDate(threads, 'createdAt', 'desc');
+
+  return threads;
+};
+
 const ThreadCreatedComponent = ({ data }) => {
   return <ThreadProfile profileSize="mini" data={data} />;
 };
@@ -30,20 +46,8 @@ export const NewThreadNotification = ({ notification, currentUser }) => {
   const date = parseNotificationDate(notification.modifiedAt);
   const context = parseContext(notification.context);
 
-  // determine if there are non-currentUser created threads
-  let threads = notification.entities.filter(
-    thread => thread.payload.creatorId !== currentUser.id
-  );
-
-  // sort by most recently created
-  threads =
-    threads &&
-    threads.sort((a, b) => {
-      const x = new Date(a.payload.createdAt).getTime();
-      const y = new Date(b.payload.createdAt).getTime();
-      const val = y - x;
-      return val;
-    });
+  // sort and order the threads
+  const threads = sortThreads(notification.entities, currentUser);
 
   const newThreadCount = threads.length > 1
     ? `New threads were`
@@ -61,9 +65,7 @@ export const NewThreadNotification = ({ notification, currentUser }) => {
         <ContentWash>
           <AttachmentsWash>
             {threads.map(thread => {
-              return (
-                <ThreadCreated key={thread.payload.id} id={thread.payload.id} />
-              );
+              return <ThreadCreated key={thread.id} id={thread.id} />;
             })}
           </AttachmentsWash>
         </ContentWash>
@@ -82,20 +84,8 @@ export const MiniNewThreadNotification = ({
   const date = parseNotificationDate(notification.modifiedAt);
   const context = parseContext(notification.context);
 
-  // determine if there are non-currentUser created threads
-  let threads = notification.entities.filter(
-    thread => thread.payload.creatorId !== currentUser.id
-  );
-
-  // sort by most recently created
-  threads =
-    threads &&
-    threads.sort((a, b) => {
-      const x = new Date(a.payload.createdAt).getTime();
-      const y = new Date(b.payload.createdAt).getTime();
-      const val = y - x;
-      return val;
-    });
+  // sort and order the threads
+  const threads = sortThreads(notification.entities, currentUser);
 
   const newThreadCount = threads.length > 1
     ? `New threads were`
@@ -113,9 +103,7 @@ export const MiniNewThreadNotification = ({
         <ContentWash mini>
           <AttachmentsWash>
             {threads.map(thread => {
-              return (
-                <ThreadCreated key={thread.payload.id} id={thread.payload.id} />
-              );
+              return <ThreadCreated key={thread.id} id={thread.id} />;
             })}
           </AttachmentsWash>
         </ContentWash>

--- a/src/views/notifications/components/notificationDropdownList.js
+++ b/src/views/notifications/components/notificationDropdownList.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import { NotificationListContainer } from '../style';
 import { parseNotification } from '../utils';
+import { sortByDate } from '../../../helpers/utils';
 import { MiniNewMessageNotification } from './newMessageNotification';
 import { MiniNewReactionNotification } from './newReactionNotification';
 import { MiniNewChannelNotification } from './newChannelNotification';
@@ -16,12 +17,14 @@ export const NotificationDropdownList = ({
   /*
     parse the notifications and cut it down to the latest 5
   */
-  const notifications = rawNotifications
+  let notifications = rawNotifications
     .map(notification => parseNotification(notification))
     .slice(0, 10)
     .filter(
       notification => notification.context.type !== 'DIRECT_MESSAGE_THREAD'
     );
+
+  notifications = sortByDate(notifications, 'modifiedAt', 'desc');
 
   return (
     <NotificationListContainer>

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -19,6 +19,7 @@ import Titlebar from '../../views/titlebar';
 import { displayLoadingNotifications } from '../../components/loading';
 import { FetchMoreButton } from '../../components/threadFeed/style';
 import { FlexCol } from '../../components/globals';
+import { sortByDate } from '../../helpers/utils';
 import {
   getNotifications,
   markNotificationsSeenMutation,
@@ -103,6 +104,7 @@ class NotificationsPure extends Component {
       );
 
     notifications = getDistinctNotifications(notifications);
+    notifications = sortByDate(notifications, 'modifiedAt', 'desc');
 
     const { notifications: { pageInfo: { hasNextPage } } } = data;
 


### PR DESCRIPTION
I kept seeing my notifications get shuffled out of order. This should ensure they are always sorted by modifedAt date (with a new helper util to sort by dates)