### PR TITLE
Fix fallback url

### DIFF
--- a/iris/routes/auth/facebook.js
+++ b/iris/routes/auth/facebook.js
@@ -4,7 +4,9 @@ import { URL } from 'url';
 import isSpectrumUrl from '../../utils/is-spectrum-url';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
-const FALLBACK_URL = IS_PROD ? '/home' : 'http://localhost:3000/home';
+const FALLBACK_URL = IS_PROD
+  ? 'https://spectrum.chat/home'
+  : 'http://localhost:3000/home';
 
 const facebookAuthRouter = Router();
 

--- a/iris/routes/auth/github.js
+++ b/iris/routes/auth/github.js
@@ -4,7 +4,9 @@ import { URL } from 'url';
 import isSpectrumUrl from '../../utils/is-spectrum-url';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
-const FALLBACK_URL = IS_PROD ? '/home' : 'http://localhost:3000/home';
+const FALLBACK_URL = IS_PROD
+  ? 'https://spectrum.chat/home'
+  : 'http://localhost:3000/home';
 
 const githubAuthRouter = Router();
 

--- a/iris/routes/auth/google.js
+++ b/iris/routes/auth/google.js
@@ -4,7 +4,9 @@ import { URL } from 'url';
 import isSpectrumUrl from '../../utils/is-spectrum-url';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
-const FALLBACK_URL = IS_PROD ? '/home' : 'http://localhost:3000/home';
+const FALLBACK_URL = IS_PROD
+  ? 'https://spectrum.chat/home'
+  : 'http://localhost:3000/home';
 
 const googleAuthRouter = Router();
 

--- a/iris/routes/auth/twitter.js
+++ b/iris/routes/auth/twitter.js
@@ -4,7 +4,9 @@ import { URL } from 'url';
 import isSpectrumUrl from '../../utils/is-spectrum-url';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
-const FALLBACK_URL = IS_PROD ? '/home' : 'http://localhost:3000/home';
+const FALLBACK_URL = IS_PROD
+  ? 'https://spectrum.chat/home'
+  : 'http://localhost:3000/home';
 
 const twitterAuthRouter = Router();
 


### PR DESCRIPTION
Figured out why deploy auth was failing @mxstbr:

Our deploy urls are `spectrum-fooId.now.sh`. So when the request hit the server during an auth it saw this code:

```js
const FALLBACK_URL = IS_PROD
  ? '/home'
  : 'http://localhost:3000/home';

let url = FALLBACK_URL;
  if (req.query.r && isSpectrumUrl(req.query.r)) {
    url = req.query.r;
  }
```

Because `isSpectrumUrl` doesn't match when we're on a deploy preview, the fallback url was simply `/home`, which downstream when trying to be parsed by Node's `URL` parser, failed.

This is why nothing was breaking on production auth because `isSpectrumUrl` matched.

This fix just makes sure we always fall back to a proper url - the only problem with this solution is that when you log in to a deploy preview, it will redirect you to spectrum.chat. You'll have to just re-open the deploy preview url but you'll be properly signed in.