### PR TITLE
HOTFIX Message deletion

### DIFF
--- a/iris/models/message.js
+++ b/iris/models/message.js
@@ -15,7 +15,7 @@ export const getMessage = (messageId: string): Promise<Message> => {
     .get(messageId)
     .run()
     .then(message => {
-      if (message.deletedAt) return null;
+      if (!message || message.deletedAt) return null;
       return message;
     });
 };


### PR DESCRIPTION
Message deletion in communities you're not an owner of is currently broken, it would throw "Cannot read property deletedAt of null".

This patch fixes it.

User report:
https://spectrum.chat/thread/a402b421-d00e-4c84-825c-2225a2b462ec