### PR TITLE
Remove all recompose/pure usage

### DIFF
--- a/src/components/appViewWrapper/index.js
+++ b/src/components/appViewWrapper/index.js
@@ -1,19 +1,16 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import { withRouter } from 'react-router';
 import { Wrapper } from './style';
 
-const AppViewWrapperPure = (props: Object): React$Element<any> =>
+const AppViewWrapperPure = (props: Object): React$Element<any> => (
   // Note(@mxstbr): This ID is needed to make infinite scrolling work
   // DO NOT REMOVE IT
-  <Wrapper id="scroller-for-thread-feed">
-    {props.children}
-  </Wrapper>;
+  <Wrapper id="scroller-for-thread-feed">{props.children}</Wrapper>
+);
 
-const AppViewWrapper = compose(withRouter, pure)(AppViewWrapperPure);
+const AppViewWrapper = compose(withRouter)(AppViewWrapperPure);
 export default AppViewWrapper;

--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -1,7 +1,5 @@
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import styled from 'styled-components';
@@ -108,6 +106,6 @@ const AvatarPure = (props: Object): React$Element<any> => {
   }
 };
 
-const Avatar = compose(pure)(AvatarPure);
+const Avatar = compose()(AvatarPure);
 
 export default Avatar;

--- a/src/components/badges/index.js
+++ b/src/components/badges/index.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import styled from 'styled-components';
@@ -78,4 +76,4 @@ class Badge extends Component {
 const map = state => ({
   currentUser: state.users.currentUser,
 });
-export default compose(connect(map), pure)(Badge);
+export default compose(connect(map))(Badge);

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import styled from 'styled-components';
@@ -26,21 +24,20 @@ const StyledCard = styled(FlexCol)`
   + span {
     margin-top: 16px;
 
-    @media(max-width: 768px) {
+    @media (max-width: 768px) {
       margin-top: 2px;
     }
   }
 
-  @media(max-width: 768px) {
+  @media (max-width: 768px) {
     border-radius: 0;
     box-shadow: none;
   }
 `;
 
-const CardPure = (props: Object): React$Element<any> =>
-  <StyledCard {...props}>
-    {props.children}
-  </StyledCard>;
+const CardPure = (props: Object): React$Element<any> => (
+  <StyledCard {...props}>{props.children}</StyledCard>
+);
 
-export const Card = compose(pure)(CardPure);
+export const Card = compose()(CardPure);
 export default Card;

--- a/src/components/channelMembers/index.js
+++ b/src/components/channelMembers/index.js
@@ -2,8 +2,6 @@
 import React, { Component } from 'react';
 import { UserListItem } from '../listItems';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 import { LoadingCard } from '../loading';
 import { getChannelMembersQuery } from '../../api/channel';
@@ -86,6 +84,6 @@ class ChannelMembers extends Component<Props> {
   }
 }
 
-export default compose(getChannelMembersQuery, viewNetworkHandler, pure)(
+export default compose(getChannelMembersQuery, viewNetworkHandler)(
   ChannelMembers
 );

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import withState from 'recompose/withState';
 // $FlowFixMe
 import withHandlers from 'recompose/withHandlers';
@@ -270,8 +268,7 @@ const ChatInput = compose(
     onChange: ({ changeState }) => state => changeState(state),
     clear: ({ changeState }) => () => changeState(fromPlainText('')),
   }),
-  connect(map),
-  pure
+  connect(map)
 )(ChatInputWithMutation);
 
 export default ChatInput;

--- a/src/components/column/index.js
+++ b/src/components/column/index.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import styled from 'styled-components';
 import { FlexCol } from '../globals';
 
@@ -52,7 +50,7 @@ const OnlyColumn = styled(PrimaryColumn)`
   }
 `;
 
-const ColumnPure = (props: Object): React$Element<any> => {
+export const Column = (props: Object): React$Element<any> => {
   if (props.type === 'primary') {
     return <PrimaryColumn {...props}>{props.children}</PrimaryColumn>;
   } else if (props.type === 'secondary') {
@@ -64,5 +62,4 @@ const ColumnPure = (props: Object): React$Element<any> => {
   }
 };
 
-export const Column = pure(ColumnPure);
 export default Column;

--- a/src/components/composer/index.js
+++ b/src/components/composer/index.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import Textarea from 'react-textarea-autosize';
 // $FlowFixMe
 import { withRouter } from 'react-router';
@@ -641,8 +639,7 @@ class ComposerWithData extends Component {
 export const ThreadComposer = compose(
   getComposerCommunitiesAndChannels, // query to get data
   publishThread, // mutation to publish a thread
-  withRouter, // needed to use history.push() as a post-publish action
-  pure
+  withRouter // needed to use history.push() as a post-publish action
 )(ComposerWithData);
 
 const mapStateToProps = state => ({

--- a/src/components/curation/index.js
+++ b/src/components/curation/index.js
@@ -2,8 +2,6 @@ import React from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import { connect } from 'react-redux';
 //$FlowFixMe
 import { Link } from 'react-router-dom';
@@ -125,6 +123,5 @@ const mapStateToProps = state => ({ currentUser: state.users.currentUser });
 
 export const FeaturedCommunity = compose(
   toggleCommunityMembershipMutation,
-  connect(mapStateToProps),
-  pure
+  connect(mapStateToProps)
 )(FeaturedCommunityWithData);

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import styled from 'styled-components';
@@ -37,5 +35,5 @@ const DropdownPure = (props: Object): React$Element<any> => (
   </StyledDropdown>
 );
 
-export const Dropdown = compose(pure)(DropdownPure);
+export const Dropdown = compose()(DropdownPure);
 export default Dropdown;

--- a/src/components/editForm/channel.js
+++ b/src/components/editForm/channel.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
 import { withRouter } from 'react-router';
@@ -275,10 +273,7 @@ class ChannelWithData extends Component {
   }
 }
 
-const Channel = compose(
-  deleteChannelMutation,
-  editChannelMutation,
-  withRouter,
-  pure
-)(ChannelWithData);
+const Channel = compose(deleteChannelMutation, editChannelMutation, withRouter)(
+  ChannelWithData
+);
 export default connect()(Channel);

--- a/src/components/editForm/index.js
+++ b/src/components/editForm/index.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 import User from './user';
 import Channel from './channel';
@@ -24,7 +22,7 @@ type FormProps = {
   data?: Object,
 };
 
-export const EditForm = compose(pure)(EditFormPure);
+export const EditForm = compose()(EditFormPure);
 export const UserEditForm = (props: FormProps) => (
   <EditForm type="user" {...props} />
 );

--- a/src/components/editForm/user.js
+++ b/src/components/editForm/user.js
@@ -6,8 +6,6 @@ import slugg from 'slugg';
 // $FlowFixMe
 import { withApollo } from 'react-apollo';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
 import { connect } from 'react-redux';
@@ -493,7 +491,6 @@ const UserSettings = compose(
   editUserMutation,
   withRouter,
   withApollo,
-  connect(map),
-  pure
+  connect(map)
 )(UserWithData);
 export default UserSettings;

--- a/src/components/flyout/index.js
+++ b/src/components/flyout/index.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import styled from 'styled-components';
@@ -27,11 +25,10 @@ const StyledRow = styled(FlexRow)`
   top: -8px;
 `;
 
-const FlyoutPure = (props: Object): React$Element<any> => (
+const Flyout = (props: Object): React$Element<any> => (
   <StyledFlyout className={'flyout'} {...props}>
     <StyledRow>{props.children}</StyledRow>
   </StyledFlyout>
 );
 
-export const Flyout = compose(pure)(FlyoutPure);
 export default Flyout;

--- a/src/components/gallery/index.js
+++ b/src/components/gallery/index.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 // $FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 import { getMediaMessagesForThread } from '../../api/message';
 import { displayLoadingGallery } from '../../components/loading';
@@ -37,4 +35,4 @@ const mapStateToProps = state => ({
   isOpen: state.gallery.isOpen,
 });
 
-export default compose(connect(mapStateToProps), pure)(Gallery);
+export default compose(connect(mapStateToProps))(Gallery);

--- a/src/components/listItems/index.js
+++ b/src/components/listItems/index.js
@@ -5,8 +5,6 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 // $FlowFixMe
 import compose from 'recompose/compose';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import Icon from '../icons';
 import Badge from '../badges';
 import Avatar from '../avatar';
@@ -250,4 +248,4 @@ class InvoiceListItemPure extends React.Component {
   }
 }
 
-export const InvoiceListItem = compose(pure, connect())(InvoiceListItemPure);
+export const InvoiceListItem = compose(connect())(InvoiceListItemPure);

--- a/src/components/profile/channel.js
+++ b/src/components/profile/channel.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import { Link } from 'react-router-dom';
 //$FlowFixMe
 import { connect } from 'react-redux';
@@ -266,9 +264,7 @@ class ChannelWithData extends Component {
   }
 }
 
-const Channel = compose(toggleChannelSubscriptionMutation, pure)(
-  ChannelWithData
-);
+const Channel = compose(toggleChannelSubscriptionMutation)(ChannelWithData);
 
 const mapStateToProps = state => ({
   currentUser: state.users.currentUser,

--- a/src/components/profile/community.js
+++ b/src/components/profile/community.js
@@ -5,8 +5,6 @@ import Card from '../card';
 //$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import { Link } from 'react-router-dom';
 //$FlowFixMe
 import { connect } from 'react-redux';
@@ -322,9 +320,7 @@ class CommunityWithData extends Component {
   }
 }
 
-const Community = compose(toggleCommunityMembershipMutation, pure)(
-  CommunityWithData
-);
+const Community = compose(toggleCommunityMembershipMutation)(CommunityWithData);
 
 const mapStateToProps = state => ({
   currentUser: state.users.currentUser,

--- a/src/components/profile/index.js
+++ b/src/components/profile/index.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 import User from './user';
 import Channel from './channel';
@@ -42,12 +40,16 @@ type ProfileProps = {
   <UserProfile /> and this file will handle the type declaration, which will
   then get passed to our switch statement above to return the right component.
 */
-export const Profile = compose(pure)(ProfilePure);
-export const UserProfile = (props: ProfileProps) =>
-  <Profile type="user" {...props} />;
-export const ChannelProfile = (props: ProfileProps) =>
-  <Profile type="channel" {...props} />;
-export const CommunityProfile = (props: ProfileProps) =>
-  <Profile type="community" {...props} />;
-export const ThreadProfile = (props: ProfileProps) =>
-  <Profile type="thread" {...props} />;
+export const Profile = compose()(ProfilePure);
+export const UserProfile = (props: ProfileProps) => (
+  <Profile type="user" {...props} />
+);
+export const ChannelProfile = (props: ProfileProps) => (
+  <Profile type="channel" {...props} />
+);
+export const CommunityProfile = (props: ProfileProps) => (
+  <Profile type="community" {...props} />
+);
+export const ThreadProfile = (props: ProfileProps) => (
+  <Profile type="thread" {...props} />
+);

--- a/src/components/profile/metaData.js
+++ b/src/components/profile/metaData.js
@@ -1,7 +1,5 @@
 //@flow
 import React from 'react';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import Icon from '../icons';
 import { Meta, MetaList, MetaListItem, Label, Count } from './style';
 
@@ -13,56 +11,58 @@ import { Meta, MetaList, MetaListItem, Label, Count } from './style';
 */
 const buildArray = (meta: Object): Array<any> => {
   // Apollo returns a __typename field in the data object; filter it out
-  return Object.keys(meta).filter(item => item !== '__typename').map(item => {
-    if (item === 'threads') {
-      return Object.assign(
-        {},
-        {
-          icon: 'post',
-          label: 'Threads',
-          count: meta[item],
-        }
-      );
-    }
+  return Object.keys(meta)
+    .filter(item => item !== '__typename')
+    .map(item => {
+      if (item === 'threads') {
+        return Object.assign(
+          {},
+          {
+            icon: 'post',
+            label: 'Threads',
+            count: meta[item],
+          }
+        );
+      }
 
-    if (item === 'channels') {
-      return Object.assign(
-        {},
-        {
-          icon: 'channel',
-          label: 'Channels',
-          count: meta[item],
-        }
-      );
-    }
+      if (item === 'channels') {
+        return Object.assign(
+          {},
+          {
+            icon: 'channel',
+            label: 'Channels',
+            count: meta[item],
+          }
+        );
+      }
 
-    if (item === 'subscribers') {
-      return Object.assign(
-        {},
-        {
-          icon: 'person',
-          label: 'Subscribers',
-          count: meta[item],
-        }
-      );
-    }
+      if (item === 'subscribers') {
+        return Object.assign(
+          {},
+          {
+            icon: 'person',
+            label: 'Subscribers',
+            count: meta[item],
+          }
+        );
+      }
 
-    if (item === 'members') {
-      return Object.assign(
-        {},
-        {
-          icon: 'person',
-          label: 'Members',
-          count: meta[item],
-        }
-      );
-    }
+      if (item === 'members') {
+        return Object.assign(
+          {},
+          {
+            icon: 'person',
+            label: 'Members',
+            count: meta[item],
+          }
+        );
+      }
 
-    return {};
-  });
+      return {};
+    });
 };
 
-const MetaDataPure = ({ data }) => {
+export const MetaData = ({ data }: any) => {
   const arr = buildArray(data);
 
   return (
@@ -83,5 +83,3 @@ const MetaDataPure = ({ data }) => {
     </Meta>
   );
 };
-
-export const MetaData = pure(MetaDataPure);

--- a/src/components/profile/thread.js
+++ b/src/components/profile/thread.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import { Link } from 'react-router-dom';
 //$FlowFixMe
 import { connect } from 'react-redux';
@@ -37,5 +35,5 @@ class ThreadWithData extends Component {
   }
 }
 
-const Thread = compose(pure, connect())(ThreadWithData);
+const Thread = compose(connect())(ThreadWithData);
 export default Thread;

--- a/src/components/profile/user.js
+++ b/src/components/profile/user.js
@@ -8,8 +8,6 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 import { addProtocolToString } from '../../helpers/utils';
 import { initNewThreadWithUser } from '../../actions/directMessageThreads';
 import { openModal } from '../../actions/modals';
@@ -294,7 +292,7 @@ const UserWithData = ({
   }
 };
 
-const User = compose(displayLoadingCard, withRouter, pure)(UserWithData);
+const User = compose(displayLoadingCard, withRouter)(UserWithData);
 const mapStateToProps = state => ({
   currentUser: state.users.currentUser,
   initNewThreadWithUser: state.directMessageThreads.initNewThreadWithUser,

--- a/src/components/threadComposer/index.js
+++ b/src/components/threadComposer/index.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import Textarea from 'react-textarea-autosize';
 // $FlowFixMe
 import { withRouter } from 'react-router';
@@ -686,8 +684,7 @@ export const ThreadComposer = compose(
   getComposerCommunitiesAndChannels, // query to get data
   publishThread, // mutation to publish a thread
   displayLoadingComposer, // handle loading state while query is fetching
-  withRouter, // needed to use history.push() as a post-publish action
-  pure
+  withRouter // needed to use history.push() as a post-publish action
 )(ThreadComposerWithData);
 
 const mapStateToProps = state => ({

--- a/src/components/threadFeed/index.js
+++ b/src/components/threadFeed/index.js
@@ -3,8 +3,6 @@ import React, { Component } from 'react';
 import styled from 'styled-components';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 // NOTE(@mxstbr): This is a custom fork published of off this (as of this writing) unmerged PR: https://github.com/CassetteRocks/react-infinite-scroller/pull/38
 // I literally took it, renamed the package.json and published to add support for scrollElement since our scrollable container is further outside
 import InfiniteList from 'react-infinite-scroller-with-scroll-element';
@@ -205,6 +203,6 @@ class ThreadFeedPure extends Component {
 const map = state => ({
   newActivityIndicator: state.newActivityIndicator.hasNew,
 });
-const ThreadFeed = compose(connect(map), pure)(ThreadFeedPure);
+const ThreadFeed = compose(connect(map))(ThreadFeedPure);
 
 export default ThreadFeed;

--- a/src/components/threadFeedCard/index.js
+++ b/src/components/threadFeedCard/index.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import { Link, withRouter } from 'react-router-dom';
@@ -94,5 +92,5 @@ const ThreadFeedCardPure = (props: Object): React$Element<any> => {
   );
 };
 
-const ThreadFeedCard = compose(pure, withRouter)(ThreadFeedCardPure);
+const ThreadFeedCard = compose(withRouter)(ThreadFeedCardPure);
 export default connect()(ThreadFeedCard);

--- a/src/components/upsell/joinChannel.js
+++ b/src/components/upsell/joinChannel.js
@@ -4,8 +4,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 // $FlowFixMe
 import compose from 'recompose/compose';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import { toggleChannelSubscriptionMutation } from '../../api/channel';
 import { addToastWithTimeout } from '../../actions/toasts';
 import { track } from '../../helpers/events';
@@ -101,6 +99,6 @@ class JoinChannel extends React.Component<Props, State> {
   }
 }
 
-export default compose(connect(), toggleChannelSubscriptionMutation, pure)(
+export default compose(connect(), toggleChannelSubscriptionMutation)(
   JoinChannel
 );

--- a/src/views/channel/components/notificationsToggle.js
+++ b/src/views/channel/components/notificationsToggle.js
@@ -1,8 +1,6 @@
 // @flow
 import * as React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import { connect } from 'react-redux';
@@ -92,7 +90,6 @@ class NotificationsTogglePure extends React.Component<Props, State> {
 
 export const NotificationsToggle = compose(
   toggleChannelNotificationsMutation,
-  connect(),
-  pure
+  connect()
 )(NotificationsTogglePure);
 export default NotificationsToggle;

--- a/src/views/channel/components/pendingUsersNotification.js
+++ b/src/views/channel/components/pendingUsersNotification.js
@@ -3,8 +3,6 @@ import React from 'react';
 // $FlowFixMe
 import { Link } from 'react-router-dom';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 import { displayLoadingCard } from '../../../components/loading';
 import { getPendingUsersQuery } from '../../../api/channel';
@@ -25,8 +23,7 @@ const PendingUsersNotificationPure = ({ data: { channel } }) => {
 
 export const PendingUsersNotification = compose(
   getPendingUsersQuery,
-  displayLoadingCard,
-  pure
+  displayLoadingCard
 )(PendingUsersNotificationPure);
 
 export default PendingUsersNotification;

--- a/src/views/channel/index.js
+++ b/src/views/channel/index.js
@@ -1,8 +1,6 @@
 import * as React from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 // $FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
@@ -256,6 +254,6 @@ const map = state => ({
   currentUser: state.users.currentUser,
 });
 
-export default compose(connect(map), getChannel, viewNetworkHandler, pure)(
+export default compose(connect(map), getChannel, viewNetworkHandler)(
   ChannelView
 );

--- a/src/views/channelSettings/components/blockedUsers.js
+++ b/src/views/channelSettings/components/blockedUsers.js
@@ -1,8 +1,6 @@
 //@flow
 import * as React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 import { UserListItem } from '../../../components/listItems';
 import { TextButton } from '../../../components/buttons';
@@ -78,6 +76,4 @@ class BlockedUsers extends React.Component<Props> {
   }
 }
 
-export default compose(getBlockedUsersQuery, displayLoadingCard, pure)(
-  BlockedUsers
-);
+export default compose(getBlockedUsersQuery, displayLoadingCard)(BlockedUsers);

--- a/src/views/channelSettings/components/pendingUsers.js
+++ b/src/views/channelSettings/components/pendingUsers.js
@@ -1,8 +1,6 @@
 //@flow
 import * as React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 import { UserListItem } from '../../../components/listItems';
 import { TextButton } from '../../../components/buttons';
@@ -80,6 +78,4 @@ class PendingUsers extends React.Component<Props> {
   }
 }
 
-export default compose(getPendingUsersQuery, displayLoadingCard, pure)(
-  PendingUsers
-);
+export default compose(getPendingUsersQuery, displayLoadingCard)(PendingUsers);

--- a/src/views/channelSettings/index.js
+++ b/src/views/channelSettings/index.js
@@ -2,8 +2,6 @@ import * as React from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import { connect } from 'react-redux';
 import { getThisChannel } from './queries';
 import { track } from '../../helpers/events';
@@ -216,6 +214,5 @@ export default compose(
   getThisChannel,
   togglePendingUserInChannelMutation,
   unblockUserInChannelMutation,
-  viewNetworkHandler,
-  pure
+  viewNetworkHandler
 )(CommunitySettings);

--- a/src/views/community/components/memberGrid.js
+++ b/src/views/community/components/memberGrid.js
@@ -2,8 +2,6 @@
 import * as React from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 import { getCommunityMembersQuery } from '../../../api/community';
 import Grid from '../../../components/grid';
 import { FlexCol } from '../../../components/globals';
@@ -75,6 +73,6 @@ class CommunityMemberGrid extends React.Component<Props> {
   }
 }
 
-export default compose(getCommunityMembersQuery, viewNetworkHandler, pure)(
+export default compose(getCommunityMembersQuery, viewNetworkHandler)(
   CommunityMemberGrid
 );

--- a/src/views/community/components/search.js
+++ b/src/views/community/components/search.js
@@ -1,8 +1,6 @@
 import * as React from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 import { throttle } from '../../../helpers/utils';
 import { searchCommunityThreadsQuery } from '../../../api/community';
 import ThreadFeed from '../../../components/threadFeed';
@@ -83,4 +81,4 @@ class Search extends React.Component<Props, State> {
   }
 }
 
-export default compose(pure)(Search);
+export default compose()(Search);

--- a/src/views/community/index.js
+++ b/src/views/community/index.js
@@ -1,8 +1,6 @@
 import * as React from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 // $FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
@@ -335,6 +333,5 @@ export default compose(
   connect(map),
   toggleCommunityMembershipMutation,
   getCommunity,
-  viewNetworkHandler,
-  pure
+  viewNetworkHandler
 )(CommunityView);

--- a/src/views/communityAnalytics/components/conversationGrowth.js
+++ b/src/views/communityAnalytics/components/conversationGrowth.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import pure from 'recompose/pure';
 import compose from 'recompose/compose';
 import viewNetworkHandler from '../../../components/viewNetworkHandler';
 import { Loading } from '../../../components/loading';
@@ -67,8 +66,6 @@ class ConversationGrowth extends React.Component<Props> {
   }
 }
 
-export default compose(
-  getCommunityConversationGrowth,
-  viewNetworkHandler,
-  pure
-)(ConversationGrowth);
+export default compose(getCommunityConversationGrowth, viewNetworkHandler)(
+  ConversationGrowth
+);

--- a/src/views/communityAnalytics/components/memberGrowth.js
+++ b/src/views/communityAnalytics/components/memberGrowth.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import pure from 'recompose/pure';
 import compose from 'recompose/compose';
 import viewNetworkHandler from '../../../components/viewNetworkHandler';
 import { Loading } from '../../../components/loading';
@@ -65,6 +64,6 @@ class MemberGrowth extends React.Component<Props> {
   }
 }
 
-export default compose(getCommunityMemberGrowth, viewNetworkHandler, pure)(
+export default compose(getCommunityMemberGrowth, viewNetworkHandler)(
   MemberGrowth
 );

--- a/src/views/communityAnalytics/components/topAndNewThreads.js
+++ b/src/views/communityAnalytics/components/topAndNewThreads.js
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import pure from 'recompose/pure';
 import compose from 'recompose/compose';
 import viewNetworkHandler from '../../../components/viewNetworkHandler';
 import { Loading } from '../../../components/loading';
@@ -100,6 +99,6 @@ class TopAndNewThreads extends React.Component<Props> {
   }
 }
 
-export default compose(getCommunityTopAndNewThreads, viewNetworkHandler, pure)(
+export default compose(getCommunityTopAndNewThreads, viewNetworkHandler)(
   TopAndNewThreads
 );

--- a/src/views/communityAnalytics/components/topMembers.js
+++ b/src/views/communityAnalytics/components/topMembers.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import pure from 'recompose/pure';
 import Icon from '../../../components/icons';
 import { initNewThreadWithUser } from '../../../actions/directMessageThreads';
 import compose from 'recompose/compose';
@@ -94,6 +93,5 @@ export default compose(
   connect(),
   withRouter,
   getCommunityTopMembers,
-  viewNetworkHandler,
-  pure
+  viewNetworkHandler
 )(ConversationGrowth);

--- a/src/views/communityAnalytics/index.js
+++ b/src/views/communityAnalytics/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import compose from 'recompose/compose';
-import pure from 'recompose/pure';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { getThisCommunity } from './queries';
@@ -96,9 +95,6 @@ class CommunitySettings extends React.Component<Props, State> {
 }
 
 const map = state => ({ currentUser: state.users.currentUser });
-export default compose(
-  connect(map),
-  getThisCommunity,
-  viewNetworkHandler,
-  pure
-)(CommunitySettings);
+export default compose(connect(map), getThisCommunity, viewNetworkHandler)(
+  CommunitySettings
+);

--- a/src/views/communitySettings/components/communityMembers.js
+++ b/src/views/communitySettings/components/communityMembers.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { UserListItem } from '../../../components/listItems';
-import pure from 'recompose/pure';
 import compose from 'recompose/compose';
 import { Loading } from '../../../components/loading';
 import ViewError from '../../../components/viewError';
@@ -71,4 +70,4 @@ class CommunityMembers extends React.Component<Props> {
   }
 }
 
-export default compose(getCommunityMembersQuery, pure)(CommunityMembers);
+export default compose(getCommunityMembersQuery)(CommunityMembers);

--- a/src/views/communitySettings/components/editForm.js
+++ b/src/views/communitySettings/components/editForm.js
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import compose from 'recompose/compose';
-import pure from 'recompose/pure';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { Link } from 'react-router-dom';
@@ -378,6 +377,5 @@ export default compose(
   connect(),
   deleteCommunityMutation,
   editCommunityMutation,
-  withRouter,
-  pure
+  withRouter
 )(EditForm);

--- a/src/views/communitySettings/components/emailInvites.js
+++ b/src/views/communitySettings/components/emailInvites.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
 // $FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
@@ -353,13 +352,11 @@ const map = state => ({
 export const EmailInvitesWithoutCard = compose(
   sendEmailInvitationsMutation,
   connect(map),
-  viewNetworkHandler,
-  pure
+  viewNetworkHandler
 )(EmailInvitesNoCard);
 export const EmailInvitesWithCard = compose(
   sendEmailInvitationsMutation,
   connect(map),
-  viewNetworkHandler,
-  pure
+  viewNetworkHandler
 )(EmailInvitesCard);
 export default EmailInvitesWithCard;

--- a/src/views/communitySettings/components/importSlack.js
+++ b/src/views/communitySettings/components/importSlack.js
@@ -3,8 +3,6 @@ import * as React from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
 import Textarea from 'react-textarea-autosize';
@@ -289,14 +287,12 @@ export const ImportSlackWithoutCard = compose(
   sendSlackInvitationsMutation,
   getSlackImport,
   connect(),
-  viewNetworkHandler,
-  pure
+  viewNetworkHandler
 )(ImportSlackNoCard);
 export const ImportSlackWithCard = compose(
   sendSlackInvitationsMutation,
   getSlackImport,
   connect(),
-  viewNetworkHandler,
-  pure
+  viewNetworkHandler
 )(ImportSlackCard);
 export default ImportSlackWithCard;

--- a/src/views/communitySettings/components/invoices.js
+++ b/src/views/communitySettings/components/invoices.js
@@ -3,8 +3,6 @@ import * as React from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import { connect } from 'react-redux';
 import { getCommunityInvoices } from '../../../api/community';
 import { Loading } from '../../../components/loading';
@@ -73,9 +71,6 @@ class Invoices extends React.Component<Props> {
   }
 }
 
-export default compose(
-  getCommunityInvoices,
-  viewNetworkHandler,
-  connect(),
-  pure
-)(Invoices);
+export default compose(getCommunityInvoices, viewNetworkHandler, connect())(
+  Invoices
+);

--- a/src/views/communitySettings/index.js
+++ b/src/views/communitySettings/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import compose from 'recompose/compose';
-import pure from 'recompose/pure';
 import { connect } from 'react-redux';
 import { getThisCommunity } from './queries';
 import { Loading } from '../../components/loading';
@@ -132,6 +131,6 @@ class CommunitySettings extends React.Component<Props> {
   }
 }
 
-export default compose(connect(), getThisCommunity, viewNetworkHandler, pure)(
+export default compose(connect(), getThisCommunity, viewNetworkHandler)(
   CommunitySettings
 );

--- a/src/views/dashboard/components/inboxThread.js
+++ b/src/views/dashboard/components/inboxThread.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import { connect } from 'react-redux';
@@ -102,4 +100,4 @@ class InboxThread extends Component {
   }
 }
 
-export default compose(connect(), withRouter, pure)(InboxThread);
+export default compose(connect(), withRouter)(InboxThread);

--- a/src/views/dashboard/components/threadFeed.js
+++ b/src/views/dashboard/components/threadFeed.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 // $FlowFixMe
 import { withRouter } from 'react-router';
 // $FlowFixMe
@@ -154,4 +152,4 @@ class ThreadFeed extends Component {
   }
 }
 
-export default compose(withRouter, connect(), pure)(ThreadFeed);
+export default compose(withRouter, connect())(ThreadFeed);

--- a/src/views/dashboard/index.js
+++ b/src/views/dashboard/index.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import generateMetaInfo from 'shared/generate-meta-info';
 // $FlowFixMe
 import { connect } from 'react-redux';
@@ -199,9 +197,6 @@ const map = state => ({
   activeCommunity: state.dashboardFeed.activeCommunity,
   activeChannel: state.dashboardFeed.activeChannel,
 });
-export default compose(
-  connect(map),
-  getCurrentUserProfile,
-  viewNetworkHandler,
-  pure
-)(Dashboard);
+export default compose(connect(map), getCurrentUserProfile, viewNetworkHandler)(
+  Dashboard
+);

--- a/src/views/directMessages/components/messages.js
+++ b/src/views/directMessages/components/messages.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import { sortAndGroupMessages } from '../../../helpers/messages';
 import ChatMessages from '../../../components/messageGroup';
 import { Loading } from '../../../components/loading';
@@ -124,8 +122,7 @@ class MessagesWithData extends Component {
 const Messages = compose(
   toggleReactionMutation,
   setLastSeenMutation,
-  getDirectMessageThreadMessages,
-  pure
+  getDirectMessageThreadMessages
 )(MessagesWithData);
 
 export default Messages;

--- a/src/views/directMessages/components/threadsList.js
+++ b/src/views/directMessages/components/threadsList.js
@@ -1,11 +1,15 @@
 // @flow
 import React from 'react';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import ListCardItemDirectMessageThread from './messageThreadListItem';
 import { ThreadsListScrollContainer } from './style';
 
-const ThreadsList = ({ threads, currentUser, active }) => {
+type Input = {
+  threads: Array<Object>,
+  currentUser: Object,
+  active: string,
+};
+
+const ThreadsList = ({ threads, currentUser, active }: Input) => {
   if (!threads || threads.length === 0) {
     return null;
   }
@@ -26,4 +30,4 @@ const ThreadsList = ({ threads, currentUser, active }) => {
   );
 };
 
-export default pure(ThreadsList);
+export default ThreadsList;

--- a/src/views/directMessages/index.js
+++ b/src/views/directMessages/index.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import { Link } from 'react-router-dom';
 // $FlowFixMe
 import { connect } from 'react-redux';
@@ -253,8 +251,7 @@ class DirectMessages extends Component {
 const DirectMessagesWithQuery = compose(
   getCurrentUserDirectMessageThreads,
   displayLoadingState,
-  markDirectMessageNotificationsSeenMutation,
-  pure
+  markDirectMessageNotificationsSeenMutation
 )(DirectMessages);
 
 const mapStateToProps = state => ({

--- a/src/views/explore/components/topCommunities.js
+++ b/src/views/explore/components/topCommunities.js
@@ -3,8 +3,6 @@ import React, { Component } from 'react';
 import compose from 'recompose/compose';
 // $FlowFixMe
 import { connect } from 'react-redux';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import { getTopCommunities } from '../queries';
 import { displayLoadingState } from '../../../components/loading';
 import { ListContainer } from '../../../components/listItems/style';
@@ -45,7 +43,7 @@ class CommunityList extends Component {
   }
 }
 
-const TopCommunityList = compose(getTopCommunities, displayLoadingState, pure)(
+const TopCommunityList = compose(getTopCommunities, displayLoadingState)(
   CommunityList
 );
 const mapStateToProps = state => ({ currentUser: state.users.currentUser });

--- a/src/views/explore/index.js
+++ b/src/views/explore/index.js
@@ -3,8 +3,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 // $FlowFixMe
 import generateMetaInfo from 'shared/generate-meta-info';
 import Titlebar from '../titlebar';
@@ -27,7 +25,7 @@ import {
 
 import { getCommunity } from './queries';
 
-const Feature = compose(getCommunity, pure)(FeaturedCommunity);
+const Feature = compose(getCommunity)(FeaturedCommunity);
 
 const ExplorePure = props => {
   const { title, description } = generateMetaInfo({
@@ -64,7 +62,7 @@ const ExplorePure = props => {
   );
 };
 
-const Explore = compose(pure)(ExplorePure);
+const Explore = compose()(ExplorePure);
 const mapStateToProps = state => ({
   currentUser: state.users.currentUser,
 });

--- a/src/views/navbar/components/notificationDropdown.js
+++ b/src/views/navbar/components/notificationDropdown.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import { withRouter } from 'react-router';
@@ -77,6 +75,6 @@ const NotificationDropdownPure = props => {
   );
 };
 
-export const NotificationDropdown = compose(withRouter, pure)(
+export const NotificationDropdown = compose(withRouter)(
   NotificationDropdownPure
 );

--- a/src/views/newCommunity/components/editCommunityForm/index.js
+++ b/src/views/newCommunity/components/editCommunityForm/index.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
 import { withRouter } from 'react-router';
@@ -304,7 +302,6 @@ const Community = compose(
   deleteCommunityMutation,
   editCommunityMutation,
   withRouter,
-  pure,
   connect()
 )(CommunityWithData);
 export default Community;

--- a/src/views/newCommunity/index.js
+++ b/src/views/newCommunity/index.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 // $FlowFixMe
 import { connect } from 'react-redux';
 // $FlowFixMe
@@ -244,6 +242,4 @@ class NewCommunity extends Component {
   }
 }
 const mapStateToProps = state => ({ currentUser: state.users.currentUser });
-export default compose(pure, withApollo, connect(mapStateToProps))(
-  NewCommunity
-);
+export default compose(withApollo, connect(mapStateToProps))(NewCommunity);

--- a/src/views/newUserOnboarding/components/discoverCommunities/index.js
+++ b/src/views/newUserOnboarding/components/discoverCommunities/index.js
@@ -3,8 +3,6 @@ import React, { Component } from 'react';
 import compose from 'recompose/compose';
 // $FlowFixMe
 import { connect } from 'react-redux';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import { track } from '../../../../helpers/events';
 import { getTopCommunities } from '../../../../api/community';
 import { toggleCommunityMembershipMutation } from '../../../../api/community';
@@ -127,7 +125,6 @@ const TopCommunities = compose(
   getTopCommunities,
   toggleCommunityMembershipMutation,
   displayLoadingState,
-  connect(),
-  pure
+  connect()
 )(TopCommunitiesPure);
 export default TopCommunities;

--- a/src/views/newUserOnboarding/components/joinFirstCommunity/index.js
+++ b/src/views/newUserOnboarding/components/joinFirstCommunity/index.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
 import { connect } from 'react-redux';
@@ -109,7 +107,6 @@ const map = state => ({
 
 const JoinFirstCommunity = compose(
   toggleCommunityMembershipMutation,
-  connect(map),
-  pure
+  connect(map)
 )(JoinFirstCommunityPure);
 export default JoinFirstCommunity;

--- a/src/views/newUserOnboarding/components/userInfo/index.js
+++ b/src/views/newUserOnboarding/components/userInfo/index.js
@@ -6,8 +6,6 @@ import slugg from 'slugg';
 // $FlowFixMe
 import { withApollo } from 'react-apollo';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
 import { connect } from 'react-redux';
@@ -350,7 +348,6 @@ const UserInfo = compose(
   editUserMutation,
   withRouter,
   withApollo,
-  connect(map),
-  pure
+  connect(map)
 )(UserInfoPure);
 export default UserInfo;

--- a/src/views/notifications/components/communityInviteNotification.js
+++ b/src/views/notifications/components/communityInviteNotification.js
@@ -1,8 +1,6 @@
 import React from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import { getCommunityById } from '../../../api/community';
 import { displayLoadingCard } from '../../../components/loading';
 import { parseNotificationDate, parseContext, parseActors } from '../utils';
@@ -21,7 +19,7 @@ const CommunityInviteComponent = ({ data }) => {
   return <CommunityProfile profileSize={'miniWithAction'} data={data} />;
 };
 
-const CommunityInvite = compose(getCommunityById, displayLoadingCard, pure)(
+const CommunityInvite = compose(getCommunityById, displayLoadingCard)(
   CommunityInviteComponent
 );
 

--- a/src/views/notifications/components/newChannelNotification.js
+++ b/src/views/notifications/components/newChannelNotification.js
@@ -1,8 +1,6 @@
 import React from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import { getChannelById } from '../../../api/channel';
 import { displayLoadingCard } from '../../../components/loading';
 import { parseNotificationDate, parseContext } from '../utils';
@@ -21,7 +19,7 @@ const NewChannelComponent = ({ data }) => {
   return <ChannelProfile profileSize="miniWithAction" data={data} />;
 };
 
-const NewChannel = compose(getChannelById, displayLoadingCard, pure)(
+const NewChannel = compose(getChannelById, displayLoadingCard)(
   NewChannelComponent
 );
 

--- a/src/views/notifications/components/newThreadNotification.js
+++ b/src/views/notifications/components/newThreadNotification.js
@@ -1,8 +1,6 @@
 import React from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
-// $FlowFixMe
-import pure from 'recompose/pure';
 import { getThreadById } from '../../../api/thread';
 import { sortByDate } from '../../../helpers/utils';
 import { displayLoadingCard } from '../../../components/loading';
@@ -37,7 +35,7 @@ const ThreadCreatedComponent = ({ data }) => {
   return <ThreadProfile profileSize="mini" data={data} />;
 };
 
-const ThreadCreated = compose(getThreadById, displayLoadingCard, pure)(
+const ThreadCreated = compose(getThreadById, displayLoadingCard)(
   ThreadCreatedComponent
 );
 

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 // $FlowFixMe
 import { connect } from 'react-redux';
 // NOTE(@mxstbr): This is a custom fork published of off this (as of this writing) unmerged PR: https://github.com/CassetteRocks/react-infinite-scroller/pull/38
@@ -299,6 +297,5 @@ export default compose(
   displayLoadingNotifications,
   markNotificationsSeenMutation,
   connect(mapStateToProps),
-  withInfiniteScroll,
-  pure
+  withInfiniteScroll
 )(NotificationsPure);

--- a/src/views/pages/styleGuide.js
+++ b/src/views/pages/styleGuide.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import withHandlers from 'recompose/withHandlers';
@@ -524,5 +522,5 @@ const StyleGuidePure = enhance(({ highlightAndCopy, toString }) => (
   </PageContainer>
 ));
 
-const StyleGuide = compose(pure)(StyleGuidePure);
+const StyleGuide = compose()(StyleGuidePure);
 export default StyleGuide;

--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
 import { connect } from 'react-redux';
@@ -613,8 +611,7 @@ const ThreadDetail = compose(
   editThreadMutation,
   pinThreadMutation,
   toggleThreadNotificationsMutation,
-  withRouter,
-  pure
+  withRouter
 )(ThreadDetailPure);
 const mapStateToProps = state => ({
   currentUser: state.users.currentUser,

--- a/src/views/thread/containers/index.js
+++ b/src/views/thread/containers/index.js
@@ -2,8 +2,6 @@ import * as React from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import { connect } from 'react-redux';
 import { track } from '../../../helpers/events';
 // $FlowFixMe
@@ -300,6 +298,6 @@ class ThreadContainer extends React.Component<Props, State> {
 }
 
 const map = state => ({ currentUser: state.users.currentUser });
-export default compose(connect(map), getThread, viewNetworkHandler, pure)(
+export default compose(connect(map), getThread, viewNetworkHandler)(
   ThreadContainer
 );

--- a/src/views/thread/index.js
+++ b/src/views/thread/index.js
@@ -4,8 +4,6 @@ import React from 'react';
 import { Route } from 'react-router';
 //$FlowFixMe
 import compose from 'recompose/compose';
-//$FlowFixMe
-import pure from 'recompose/pure';
 import ThreadContainer from './containers';
 
 const ThreadPure = ({ match, location }) => (
@@ -17,6 +15,6 @@ const ThreadPure = ({ match, location }) => (
   />
 );
 
-const Thread = compose(pure)(ThreadPure);
+const Thread = compose()(ThreadPure);
 
 export default Thread;

--- a/src/views/user/index.js
+++ b/src/views/user/index.js
@@ -2,8 +2,6 @@ import * as React from 'react';
 //$FlowFixMe
 import compose from 'recompose/compose';
 //$FlowFixMe
-import pure from 'recompose/pure';
-//$FlowFixMe
 import { connect } from 'react-redux';
 //$FlowFixMe
 import generateMetaInfo from 'shared/generate-meta-info';
@@ -169,6 +167,4 @@ class UserView extends React.Component<Props> {
 }
 
 const map = state => ({ currentUser: state.users.currentUser });
-export default compose(connect(map), getUser, viewNetworkHandler, pure)(
-  UserView
-);
+export default compose(connect(map), getUser, viewNetworkHandler)(UserView);

--- a/src/views/userSettings/components/invoices.js
+++ b/src/views/userSettings/components/invoices.js
@@ -2,8 +2,6 @@ import React, { Component } from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
 // $FlowFixMe
-import pure from 'recompose/pure';
-// $FlowFixMe
 import { connect } from 'react-redux';
 import { getUserInvoices } from '../../../api/user';
 import { displayLoadingCard } from '../../../components/loading';
@@ -41,7 +39,7 @@ class InvoicesPure extends Component {
   }
 }
 
-const Invoices = compose(getUserInvoices, displayLoadingCard, connect(), pure)(
+const Invoices = compose(getUserInvoices, displayLoadingCard, connect())(
   InvoicesPure
 );
 

--- a/src/views/userSettings/index.js
+++ b/src/views/userSettings/index.js
@@ -3,8 +3,6 @@ import * as React from 'react';
 import compose from 'recompose/compose';
 //$FlowFixMe
 import { connect } from 'react-redux';
-//$FlowFixMe
-import pure from 'recompose/pure';
 import { track } from '../../helpers/events';
 import AppViewWrapper from '../../components/appViewWrapper';
 import Column from '../../components/column';
@@ -136,6 +134,6 @@ const map = state => ({
   currentUser: state.users.currentUser,
 });
 
-export default compose(connect(map), GetUserProfile, viewNetworkHandler, pure)(
+export default compose(connect(map), GetUserProfile, viewNetworkHandler)(
   UserSettings
 );


### PR DESCRIPTION
We have issues in the app where things don't re-render even though they should, for example the favicon won't update even if new notifications come in. I have a hunch that this is because we're using `recompose/pure`.

`recompose/pure` does a shallow comparison between the current props and the next props. This can lead to subtle bugs where nested objects change, but the component doesn't re-render because the top-level keys and property types are the same. See this note from [the React docs about `PureComponent`](https://reactjs.org/docs/react-api.html#reactpurecomponent): (which does the same thing as `recompose/pure`)

![screen shot 2017-10-07 at 10 15 39 am](https://user-images.githubusercontent.com/7525670/31306078-8ad276d6-ab48-11e7-93a8-5f43f58ed715.png)

It can also be more expensive to check the difference in props than to just render again because React is so fast. (especially true for leaf components) We need to use it like surgeons but currently we're like a gatling gun throwing it anything that moves.

I went ahead and removed all instances of `recompose/pure` usage. Now, we can introduce it again in high-level components where we notice performance problems, but only after careful consideration of the impact and only in those components.