### PR TITLE
Fix async/await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,23 @@
 {
-  "presets": ["backpack-core/babel", ["env", {
-    "targets": {
-      "node": "current"
-    }
-  }]],
-  "plugins": ["transform-flow-strip-types", "transform-object-rest-spread", "babel-plugin-transform-react-jsx", "syntax-dynamic-import"]
+  "presets": [
+    [
+      "env",
+      {
+        "targets": {
+          "node": "current"
+        },
+        "useBuiltIns": true,
+        "exclude": [
+          "babel-plugin-transform-regenerator",
+          "transform-async-to-generator"
+        ]
+      }
+    ]
+  ],
+  "plugins": [
+    "transform-flow-strip-types",
+    "transform-object-rest-spread",
+    "babel-plugin-transform-react-jsx",
+    "syntax-dynamic-import"
+  ]
 }


### PR DESCRIPTION
The Babel preset we were using from `backpack` ([this
one](https://github.com/jaredpalmer/backpack/blob/master/packages/babel-preset-backpack/index.js)) includes a couple of presets/plugins that will transpile async/await to generators and then require a generator polyfill library-except we don't have that polyfill library in our dependencies.

Since Node 8 one doesn't need to transpile async/await to generators, so
I've removed that preset and edited our babel configuration to the
minimal subset of it that'll work for now.

Replaces #1428 