### PR TITLE
Fix Iris restarting for changes in src/

### DIFF
--- a/backpack.config.js
+++ b/backpack.config.js
@@ -21,7 +21,10 @@ module.exports = {
 
     if (process.env.NODE_ENV !== 'production' && !process.env.SSR) {
       config.plugins.push(
-        new webpack.WatchIgnorePlugin([path.resolve(__dirname, './src')])
+        new webpack.WatchIgnorePlugin([
+          path.resolve(__dirname, './src'),
+          path.resolve(__dirname, './build'),
+        ])
       );
     }
     config.plugins.push(


### PR DESCRIPTION
The code splitting PR introduced a new manifest file
(`react-lodable.json`) that's necessary for SSR + code splitting and is
emitted to the `build/` folder. Unfortunately, iris listened to changes
to that file as it requires it, meaning every time you changed the
frontend that file would be changed, then iris would restart, breaking
the development experience.

Fixed by adding build/ to the watch ignore plugin.