### PR TITLE
Optimize getting channel by slug query

### DIFF
--- a/iris/models/channel.js
+++ b/iris/models/channel.js
@@ -91,16 +91,13 @@ const getChannelBySlug = (
 ): Promise<Object> => {
   return db
     .table('channels')
+    .filter(channel =>
+      channel('slug')
+        .eq(channelSlug)
+        .and(db.not(channel.hasFields('deletedAt')))
+    )
     .eqJoin('communityId', db.table('communities'))
-    .filter({
-      left: {
-        slug: channelSlug,
-      },
-      right: {
-        slug: communitySlug,
-      },
-    })
-    .filter(channel => db.not(channel.hasFields('deletedAt')))
+    .filter({ right: { slug: communitySlug } })
     .run()
     .then(result => {
       if (result && result[0]) {


### PR DESCRIPTION
Rather than loading all the channels, joining them with all their communities and then filtering by the two slugs we filter the channels first by their slugs to only get all channels with a certain slug and then join them and filter them by their community slug.

This makes a 10x improvement in db query speed anytime you visit a channel page I think. I hope this works the same way, here's a deploy:  https://spectrum-fxourxqzib.now.sh