### PR TITLE
Disable Sentry in development on the server

### DIFF
--- a/iris/routes/api/graphql.js
+++ b/iris/routes/api/graphql.js
@@ -1,6 +1,5 @@
 // @flow
 import { graphqlExpress } from 'graphql-server-express';
-import Raven from 'raven';
 import OpticsAgent from 'optics-agent';
 import createLoaders from '../../loaders/';
 

--- a/iris/routes/middlewares/index.js
+++ b/iris/routes/middlewares/index.js
@@ -3,9 +3,11 @@ import { Router } from 'express';
 
 const middlewares = Router();
 
-// Raven (Sentry client) needs to come before everything else
-import raven from './raven';
-middlewares.use(raven);
+if (process.env.NODE_ENV === 'production') {
+  // Raven (Sentry client) needs to come before everything else
+  const raven = require('./raven');
+  middlewares.use(raven);
+}
 
 // Apollo Optics middleware
 import OpticsAgent from 'optics-agent';

--- a/iris/utils/create-graphql-error-formatter.js
+++ b/iris/utils/create-graphql-error-formatter.js
@@ -3,20 +3,19 @@ import Raven from 'raven';
 import { IsUserError } from './UserError';
 
 const createGraphQLErrorFormatter = req => error => {
-  console.log(error);
-  const sentryId = Raven.captureException(
-    error,
-    Raven.parsers.parseRequest(req)
-  );
   const isUserError = error.originalError
     ? error.originalError[IsUserError]
     : false;
+  let sentryId = 'ID only generated in production';
+  if (!isUserError && process.env.NODE_ENV === 'production') {
+    sentryId = Raven.captureException(error, Raven.parsers.parseRequest(req));
+  }
+  console.log(error);
   return {
     message: isUserError ? error.message : `Internal server error: ${sentryId}`,
     // Hide the stack trace in production mode
-    stack: !process.env.NODE_ENV === 'production'
-      ? error.stack.split('\n')
-      : null,
+    stack:
+      !process.env.NODE_ENV === 'production' ? error.stack.split('\n') : null,
   };
 };
 


### PR DESCRIPTION
We got lots of errors on Sentry that happened in development. Eventhough we set the environment Sentry still sends emails for them etc. so we just shouldn't report errors in development to Sentry!