### PR TITLE
Optimize images

### DIFF
--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -7,6 +7,7 @@ import compose from 'recompose/compose';
 // $FlowFixMe
 import styled from 'styled-components';
 import { Gradient } from '../globals';
+import { optimize } from '../../helpers/images';
 
 const StyledAvatar = styled.img`
   position: absolute;
@@ -49,7 +50,12 @@ const StyledAvatarContainer = styled.object`
 
 const AvatarPure = (props: Object): React$Element<any> => (
   <StyledAvatarContainer {...props}>
-    <StyledAvatar {...props} />
+    <StyledAvatar
+      {...props}
+      src={optimize(props.src, {
+        w: props.size,
+      })}
+    />
   </StyledAvatarContainer>
 );
 

--- a/src/components/profile/coverPhoto.js
+++ b/src/components/profile/coverPhoto.js
@@ -6,13 +6,20 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { Gradient } from '../globals';
 import { ProfileHeaderAction } from './style';
+import { optimize } from '../../helpers/images';
 
 const PhotoContainer = styled.div`
   position: relative;
   width: 100%;
   flex: 0 0 ${props => (props.large ? '320px' : '96px')};
   background-color: ${({ theme }) => theme.space.light};
-  background-image: ${props => (props.coverURL ? `url(${props.coverURL}?w=${props.large ? 1024 : 320}&dpr=2)` : Gradient(props.theme.space.light, props.theme.space.dark))};
+  background-image: ${props => (props.coverURL ? `url(${optimize(
+        props.coverURL,
+        {
+          w: props.large ? 1024 : 320,
+          dpr: 2,
+        }
+      )})` : Gradient(props.theme.space.light, props.theme.space.dark))};
   background-size: cover;
   background-repeat: no-repeat;
   background-position: center;

--- a/src/helpers/images.js
+++ b/src/helpers/images.js
@@ -1,0 +1,15 @@
+// @flow
+type QueryParams = {
+  [key: string]: string,
+};
+
+/**
+ * Optimize an image
+ */
+export const optimize = (src: string, params?: QueryParams = {}): string => {
+  if (src.indexOf('spectrum.imgix.net') < 0) return src;
+  const queryparams = Object.keys(params).reduce((string, key) => {
+    return `${string}&${key}=${params[key]}`;
+  }, '');
+  return `${src}?auto=compress${queryparams}`;
+};


### PR DESCRIPTION
By using the `auto=compress` query param we save a lot of data being loaded. I've applied this to most images, specifically the biggest offenders.