### PR TITLE
Permanently show refresh to update toast, refresh on click

### DIFF
--- a/src/actions/toasts.js
+++ b/src/actions/toasts.js
@@ -1,13 +1,21 @@
 // @flow
 type Toasts = 'success' | 'error' | 'neutral';
 
-const addToast = (id: number, kind: Toasts, message: string) => {
+type Action = 'refresh';
+
+export const addToast = (
+  id: number,
+  kind: Toasts,
+  message: string,
+  action?: Action
+) => {
   return {
     type: 'ADD_TOAST',
     payload: {
       id,
       kind,
       message,
+      action,
     },
   };
 };
@@ -19,7 +27,8 @@ const removeToast = (id: number) => {
 let nextToastId = 0;
 export const addToastWithTimeout = (
   kind: Toasts,
-  message: string
+  message: string,
+  action?: Action
 ) => dispatch => {
   const id = nextToastId++;
   dispatch(addToast(id, kind, message));

--- a/src/components/toasts/index.js
+++ b/src/components/toasts/index.js
@@ -16,15 +16,32 @@ const ToastsPure = ({ toasts }): React$Element<any> => {
   return (
     <Container>
       {toasts.map(toast => {
+        const onClick =
+          toast.action === 'refresh' &&
+          (() => {
+            window.location.reload(false);
+          });
         switch (toast.kind) {
           case 'error': {
-            return <ErrorToast key={toast.id}>{toast.message}</ErrorToast>;
+            return (
+              <ErrorToast onClick={onClick} key={toast.id}>
+                {toast.message}
+              </ErrorToast>
+            );
           }
           case 'success': {
-            return <SuccessToast key={toast.id}>{toast.message}</SuccessToast>;
+            return (
+              <SuccessToast onClick={onClick} key={toast.id}>
+                {toast.message}
+              </SuccessToast>
+            );
           }
           case 'neutral': {
-            return <NeutralToast key={toast.id}>{toast.message}</NeutralToast>;
+            return (
+              <NeutralToast onClick={onClick} key={toast.id}>
+                {toast.message}
+              </NeutralToast>
+            );
           }
           default: {
             return <span />;

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import { getItemFromStorage } from './helpers/localStorage';
 import { theme } from './components/theme';
 import Routes from './routes';
 import Homepage from './views/homepage';
-import { addToastWithTimeout } from './actions/toasts';
+import { addToast } from './actions/toasts';
 import registerServiceWorker from './registerServiceWorker';
 import type { ServiceWorkerResult } from './registerServiceWorker';
 import { track } from './helpers/events';
@@ -66,9 +66,11 @@ try {
 registerServiceWorker().then(({ newContent }: ServiceWorkerResult) => {
   if (newContent) {
     store.dispatch(
-      addToastWithTimeout(
+      addToast(
+        Infinity,
         'success',
-        'A new version of Spectrum is available, refresh the page to see it! 🚀'
+        'A new version of Spectrum is available, refresh the page to see it! 🚀',
+        'refresh'
       )
     );
   }


### PR DESCRIPTION
Don't make that "refresh to update" toast (which is pretty important to use because if users run old code their page might break if we update the server) go away and let them click it to refresh.