### PR TITLE
fixes link preview styling.

### DIFF
--- a/public/reset.css
+++ b/public/reset.css
@@ -160,10 +160,6 @@ textarea {
   font-weight: 700;
 }
 
-.markdown span {
-  font-size: inherit;
-}
-
 .markdown ul,
 .markdown ol {
   color: inherit;

--- a/src/components/linkPreview/style.js
+++ b/src/components/linkPreview/style.js
@@ -48,7 +48,7 @@ export const LinkPreviewTextContainer = styled.div`
   align-self: stretch;
 `;
 
-export const BaseMeta = styled.p`
+export const BaseMeta = styled.span`
   display: flex;
   flex: none;
   line-height: 1.2;


### PR DESCRIPTION
 Our markdown class selectors are breaking a bunch of things because they're overriding specificity.