### PR TITLE
Fix downgrade flow

### DIFF
--- a/src/components/modals/UpgradeModal/index.js
+++ b/src/components/modals/UpgradeModal/index.js
@@ -121,12 +121,7 @@ class UpgradeModal extends React.Component {
   render() {
     const { user } = this.props;
     const { upgradeError, isOpen, isLoading } = this.state;
-    const emailProps = {
-      emailAddress: 'help@spectrum.chat',
-      subject: 'Cancel my Pro plan on Spectrum',
-      body: `Hi there, please cancel my Pro plan on Spectrum for ${user.id}`,
-    };
-    const email = `mailto:${emailProps.emailAddress}?subject=${emailProps.subject}&body=${emailProps.body}`;
+
     return (
       <Modal
         isOpen={isOpen}
@@ -153,16 +148,14 @@ class UpgradeModal extends React.Component {
                 subscription instantly below. Thanks for your support!
               </Subheading>
 
-              <Notice>
-                Note: We're currently moving Stripe accounts - cancel your
-                subscription below and we will get you taken care of!
-              </Notice>
               <SectionActions centered={true}>
-                <a href={email}>
-                  <OutlineButton disabled={isLoading} loading={isLoading}>
-                    Cancel my Pro Subscription
-                  </OutlineButton>
-                </a>
+                <OutlineButton
+                  disabled={isLoading}
+                  loading={isLoading}
+                  onClick={this.downgradeFromPro}
+                >
+                  Cancel my Pro Subscription
+                </OutlineButton>
 
                 <Button
                   onClick={() => (window.location.href = '/spectrum/support')}


### PR DESCRIPTION
Okay @mxstbr @uberbryn here's what I've done:

1. Migrated all old customers from SPECFM -> SPECTRUM Stripe account
2. For each *new* customer on SPECTRUM Stripe account, create a Subscription that is on a *trial period that will end when their previous subscription was supposed to charge them again*
3. Delete all old subscriptions on SPECFM Stripe account
4. Fix the Pro downgrade flow to do the following:

Since we no longer have the proper `subscriptionId` through the migration, we have to first look up the customer id on Stripe and return their subscriptions. Using that return, we can pass the subscription id to Stripe to cancel the sub.

Note - this means that subscription IDs in the database are out of sync, but it doesn't matter because we no longer use them. We're just storing all the Stripe data *just in case* - although really we only need to ever store the customer id and subscription status. Anyways, that's for another time.

Note: @mxstbr - we *can't* merge this until we run the `thread notification emails migration` - otherwise it will crash the user's settings page.