### PR TITLE
Fix bug with thread notifications and participant status

### DIFF
--- a/iris/mutations/message.js
+++ b/iris/mutations/message.js
@@ -1,5 +1,4 @@
 // @flow
-import Raven from 'raven';
 const debug = require('debug')('iris:mutations:message');
 import UserError from '../utils/UserError';
 import {
@@ -15,7 +14,6 @@ import {
 } from '../models/usersThreads';
 import { setUserLastSeenInDirectMessageThread } from '../models/usersDirectMessageThreads';
 import { getThread } from '../models/thread';
-import { getDirectMessageThread } from '../models/directMessageThread';
 import { getUserPermissionsInCommunity } from '../models/usersCommunities';
 import { getUserPermissionsInChannel } from '../models/usersChannels';
 import { uploadImage } from '../utils/s3';
@@ -155,7 +153,7 @@ module.exports = {
           communityPermissions.isModerator;
         if (!canModerate)
           throw new UserError(
-            `You don't have permission to delete this message.`
+            "You don't have permission to delete this message."
           );
       }
 
@@ -165,7 +163,7 @@ module.exports = {
         // We don't need to delete participants of direct message threads
         if (message.threadType === 'directMessageThread') return true;
 
-        debug(`thread message, check if user has more messages in thread`);
+        debug('thread message, check if user has more messages in thread');
         return userHasMessagesInThread(
           message.threadId,
           message.senderId


### PR DESCRIPTION
Closes #1951 

Problem: if you opted to receive notifications on a thread without having been a participant, then leaving a message on that thread later would never mark you as a participant. This has been fixed.