### PR TITLE
Only save user timezone if user is logged in

### DIFF
--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -138,12 +138,6 @@ class Navbar extends Component {
     } else return false;
   };
 
-  componentDidMount() {
-    if (this.props.currentUser && !this.props.currentUser.timezone) {
-      this.props.editUser({ timezone: new Date().getTimezoneOffset() * -1 });
-    }
-  }
-
   componentDidUpdate(prevProps) {
     // if the query returned notifications
     if (
@@ -168,6 +162,9 @@ class Navbar extends Component {
     if (!user) return;
 
     if (prevProps.data.user !== user && user !== null) {
+      if (!user.timezone) {
+        this.props.editUser({ timezone: new Date().getTimezoneOffset() * -1 });
+      }
       dispatch(saveUserDataToLocalStorage(user));
 
       // if the user lands on /home, it means they just logged in. If this code


### PR DESCRIPTION
Previously I checked for the existence of `currentUser`, but that's the one from localStorage so somebody might've signed out and we still tried to store their timezone, throwing an error on the the server.