### PR TITLE
Remove participants from thread querying

### DIFF
--- a/iris/models/usersThreads.js
+++ b/iris/models/usersThreads.js
@@ -49,21 +49,6 @@ export const createNotifiedUserInThread = (
   });
 };
 
-export const getParticipantsInThread = (
-  threadId: string
-): Promise<Array<Object>> => {
-  return db
-    .table('usersThreads')
-    .getAll(threadId, { index: 'threadId' })
-    .filter({ isParticipant: true })
-    .eqJoin('userId', db.table('users'))
-    .without({
-      left: ['createdAt', 'id', 'threadId', 'userId'],
-    })
-    .zip()
-    .run();
-};
-
 export const getThreadNotificationStatusForUser = (
   threadId: string,
   userId: string

--- a/iris/queries/thread.js
+++ b/iris/queries/thread.js
@@ -6,10 +6,7 @@ const {
 } = require('../models/community');
 const { getUsers } = require('../models/user');
 import { getUserPermissionsInChannel } from '../models/usersChannels';
-import {
-  getParticipantsInThread,
-  getThreadNotificationStatusForUser,
-} from '../models/usersThreads';
+import { getThreadNotificationStatusForUser } from '../models/usersThreads';
 const { getMessages, getMessageCount } = require('../models/message');
 import paginate from '../utils/paginate-arrays';
 import type { PaginationOptions } from '../utils/paginate-arrays';
@@ -70,9 +67,6 @@ module.exports = {
       _: any,
       { loaders }: GraphQLContext
     ) => loaders.community.load(communityId),
-    participants: ({ id, creatorId }, _, { loaders }) => {
-      return getParticipantsInThread(id);
-    },
     isCreator: (
       { creatorId }: { creatorId: String },
       _: any,

--- a/iris/types/Thread.js
+++ b/iris/types/Thread.js
@@ -43,7 +43,6 @@ const Thread = /* GraphQL */ `
 		receiveNotifications: Boolean
 		type: ThreadType
 		edits: [Edit!]
-		participants: [User]
 		messageConnection(first: Int, after: String): ThreadMessagesConnection!
 		messageCount: Int
 		creator: User!

--- a/src/api/fragments/thread/threadInfo.js
+++ b/src/api/fragments/thread/threadInfo.js
@@ -32,9 +32,6 @@ export const threadInfoFragment = gql`
     isLocked
     isCreator
 		type
-    participants {
-      ...userInfo
-    }
     content {
       title
       body

--- a/src/components/threadFeedCard/formattedThreadLocation.js
+++ b/src/components/threadFeedCard/formattedThreadLocation.js
@@ -28,16 +28,6 @@ const FormattedThreadLocation = props => {
     props.viewContext === 'community' ||
     props.viewContext === 'channel';
 
-  const needsParticipantDetails =
-    props.viewContext === 'dashboard' ||
-    props.viewContext === 'profile' ||
-    props.viewContext === 'community' ||
-    props.viewContext === 'channel';
-
-  // const participantList = props.data.participants.filter(
-  //   participant => participant.id !== props.data.creator.id
-  // );
-
   return (
     <ThreadContext>
       {needsCommunityDetails &&
@@ -77,7 +67,7 @@ const FormattedThreadLocation = props => {
                 {props.data.channel.name}
               </Link>}
           </Location>}
-        {(needsAuthorDetails || needsParticipantDetails) &&
+        {needsAuthorDetails &&
           <FlexRow>
             {needsAuthorDetails &&
               <FlexRow>

--- a/src/components/threadFeedCard/style.js
+++ b/src/components/threadFeedCard/style.js
@@ -124,15 +124,6 @@ export const MetaNew = styled(Meta)`
   color: ${({ theme }) => theme.success.default};
 `;
 
-export const ParticipantCount = styled.span`
-  margin-left: 4px;
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1;
-  vertical-align: middle;
-  color: ${({ theme }) => theme.text.alt};
-`;
-
 export const Location = styled.span`
   display: inline-block;
   flex: 0 0 auto;

--- a/src/views/thread/components/messages.js
+++ b/src/views/thread/components/messages.js
@@ -49,13 +49,8 @@ class MessagesWithData extends Component {
   }
 
   componentDidMount() {
-    const { currentUser, participants } = this.props;
+    const { currentUser } = this.props;
     if (!currentUser || !currentUser.id) return;
-
-    const isParticipant = participants.some(user => user === currentUser.id);
-    if (isParticipant) {
-      this.props.forceScrollToBottom();
-    }
     this.subscribe();
   }
 

--- a/src/views/thread/containers/index.js
+++ b/src/views/thread/containers/index.js
@@ -158,20 +158,6 @@ class ThreadContainerPure extends Component {
         },
       });
 
-      // create an array of participant Ids and the creator Id
-      // which gets passed into the <Messages> component - if the current
-      // user is a participant or the thread creator, we will trigger
-      // a forceScrollToBottom on mount
-      const participantIds =
-        thread.participants && thread.participants.map(user => user.id);
-      // add checks to make sure that participantIds has ids in it. if there
-      // are no participants yet, only pass the creator id to the forceScrollToBottom
-      // method
-      const participantsAndCreator =
-        participantIds.length > 0
-          ? [...participantIds, thread.creator.id]
-          : [thread.creator.id];
-
       return (
         <View slider={this.props.slider}>
           <Head title={title} description={description} />
@@ -194,7 +180,6 @@ class ThreadContainerPure extends Component {
               <Messages
                 threadType={thread.threadType}
                 id={thread.id}
-                participants={participantsAndCreator}
                 currentUser={loggedInUser}
                 forceScrollToBottom={this.forceScrollToBottom}
                 contextualScrollToBottom={this.contextualScrollToBottom}


### PR DESCRIPTION
We can make threads a bit faster to load now since we're not rendering the participants facepile on the cards. This means we can avoid the extra call to the database.