### PR TITLE
Fallback for fb signing without an email

### DIFF
--- a/iris/authentication.js
+++ b/iris/authentication.js
@@ -135,7 +135,9 @@ const init = () => {
           description: profile.about ? profile.about : '',
           website: profile.website ? profile.website : '',
           email:
-            profile.emails.length > 0 && profile.emails[0].value !== undefined
+            profile.emails &&
+            profile.emails.length > 0 &&
+            profile.emails[0].value !== undefined
               ? profile.emails[0].value
               : null,
           profilePhoto:


### PR DESCRIPTION
This was failing because there was no `profile.email` field if the user opted out of email. Properly checking for this allows for signups - future PR to add an email + change email