### PR TITLE
Hotfix: community permissions

### DIFF
--- a/iris/queries/channel.js
+++ b/iris/queries/channel.js
@@ -11,6 +11,7 @@ const {
   getMembersInChannel,
   getOwnersInChannel,
 } = require('../models/usersChannels');
+import { getUserPermissionsInCommuniyt } from '../models/usersCommunities';
 const { getThreadsByChannel } = require('../models/thread');
 import paginate from '../utils/paginate-arrays';
 import { encode, decode } from '../utils/base64';
@@ -59,7 +60,7 @@ module.exports = {
     communityPermissions: (args, _: any, { user, loaders }: Context) => {
       const communityId = args.id || args.communityId;
       if (!communityId || !user) return false;
-      return loaders.userPermissionsInCommunity.load([user.id, communityId]);
+      return getUserPermissionsInCommunity(communityId, user.id);
     },
     memberConnection: (
       { id },

--- a/iris/queries/community.js
+++ b/iris/queries/community.js
@@ -13,7 +13,10 @@ const {
   getCommunityGrowth,
 } = require('../models/community');
 const { getTopMembersInCommunity } = require('../models/reputationEvents');
-const { getMembersInCommunity } = require('../models/usersCommunities');
+const {
+  getMembersInCommunity,
+  getUserPermissionsInCommunity,
+} = require('../models/usersCommunities');
 import { getMessageCount } from '../models/message';
 const { getUserByUsername } = require('../models/user');
 const {
@@ -77,7 +80,7 @@ module.exports = {
       { user, loaders }: GraphQLContext
     ) => {
       if (!id || !user) return false;
-      return loaders.userPermissionsInCommunity.load([user.id, id]);
+      return getUserPermissionsInCommunity(id, user.id);
     },
     channelConnection: ({ id }: { id: string }) => ({
       pageInfo: {
@@ -232,10 +235,10 @@ module.exports = {
       }
 
       const queryRecurringPayments = async () => {
-        const userPermissions = await loaders.userPermissionsInCommunity.load([
-          currentUser.id,
+        const userPermissions = await getUserPermissionsInCommunity(
           id,
-        ]);
+          currentUser.id
+        );
         if (!userPermissions.isOwner) return;
 
         const rPayments = await loaders.communityRecurringPayments.load(id);
@@ -267,10 +270,10 @@ module.exports = {
         return new UserError('You must be signed in to continue.');
       }
 
-      const { isOwner } = await loaders.userPermissionsInCommunity.load([
-        currentUser.id,
+      const { isOwner } = await getUserPermissionsInCommunity(
         id,
-      ]);
+        currentUser.id
+      );
 
       if (!isOwner) {
         return new UserError(
@@ -320,10 +323,10 @@ module.exports = {
         return new UserError('You must be signed in to continue.');
       }
 
-      const { isOwner } = await loaders.userPermissionsInCommunity.load([
-        currentUser.id,
+      const { isOwner } = await getUserPermissionsInCommunity(
         id,
-      ]);
+        currentUser.id
+      );
 
       if (!isOwner) {
         return new UserError(
@@ -364,10 +367,10 @@ module.exports = {
         return new UserError('You must be signed in to continue.');
       }
 
-      const { isOwner } = await loaders.userPermissionsInCommunity.load([
-        currentUser.id,
+      const { isOwner } = await getUserPermissionsInCommunity(
         id,
-      ]);
+        currentUser.id
+      );
 
       if (!isOwner) {
         return new UserError(
@@ -391,10 +394,10 @@ module.exports = {
         return new UserError('You must be signed in to continue.');
       }
 
-      const { isOwner } = await loaders.userPermissionsInCommunity.load([
-        currentUser.id,
+      const { isOwner } = await getUserPermissionsInCommunity(
         id,
-      ]);
+        currentUser.id
+      );
 
       return getThreadsByCommunityInTimeframe(
         id,
@@ -460,10 +463,7 @@ module.exports = {
               reputation,
               isModerator,
               isOwner,
-            } = await loaders.userPermissionsInCommunity.load([
-              user.id,
-              community.id,
-            ]);
+            } = await getUserPermissionsInCommunity(community.id, user.id);
             return {
               reputation,
               isModerator,

--- a/iris/queries/message.js
+++ b/iris/queries/message.js
@@ -1,6 +1,7 @@
 const { getMessage, getMediaMessagesForThread } = require('../models/message');
 import { getReactions } from '../models/reaction';
 import { getThread } from '../models/thread';
+import { getUserPermissionsInCommunity } from '../models/usersCommunities';
 import type { GraphQLContext } from '../';
 
 type GetMessageProps = {
@@ -41,10 +42,7 @@ module.exports = {
         reputation,
         isModerator,
         isOwner,
-      } = await loaders.userPermissionsInCommunity.load([
-        senderId,
-        communityId,
-      ]);
+      } = await getUserPermissionsInCommunity(communityId, senderId);
 
       return {
         ...sender,

--- a/iris/queries/thread.js
+++ b/iris/queries/thread.js
@@ -5,6 +5,7 @@ const {
 } = require('../models/community');
 const { getUsers } = require('../models/user');
 import { getUserPermissionsInChannel } from '../models/usersChannels';
+const { getUserPermissionsInCommunity } = require('../models/usersCommunities');
 import {
   getParticipantsInThread,
   getThreadNotificationStatusForUser,
@@ -140,10 +141,7 @@ module.exports = {
         reputation,
         isModerator,
         isOwner,
-      } = await loaders.userPermissionsInCommunity.load([
-        creatorId,
-        communityId,
-      ]);
+      } = await getUserPermissionsInCommunity(communityId, creatorId);
 
       return {
         ...creator,

--- a/iris/queries/user.js
+++ b/iris/queries/user.js
@@ -30,7 +30,10 @@ import type { PaginationOptions } from '../utils/paginate-arrays';
 import UserError from '../utils/UserError';
 import type { GraphQLContext } from '../';
 import type { DBUser } from '../models/user';
-import { getReputationByUser } from '../models/usersCommunities';
+import {
+  getReputationByUser,
+  getUserPermissionsInCommunity,
+} from '../models/usersCommunities';
 let imgix = new ImgixClient({
   host: 'spectrum-imgp.imgix.net',
   secureURLToken: 'asGmuMn5yq73B3cH',
@@ -254,10 +257,7 @@ module.exports = {
               reputation,
               isModerator,
               isOwner,
-            } = await loaders.userPermissionsInCommunity.load([
-              user.id,
-              communityId,
-            ]);
+            } = await getUserPermissionsInCommunity(communityId, user.id);
             return {
               reputation,
               isModerator,
@@ -271,10 +271,7 @@ module.exports = {
               reputation,
               isModerator,
               isOwner,
-            } = await loaders.userPermissionsInCommunity.load([
-              user.id,
-              communityId,
-            ]);
+            } = await getUserPermissionsInCommunity(communityId, user.id);
             return {
               reputation,
               isModerator,
@@ -290,7 +287,7 @@ module.exports = {
               reputation,
               isModerator,
               isOwner,
-            } = await loaders.userPermissionsInCommunity.load([user.id, id]);
+            } = await getUserPermissionsInCommunity(id, user.id);
             return {
               reputation: reputation || 0,
               isModerator,


### PR DESCRIPTION
@mxstbr I had to revert most of #1650 - the reason is that the loader was returning `null` when a user was viewing a community they had never joined before (i.e. no `usersCommunities` records exist`)

The reason this was annoying to have to revert was because the *db query itself* handles a null response...so I honestly have no clue why the loader would return null when the db query itself has a fallback:

```js
if (data.length > 0) {
        return data[0];
      } else {
        return {
          isOwner: false,
          isMember: false,
          isModerator: false,
          isBlocked: false,
          receiveNotifications: false,
          reputation: 0,
        };
      }
```