### PR TITLE
Safeguard for duplicate records

### DIFF
--- a/athena/models/usersChannels.js
+++ b/athena/models/usersChannels.js
@@ -8,6 +8,7 @@ export const getMembersInChannelWithNotifications = (
     .table('usersChannels')
     .getAll(channelId, { index: 'channelId' })
     .filter({ isMember: true, receiveNotifications: true })
+    .group('userId')
     .run()
-    .then(users => users.map(user => user.userId));
+    .then(users => users.map(u => u.group));
 };


### PR DESCRIPTION
Had a user report that they were getting 10x emails for every thread published in a channel. Investigated and found that they had 10 `usersChannels` records for that channel - I have *no* clue how this is possible..

While I figure that out, this is a temporary safeguard on this notification type to prevent sending a notification to the same userId twice...:/