### PR TITLE
Enable query batching and deduplication on the client

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -6,7 +6,7 @@ import {
   toIdValue,
 } from 'react-apollo';
 // $FlowFixMe
-import { createNetworkInterface } from 'apollo-upload-client';
+import { createBatchingNetworkInterface } from 'apollo-upload-client';
 // $FlowFixMe
 import {
   SubscriptionClient,
@@ -24,8 +24,9 @@ const wsClient = new SubscriptionClient(
 
 // In production the API is at the same URL, in development it's at a different port
 const API_URI = IS_PROD ? '/api' : 'http://localhost:3001/api';
-const networkInterface = createNetworkInterface({
+const networkInterface = createBatchingNetworkInterface({
   uri: API_URI,
+  batchInterval: 10,
   opts: {
     credentials: 'include',
   },
@@ -43,6 +44,7 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
 export const client = new ApolloClient({
   networkInterface: networkInterfaceWithSubscriptions,
   fragmentMatcher,
+  queryDeduplication: true,
   dataIdFromObject: result => {
     if (result.__typename) {
       // Custom Community cache key based on slug


### PR DESCRIPTION
Found this by chance while digging through the Apollo Client docs. This change means that we batch multiple queries happening in a short amount of time into a single request, rather than sending 10 requests. Together with query de-duplication this decreases network activity quite heavily.

This is what the network waterfall looks like when loading my homepage on `spectrum.chat` right now:

![9 individual network requests to spectrum.chat/api](https://user-images.githubusercontent.com/7525670/28959007-ee539a8c-78f8-11e7-9a21-c3dc29b96936.PNG)

This is what it looks like on the new deploy, `https://spectrum-tjaemehlbe.now.sh/`:

![2 individual network requests to spectrum.chat/api](https://user-images.githubusercontent.com/7525670/28959017-f7b84c58-78f8-11e7-8038-3021b112276a.PNG)

So yeah, that's pretty cool!

Docs: http://dev.apollodata.com/core/network.html#query-batching