### PR TITLE
Make notifications fast

### DIFF
--- a/iris/models/usersNotifications.js
+++ b/iris/models/usersNotifications.js
@@ -106,7 +106,10 @@ export const markAllNotificationsSeen = (userId: string): Promise<Object> => {
           .map(notification => notification.id)
       )
     )
-    .then(() => getNotificationsByUser(userId));
+    .then(() => true)
+    .catch(err => {
+      return false;
+    });
 };
 
 // marks all notifications for a user as read
@@ -148,7 +151,10 @@ export const markDirectMessageNotificationsSeen = (
           .map(notification => notification.id)
       )
     )
-    .then(() => getNotificationsByUser(userId));
+    .then(() => true)
+    .catch(err => {
+      return false;
+    });
 };
 
 /*

--- a/iris/types/Notification.js
+++ b/iris/types/Notification.js
@@ -57,9 +57,9 @@ const Notification = /* GraphQL */ `
 	}
 
 	extend type Mutation {
-		markAllNotificationsSeen: [ Notification ]
+		markAllNotificationsSeen: Boolean
 		markAllNotificationsRead: [ Notification ]
-		markDirectMessageNotificationsSeen: [ Notification ]
+		markDirectMessageNotificationsSeen: Boolean
 		markSingleNotificationSeen(id: ID!): Notification
 		toggleNotificationReadState(notificationId: ID!): Notification!
 	}

--- a/src/api/notification.js
+++ b/src/api/notification.js
@@ -1,9 +1,7 @@
 // @flow
 // $FlowFixMe
 import { graphql, gql } from 'react-apollo';
-import {
-  notificationInfoFragment,
-} from './fragments/notification/notificationInfo';
+import { notificationInfoFragment } from './fragments/notification/notificationInfo';
 import { subscribeToNewNotifications } from './subscriptions';
 
 const LoadMoreNotifications = gql`
@@ -175,11 +173,8 @@ export const markNotificationsReadMutation = graphql(
 
 export const MARK_NOTIFICATIONS_SEEN_MUTATION = gql`
   mutation markAllNotificationsSeen {
-    markAllNotificationsSeen {
-      ...notificationInfo
-    }
+    markAllNotificationsSeen
   }
-  ${notificationInfoFragment}
 `;
 
 export const MARK_NOTIFICATIONS_SEEN_OPTIONS = {
@@ -195,11 +190,8 @@ export const markNotificationsSeenMutation = graphql(
 
 export const MARK_DM_NOTIFICATIONS_SEEN_MUTATION = gql`
   mutation markDirectMessageNotificationsSeen {
-    markDirectMessageNotificationsSeen {
-      ...notificationInfo
-    }
+    markDirectMessageNotificationsSeen
   }
-  ${notificationInfoFragment}
 `;
 
 export const MARK_DM_NOTIFICATIONS_SEEN_OPTIONS = {


### PR DESCRIPTION
Spent a bit of time investigating seen mutations because holy shit

![mutations](https://user-images.githubusercontent.com/7525670/28251788-ea5731a0-6a39-11e7-80c5-ce8d4b88e79b.PNG)

The two mark notifications as seen mutations are (average) our slowest mutations by a long margin. This is due to these two things we did but I've now removed:

- Filter for unseen notifications rather than updating all of them
- Don't return notifications from the `markNotificationsSeen` mutations, it's unnecessary

**This depends on #1194 where I implemented optimistic client-side updates for marking notifications seen, if we ship this as-is users will have the bubble stay there until they refresh**