### PR TITLE
Fix dynamic favicon always showing

### DIFF
--- a/src/components/head/index.js
+++ b/src/components/head/index.js
@@ -8,6 +8,7 @@ type Props = {
   image?: string,
 };
 
+let renderCount = 0;
 export default ({ title, description, showUnreadFavicon, image }: Props) => {
   return (
     <Helmet>
@@ -38,13 +39,14 @@ export default ({ title, description, showUnreadFavicon, image }: Props) => {
         <link
           rel="shortcut icon"
           id="dynamic-favicon"
-          href={`${process.env.PUBLIC_URL}/img/favicon_unread.ico`}
+          href={`${process.env
+            .PUBLIC_URL}/img/favicon_unread.ico?v=${renderCount++}`}
         />
       ) : (
         <link
           rel="shortcut icon"
           id="dynamic-favicon"
-          href={`${process.env.PUBLIC_URL}/img/favicon.ico`}
+          href={`${process.env.PUBLIC_URL}/img/favicon.ico?v=${renderCount++}`}
         />
       )}
     </Helmet>


### PR DESCRIPTION
Previously, even when all your notifications were read you would see the
unread favicon.

This patch fixes it by forcing the browser to re-download the favicon
every time, which is suboptimal but makes for a much nicer experience
for the user.

Taken from https://stackoverflow.com/a/7116701, closes #1819