### PR TITLE
Fix channel deletion logic

### DIFF
--- a/iris/models/thread.js
+++ b/iris/models/thread.js
@@ -20,6 +20,15 @@ export const getThreads = (
     .run();
 };
 
+// this is used to get all threads that need to be marked as deleted whenever a channel is deleted
+export const getThreadsByChannelToDelete = channelId => {
+  return db
+    .table('threads')
+    .getAll(channelId, { index: 'channelId' })
+    .filter(thread => db.not(thread.hasFields('deletedAt')))
+    .run();
+};
+
 export const getThreadsByChannel = (
   channelId: string,
   { first, after }

--- a/iris/mutations/channel.js
+++ b/iris/mutations/channel.js
@@ -36,7 +36,7 @@ import type {
   CreateChannelArguments,
   EditChannelArguments,
 } from '../models/channel';
-import { getThreadsByChannel, deleteThread } from '../models/thread';
+import { getThreadsByChannelToDelete, deleteThread } from '../models/thread';
 
 type Context = {
   user: Object,
@@ -170,7 +170,9 @@ module.exports = {
               // delete the channel requested from the client side user
               const deleteTheInputChannel = deleteChannel(channelId);
               // get all the threads in the channel to prepare for deletion
-              const getAllThreadsInChannel = getThreadsByChannel(channelId);
+              const getAllThreadsInChannel = getThreadsByChannelToDelete(
+                channelId
+              );
               // update all the UsersChannels objects in the db to be non-members
               const removeRelationships = removeMembersInChannel(channelId);
 


### PR DESCRIPTION
cc @mxstbr - when we switched the old query over to pagination, it broke deleting a channel (which deletes all threads within that channel).

No big deal, but something that we need to double check for :)