### PR TITLE
Update drag-n-drop plugin to rc9

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "debug": "^2.6.8",
     "draft-js": "^0.10.2",
     "draft-js-code-editor-plugin": "0.2.1",
-    "draft-js-drag-n-drop-plugin": "2.0.0-rc2",
+    "draft-js-drag-n-drop-plugin": "2.0.0-rc9",
     "draft-js-embed-plugin": "^1.2.0",
     "draft-js-focus-plugin": "2.0.0-rc2",
     "draft-js-image-plugin": "2.0.0-rc8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,9 +2742,9 @@ draft-js-code@0.3.x:
     ends-with "^0.2.0"
     immutable "3.x"
 
-draft-js-drag-n-drop-plugin@2.0.0-rc2:
-  version "2.0.0-rc2"
-  resolved "https://registry.yarnpkg.com/draft-js-drag-n-drop-plugin/-/draft-js-drag-n-drop-plugin-2.0.0-rc2.tgz#81ffee2323f91daf0ba01312cb4ae3a46b9ba85b"
+draft-js-drag-n-drop-plugin@2.0.0-rc9:
+  version "2.0.0-rc9"
+  resolved "https://registry.yarnpkg.com/draft-js-drag-n-drop-plugin/-/draft-js-drag-n-drop-plugin-2.0.0-rc9.tgz#679975d05ce9444bea6a585c560b68c235f0c85f"
   dependencies:
     decorate-component-with-props "^1.0.2"
     find-with-regex "^1.0.2"


### PR DESCRIPTION
This contains my fix from draft-js-plugins/draft-js-plugins#929, which
should finally resolve
https://sentry.io/space-program/spectrum/issues/375110612/

Closes #1702