### PR TITLE
Hotfix new community view

### DIFF
--- a/src/components/avatar/index.js
+++ b/src/components/avatar/index.js
@@ -1,14 +1,9 @@
 // @flow
 import React, { Component } from 'react';
-// $FlowFixMe
 import compose from 'recompose/compose';
-// $FlowFixMe
 import styled from 'styled-components';
-// $FlowFixMe
 import { connect } from 'react-redux';
-// $FlowFixMe
 import { Link } from 'react-router-dom';
-// $FlowFixMe
 import { withRouter } from 'react-router';
 import { zIndex } from '../globals';
 import { Card } from '../card';
@@ -65,7 +60,7 @@ class HoverProfile extends Component<ProfileProps> {
       currentUser,
     } = this.props;
 
-    if (showProfile && (community || user)) {
+    if (showProfile && community) {
       if (community) {
         return (
           <HoverWrapper
@@ -109,7 +104,7 @@ class HoverProfile extends Component<ProfileProps> {
             </Container>
           </HoverWrapper>
         );
-      } else {
+      } else if (showProfile && user) {
         return (
           <HoverWrapper
             top={this.props.top ? true : this.props.bottom ? false : true}
@@ -232,7 +227,10 @@ const AvatarWithFallback = ({ style, ...props }) => (
 
 const Avatar = (props: Object): React$Element<any> => {
   const { src, community, user, size, link, noLink, showProfile } = props;
-  const source = src || community.profilePhoto || user.profilePhoto;
+  const source = src;
+
+  // $FlowFixMe
+  if (!source) return null;
 
   return (
     <StyledAvatarStatus size={props.size || 32} {...props}>

--- a/src/views/explore/view.js
+++ b/src/views/explore/view.js
@@ -175,10 +175,13 @@ class CollectionSwitcher extends Component {
           <TopCommunityList
             selected={this.state.selectedView === 'Top Communities'}
           />
-          {collections.map(collection => {
+          {collections.map((collection, index) => {
             const { title, categories } = collection;
             return (
-              <CategoryWrapper selected={this.state.selectedView === title}>
+              <CategoryWrapper
+                key={index}
+                selected={this.state.selectedView === title}
+              >
                 {categories.map((category, i) => {
                   return (
                     <Category


### PR DESCRIPTION
Just a heads up @uberbryn - in a lot of places the `community` prop passed into the avatar component is a boolean, not an object. So the flow typing here screwed us up a bit because we were calling `community.profilePhoto` on a boolean, which crashed the new community flow. I've hotfixed this out, but we need to refactor this to make sure that the proptypes are correct.

 This is a hacky hotfix and only solves the problem of the new community view crashing the app