### PR TITLE
Load messages (and thusly threads) faster

### DIFF
--- a/iris/queries/message.js
+++ b/iris/queries/message.js
@@ -26,13 +26,17 @@ module.exports = {
       _: any,
       { loaders }: GraphQLContext
     ) => {
-      const sender = await loaders.user.load(senderId);
-
       // there will be no community to resolve in direct message threads, so we can escape early
       // and only return the sender
-      if (threadType === 'directMessageThread') return sender;
+      if (threadType === 'directMessageThread') {
+        return loaders.user.load(senderId);
+      }
 
-      const { communityId } = await getThread(threadId);
+      const [{ communityId }, sender] = await Promise.all([
+        loaders.thread.load(threadId),
+        loaders.user.load(senderId),
+      ]);
+
       const {
         reputation,
         isModerator,


### PR DESCRIPTION
For ever message loaded we would load the thread that message was in in the `message.sender` resolver again. I.e. if a thread has 100 messages we query for the thread 101x from the database.

Fixed by using a loader, and I also parallelized the loader work between fetching the sender and fetching the thread by putting the direct message thread case first, which should speed up things even more.