### PR TITLE
[RFC] Add cache hints to GraphQL schema

### DIFF
--- a/iris/types/Channel.js
+++ b/iris/types/Channel.js
@@ -58,7 +58,7 @@ const Channel = /* GraphQL */ `
 		userId: ID!
 	}
 
-	type Channel {
+	type Channel @cacheControl(maxAge: 86400) {
 		id: ID!
 		createdAt: Date!
 		modifiedAt: Date
@@ -67,10 +67,10 @@ const Channel = /* GraphQL */ `
 		slug: String!
 		isPrivate: Boolean
     isDefault: Boolean
-		channelPermissions: ChannelPermissions!
-		communityPermissions: CommunityPermissions!
+		channelPermissions: ChannelPermissions! @cacheControl(scope: PRIVATE)
+		communityPermissions: CommunityPermissions! @cacheControl(scope: PRIVATE)
 		community: Community!
-		threadConnection(first: Int = 20, after: String): ChannelThreadsConnection!
+		threadConnection(first: Int = 20, after: String): ChannelThreadsConnection! @cacheContrl(maxAge: 0)
 		memberConnection(first: Int = 20, after: String): ChannelMembersConnection!
 		memberCount: Int!
 		metaData: ChannelMetaData

--- a/iris/types/Thread.js
+++ b/iris/types/Thread.js
@@ -32,7 +32,7 @@ const Thread = /* GraphQL */ `
 		data: String
 	}
 
-	type Thread {
+	type Thread @cacheControl(maxAge: 84600) {
 		id: ID!
 		createdAt: Date!
 		modifiedAt: Date

--- a/iris/types/User.js
+++ b/iris/types/User.js
@@ -68,7 +68,7 @@ const User = /* GraphQL */ `
 		notifications: UserNotificationsSettings
 	}
 
-	type User {
+	type User @cacheControl(maxAge: 86400) {
 		id: ID!
 		name: String
 		firstName: String
@@ -92,12 +92,12 @@ const User = /* GraphQL */ `
 		isPro: Boolean!
 		communityConnection: UserCommunitiesConnection!
 		channelConnection: UserChannelsConnection!
-		directMessageThreadsConnection: UserDirectMessageThreadsConnection!
+		directMessageThreadsConnection: UserDirectMessageThreadsConnection! @cacheControl(scope: PRIVATE)
 		threadConnection(first: Int = 20, after: String): UserThreadsConnection!
 		everything(first: Int = 20, after: String): EverythingThreadsConnection!
-		recurringPayments: [RecurringPayment]
-		invoices: [Invoice]
-		settings: UserSettings
+		recurringPayments: [RecurringPayment] @cacheControl(scope: PRIVATE)
+		invoices: [Invoice] @cacheControl(scope: PRIVATE)
+		settings: UserSettings @cacheControl(scope: PRIVATE)
 		contextPermissions: ContextPermissions
 	}
 


### PR DESCRIPTION
With Apollo engine (#1741) we can now add cache hints to our GraphQL schema to tell engine to cache certain responses for a certain amount of time.

See the [caching docs](https://www.apollographql.com/docs/engine/caching.html) for more information.

WDYT about doing this? Shall we cache some low-level resources (user, community, channel data) so that things load much faster for end users?

This might come at a tradeoff with data freshness etc, so we should figure out how to invalidate a certain cache if a mutation comes in to e.g. change the user avatar, but the docs don't have any info about that rn. Seems like an edge case to me, depending on what we cache.