### PR TITLE
Defer Raven.js <script>

### DIFF
--- a/iris/renderer/get-html.js
+++ b/iris/renderer/get-html.js
@@ -24,11 +24,11 @@ export const getHTML = ({ styleTags, metaTags, state, content }: Arguments) => {
         '<div id="root"></div>',
         `<script>window.__SERVER_STATE__=${serialize(
           state
-        )}</script><div id="root">${content}</div>`
+        )}</script><div id="root">${content}</div>${sentry}`
       )
       // Inject the meta tags at the start of the <head>
       .replace('<head>', `<head>${metaTags}`)
       // Inject the style tags at the end of the <head>
-      .replace('</head>', `${styleTags}${sentry}</head>`)
+      .replace('</head>', `${styleTags}</head>`)
   );
 };


### PR DESCRIPTION
**TL;DR: This one-word change means the first render in the browser with the server-side rendered HTML happens ~4s earlier on all our pages**

----

The `defer` attribute makes it so that a script is only executed _after_ the HTML has been parsed and rendered. Contrary to the `async` attribute, `defer` also guarantees that the ordering of script executions is consistent. (i.e. a later script in the HTML will execute after the deferred one, no matter in what order they're loaded)

Looking at some [WebPageTest results](https://www.webpagetest.org/result/171012_PZ_92a736797d24b4b5861d897ca52697d4/) one can clearly see that the first content shows up on the users screen at 8s:

![filmstrip-1](https://user-images.githubusercontent.com/7525670/31494145-5677478c-af52-11e7-909e-2a177cd70ff5.png)

The thing is that the server-side rendered HTML was already done and loaded at ~4s, but the render is blocked by the `raven.js` script tag!

<img width="964" alt="screen shot 2017-10-12 at 1 41 11 pm" src="https://user-images.githubusercontent.com/7525670/31494454-a6c36f26-af53-11e7-8cf9-1b2427e08ebb.png">

> Note the big green bar (which is the initial content render) and how it could've happened at 4s but was blocked by raven.js

That's super stupid, as we don't want Raven.js to block the initial HTML (from SSR) render at all! We want raven.js to be executed before the main bundle so any errors in the initialization code of the main bundle are correctly reported to Sentry, but it should not block the initial HTML render.

That's why the `defer` attribute on the `script` tag makes sense here:

1. `raven.js` doesn't block the initial render anymore
2. It's still guaranteed that our `bundle.js` is executed after `raven.js`

That's perfect for our needs and makes the initial render much faster:

![filmstrip](https://user-images.githubusercontent.com/7525670/31494168-6956c0da-af52-11e7-936b-c40ac70a276d.png)

That filmstrip is from [this WebPageTest](https://www.webpagetest.org/result/171012_B7_1cf3792e7ce6948e55d2cecc419c1498/) which I ran on a deploy with this change.

As you can see, **the time it takes for the initial content to show up dropped from ~8s to 4.5s**, which is massive!