### PR TITLE
Speed up user community permission query

### DIFF
--- a/iris/migrations/20170926102527-speedy-gonzales.js
+++ b/iris/migrations/20170926102527-speedy-gonzales.js
@@ -1,0 +1,17 @@
+'use strict';
+
+exports.up = function(r, connection) {
+  return Promise.all([
+    r
+      .db('spectrum')
+      .table('usersCommunities')
+      .indexCreate('userIdAndCommunityId', [
+        r.row('userId'),
+        r.row('communityId'),
+      ]),
+  ]);
+};
+
+exports.down = function(r, connection) {
+  return Promise.resolve();
+};

--- a/iris/models/usersCommunities.js
+++ b/iris/models/usersCommunities.js
@@ -312,8 +312,11 @@ const getUserPermissionsInCommunity = (
 ): Promise<Object> => {
   return db
     .table('usersCommunities')
-    .getAll(communityId, { index: 'communityId' })
-    .filter({ userId })
+    .between([userId, communityId], [userId, communityId], {
+      index: 'userIdAndCommunityId',
+      rightBound: 'closed',
+      leftBound: 'closed',
+    })
     .run()
     .then(data => {
       // if a record exists


### PR DESCRIPTION
Looking at our Apollo Optics data, some of the standout slow parts of our queries are:

- `message.sender`, avg. duration 724ms
- `thread.creator`, avg. duration 557ms

![screen shot 2017-09-26 at 12 27 48 pm](https://user-images.githubusercontent.com/7525670/30856028-548c43f2-a2b7-11e7-84cf-2fe4f1f9edef.png)

![screen shot 2017-09-26 at 12 24 44 pm](https://user-images.githubusercontent.com/7525670/30856037-57d1fe4e-a2b7-11e7-87df-3411863ccbd0.png)

At first glance, it seems like those should be fast. `message.sender` is an id, so just do a `getUser(id)` and done, why does that take 724ms?! The same thing for `thread.creator`, why does that take 557ms?!

Looking at the resolvers, much become clear. Due to the complexity in our setup we have to check permissions before returning anything to the client.

In the case of `message.sender` this means two additional db queries:

1. Load `message.thread` to get the `message.thread.communityId`
2. Check the users permission in `message.thread.communityId`

In the case of `thread.creator`, this means one additional query to get the permission in `thread.community`.

Looking at the first case, getting `message.thread` is (again) only a `getThread(threadId)`, so a very quick query on the primary key.

**This leads me to believe that our `getUserPermissionInCommunity` query is part of the problem for our slow loading for signed in users.**

This change fixes the performance issue by introducing a new index on `usersCommunities`: `userIdAndCommunityId`. By leveraging a `.between` query in our `getUserPermissionInCommunity` we significantly speed up the query, especially in large communities, as we avoid a `.filter` through all `usersCommunities` records in a community.

This is what the query profiler looked like before: (this is in production, getting my permissions for the Spectrum community)

![screen shot 2017-09-26 at 3 04 10 pm](https://user-images.githubusercontent.com/7525670/30861818-3b636f30-a2cc-11e7-8c48-33a0277e28ef.png)

This is what it looked like after:

![screen shot 2017-09-26 at 3 05 16 pm](https://user-images.githubusercontent.com/7525670/30861823-3f9717b4-a2cc-11e7-843c-c7ad23a7d819.png)

Note that I expect the impact of this change to scale based on community size, the more members a community has the slower the previous query would be. Now, it'll always stay fast.

This requires a migration to be run after merging.