### PR TITLE
channelPendingUsers loader

### DIFF
--- a/iris/loaders/channel.js
+++ b/iris/loaders/channel.js
@@ -5,6 +5,7 @@ import {
   getChannelsMemberCounts,
 } from '../models/channel';
 import createLoader from './create-loader';
+import { getPendingUsersInChannels } from '../models/usersChannels';
 import type { Loader } from './types';
 
 export const __createChannelLoader = () =>
@@ -15,6 +16,9 @@ export const __createChannelThreadCountLoader = () =>
 
 export const __createChannelMemberCountLoader = () =>
   createLoader(channels => getChannelsMemberCounts(channels), 'group');
+
+export const __createChannelPendingMembersLoader = () =>
+  createLoader(channels => getPendingUsersInChannels(channels), 'group');
 
 export default () => {
   throw new Error(

--- a/iris/loaders/index.js
+++ b/iris/loaders/index.js
@@ -18,6 +18,7 @@ import {
   __createChannelLoader,
   __createChannelMemberCountLoader,
   __createChannelThreadCountLoader,
+  __createChannelPendingMembersLoader,
 } from './channel';
 import {
   __createCommunityLoader,
@@ -43,6 +44,7 @@ const createLoaders = () => ({
   channel: __createChannelLoader(),
   channelMemberCount: __createChannelMemberCountLoader(),
   channelThreadCount: __createChannelThreadCountLoader(),
+  channelPendingUsers: __createChannelPendingMembersLoader(),
   community: __createCommunityLoader(),
   communityBySlug: __createCommunityBySlugLoader(),
   communityRecurringPayments: __createCommunityRecurringPaymentsLoader(),

--- a/iris/models/usersChannels.js
+++ b/iris/models/usersChannels.js
@@ -472,6 +472,15 @@ const getPendingUsersInChannel = (
   );
 };
 
+const getPendingUsersInChannels = (channelIds: Array<string>) => {
+  return db
+    .table('usersChannels')
+    .getAll(...channelIds, { index: 'channelId' })
+    .group('channelId')
+    .filter({ isPending: true })
+    .run();
+};
+
 const getBlockedUsersInChannel = (
   channelId: string
 ): Promise<Array<string>> => {
@@ -592,4 +601,5 @@ module.exports = {
   getOwnersInChannel,
   getUserPermissionsInChannel,
   getUsersPermissionsInChannels,
+  getPendingUsersInChannels,
 };

--- a/iris/queries/channel.js
+++ b/iris/queries/channel.js
@@ -93,9 +93,10 @@ module.exports = {
       }));
     },
     pendingUsers: ({ id }: { id: string }, _, { loaders }) => {
-      return getPendingUsersInChannel(id).then(users =>
-        loaders.user.loadMany(users)
-      );
+      return loaders.channelPendingUsers
+        .load(id)
+        .then(res => res.reduction.map(rec => rec.userId))
+        .then(users => loaders.user.loadMany(users));
     },
     blockedUsers: ({ id }: { id: string }, _, { loaders }) => {
       return getBlockedUsersInChannel(id).then(users =>


### PR DESCRIPTION
For some reason this is fetched from the home community view for every
single channel and then never displayed, which is... suboptimal.
(even loads if you're not an admin, what)

Anyways, this implements a loader so it will be faster, but ideally we
shouldn't request this at all unless you go to the channel member view
and are a channel mod or something like that.