### PR TITLE
Fix channel issues

### DIFF
--- a/iris/mutations/channel.js
+++ b/iris/mutations/channel.js
@@ -426,18 +426,18 @@ module.exports = {
                 ) => {
                   // if the user is a member of the parent community, we can return
                   if (currentUserCommunityPermissions.isMember) {
-                    return Promise.all([channelToEvaluate]);
+                    return Promise.all([joinedChannel]);
                   } else {
                     // if the user is not a member of the parent community,
                     // join the community and the community's default channels
                     return Promise.all([
-                      channelToEvaluate,
+                      joinedChannel,
                       createMemberInCommunity(
-                        channelToEvaluate.communityId,
+                        joinedChannel.communityId,
                         currentUser.id
                       ),
                       createMemberInDefaultChannels(
-                        channelToEvaluate.communityId,
+                        joinedChannel.communityId,
                         currentUser.id
                       ),
                     ]);

--- a/iris/queries/community.js
+++ b/iris/queries/community.js
@@ -195,8 +195,8 @@ module.exports = {
         loaders.communityChannelCount.load(id),
         loaders.communityMemberCount.load(id),
       ]).then(([channelCount, memberCount]) => ({
-        channels: channelCount.reduction,
-        members: memberCount.reduction,
+        channels: channelCount ? channelCount.reduction : 0,
+        members: memberCount ? memberCount.reduction : 0,
       }));
     },
     slackImport: ({ id }: { id: string }, _: any, { user }: GraphQLContext) => {

--- a/src/api/channel.js
+++ b/src/api/channel.js
@@ -93,9 +93,6 @@ const TOGGLE_CHANNEL_SUBSCRIPTION_MUTATION = gql`
   mutation toggleChannelSubscription($channelId: ID!) {
     toggleChannelSubscription (channelId: $channelId) {
       ...channelInfo
-      community {
-        ...communityInfo
-      }
     }
   }
   ${channelInfoFragment}
@@ -135,9 +132,6 @@ const TOGGLE_PENDING_USER_MUTATION = gql`
         ...userInfo
       }
       ...channelMetaData
-      community {
-        ...communityInfo
-      }
     }
   }
   ${channelInfoFragment}
@@ -184,9 +178,6 @@ const UNBLOCK_USER_MUTATION = gql`
         ...userInfo
       }
       ...channelMetaData
-      community {
-        ...communityInfo
-      }
     }
   }
   ${channelInfoFragment}
@@ -233,9 +224,6 @@ export const getChannelById = graphql(
 		query getChannel($id: ID) {
 			channel(id: $id) {
         ...channelInfo
-        community {
-          ...communityInfo
-        }
       }
 		}
     ${channelInfoFragment}
@@ -261,9 +249,6 @@ export const getPendingUsersQuery = graphql(
 		query getChannel($id: ID) {
 			channel(id: $id) {
         ...channelInfo
-        community {
-          ...communityInfo
-        }
         pendingUsers {
           ...userInfo
         }
@@ -293,9 +278,6 @@ export const getBlockedUsersQuery = graphql(
 		query getChannel($id: ID) {
 			channel(id: $id) {
         ...channelInfo
-        community {
-          ...communityInfo
-        }
         blockedUsers {
           ...userInfo
         }
@@ -341,9 +323,6 @@ const LoadMoreMembers = gql`
     channel(id: $id) {
       ...channelInfo
       ...channelMetaData
-      community {
-        ...communityInfo
-      }
       memberConnection(after: $after) {
         pageInfo {
           hasNextPage
@@ -427,9 +406,6 @@ const GET_CHANNEL_MEMBERS_QUERY = gql`
     channel(id: $id) {
       ...channelInfo
       ...channelMetaData
-      community {
-        ...communityInfo
-      }
       memberConnection {
         pageInfo {
           hasNextPage

--- a/src/api/fragments/channel/channelInfo.js
+++ b/src/api/fragments/channel/channelInfo.js
@@ -1,4 +1,5 @@
 import { gql } from 'react-apollo';
+import { communityInfoFragment } from '../community/communityInfo.js';
 
 export const channelInfoFragment = gql`
   fragment channelInfo on Channel {
@@ -16,5 +17,9 @@ export const channelInfoFragment = gql`
       isModerator
       receiveNotifications
     }
+    community {
+      ...communityInfo
+    }
   }
+  ${communityInfoFragment}
 `;

--- a/src/components/threadComposer/index.js
+++ b/src/components/threadComposer/index.js
@@ -18,8 +18,9 @@ import { URLS } from '../../helpers/regexps';
 import { TextButton, Button } from '../buttons';
 import { FlexRow } from '../../components/globals';
 import Icon from '../icons';
-import { displayLoadingComposer } from '../loading';
+import { LoadingComposer } from '../loading';
 import { NullCard } from '../upsell';
+import viewNetworkHandler from '../viewNetworkHandler';
 import {
   Container,
   Composer,
@@ -552,15 +553,15 @@ class ThreadComposerWithData extends Component {
       fetchingLinkPreview,
     } = this.state;
 
-    const { isOpen, data: { networkStatus }, isInbox } = this.props;
+    const { isOpen, isLoading, hasError, isInbox } = this.props;
     const showCommunityOwnerUpsell = this.props.showComposerUpsell || false;
 
-    if (networkStatus === 7 && (!availableCommunities || !availableChannels)) {
+    if (!isLoading && (!availableCommunities || !availableChannels)) {
       return (
         <NullCard
           bg="community"
           heading={`Once you join a community, you can start conversations there!`}
-          copy={`Let's find you something worth joining...`}
+          copy={`Let‘s find you something worth joining...`}
         >
           <Link to={`/explore`}>
             <Button icon="explore" color="text.alt">
@@ -569,7 +570,9 @@ class ThreadComposerWithData extends Component {
           </Link>
         </NullCard>
       );
-    } else {
+    }
+
+    if (!isLoading && availableCommunities && availableChannels) {
       return (
         <Container isOpen={isOpen} isInbox={isInbox}>
           <Overlay
@@ -670,14 +673,20 @@ class ThreadComposerWithData extends Component {
         </Container>
       );
     }
+
+    if (isLoading) {
+      return <LoadingComposer />;
+    }
+
+    return null;
   }
 }
 
 export const ThreadComposer = compose(
-  getComposerCommunitiesAndChannels, // query to get data
-  publishThread, // mutation to publish a thread
-  displayLoadingComposer, // handle loading state while query is fetching
-  withRouter // needed to use history.push() as a post-publish action
+  getComposerCommunitiesAndChannels,
+  publishThread,
+  viewNetworkHandler,
+  withRouter
 )(ThreadComposerWithData);
 
 const mapStateToProps = state => ({

--- a/src/views/channel/queries.js
+++ b/src/views/channel/queries.js
@@ -154,9 +154,6 @@ export const getChannel = graphql(
 			channel(channelSlug: $channelSlug, communitySlug: $communitySlug) {
         ...channelInfo
         ...channelMetaData
-        community {
-          ...communityInfo
-        }
       }
 		}
     ${channelInfoFragment}

--- a/src/views/community/queries.js
+++ b/src/views/community/queries.js
@@ -144,9 +144,6 @@ export const GET_COMMUNITY_CHANNELS_QUERY = gql`
           node {
             ...channelInfo
             ...channelMetaData
-            community {
-              ...communityInfo
-            }
             pendingUsers {
               ...userInfo
             }

--- a/src/views/thread/containers/index.js
+++ b/src/views/thread/containers/index.js
@@ -130,7 +130,6 @@ class ThreadContainer extends React.Component<Props, State> {
     } = this.props;
 
     const isLoggedIn = currentUser;
-
     if (data && data.thread) {
       // successful network request to get a thread
       const { title, description } = generateMetaInfo({


### PR DESCRIPTION
Basically fucking around with the ...channelInfo fragment screwed up some stuff because in some places in the app it assumed that channel knew what community it was in, and in other cases it didn't. This change is technically less performant, because in some cases we'll be double-fetching communities, but it needs to work this way right now for Apollo to do its thing properly with cache updating :/