### PR TITLE
Fix web push subscriptions

### DIFF
--- a/src/api/web-push-subscriptions.js
+++ b/src/api/web-push-subscriptions.js
@@ -12,7 +12,13 @@ const SUBSCRIBE_TO_WEB_PUSH_OPTIONS = {
     subscribeToWebPush: subscription =>
       mutate({
         variables: {
-          subscription,
+          subscription: {
+            endpoint: subscription.endpoint,
+            keys: {
+              p256dh: subscription.getKey('p256dh'),
+              auth: subscription.getKey('auth'),
+            },
+          },
         },
       }),
   }),

--- a/src/helpers/web-push-manager.js
+++ b/src/helpers/web-push-manager.js
@@ -34,7 +34,7 @@ class WebPushManager {
   subscribe = () => {
     if (!this.manager) {
       this.subscriptionAttempt = true;
-      return Promise.resolve({});
+      return Promise.reject('Please try again.');
     }
     return this.manager.subscribe({
       userVisibleOnly: true,

--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -20,7 +20,7 @@ const IS_PROD = process.env.NODE_ENV === 'production';
 
 const swUrl = IS_PROD
   ? `${process.env.PUBLIC_URL}/service-worker.js`
-  : `${process.env.PUBLIC_URL}/push-sw.js`;
+  : `${process.env.PUBLIC_URL}/push-sw-v1.js`;
 
 export default function register(): Promise<ServiceWorkerResult> {
   if ('serviceWorker' in navigator) {

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -131,6 +131,7 @@ class NotificationsPure extends Component {
       })
       .catch(err => {
         track('browser push notifications', 'blocked');
+        console.log('err', err);
         this.setState({
           webPushPromptLoading: false,
         });

--- a/src/views/userSettings/components/notificationSettings.js
+++ b/src/views/userSettings/components/notificationSettings.js
@@ -53,6 +53,7 @@ class NotificationSettings extends Component {
       })
       .catch(err => {
         track('browser push notifications', 'blocked');
+        console.log('err', err);
         return this.props.dispatch(
           addToastWithTimeout(
             'error',


### PR DESCRIPTION
In some recent version of Chrome it added a field to the `subscriptions` object we get back when subscribing users to push notifications called `expirationTime`. Our GraphQL API wasn't set up to handle that field (duh) and thusly threw an error constantly.

It also turns out our setup locally was broken, so I fixed that while I was at it.

Closes #1329 
