### PR TITLE
Hotfix DMs

### DIFF
--- a/iris/queries/message.js
+++ b/iris/queries/message.js
@@ -32,7 +32,11 @@ module.exports = {
 
       // there will be no community to resolve in direct message threads, so we can escape early
       // and only return the sender
-      if (threadType === 'directMessageThread') return sender;
+      if (
+        threadType === 'directMessageThread' ||
+        threadType === 'DIRECT_MESSAGE_GROUP'
+      )
+        return sender;
 
       const { communityId } = await getThread(threadId);
       const {


### PR DESCRIPTION
We have 1,237 messages that have an outdated data model:

```js
r.db('spectrum')
  .table('messages')
  .filter({threadType: 'DIRECT_MESSAGE_GROUP'})
  .count()
```

This was breaking direct message threads that were started pre-rethink migration. Very bad, only because I don't exactly know how to discover what other data models are out of sync.

This is a temporary fix that I've aliased ahead of this PR in order to fix those dm threads.