### PR TITLE
Fix mention highlighting while typing in chatInput

### DIFF
--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -68,7 +68,12 @@ class ChatInput extends Component {
   }
 
   triggerFocus = () => {
-    this.editor.focus();
+    // NOTE(@mxstbr): This needs to be delayed for a tick, otherwise the
+    // decorators that are passed to the editor are removed from the editor
+    // state
+    setTimeout(() => {
+      this.editor && this.editor.focus();
+    }, 0);
   };
 
   toggleCodeMessage = () => {

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -22,6 +22,10 @@ export const ChatInputWrapper = styled(FlexRow)`
     position: relative;
     z-index: ${zIndex.mobileInput};
   }
+
+  a {
+    text-decoration: underline;
+  }
 `;
 
 export const Form = styled.form`


### PR DESCRIPTION
This took way too long to track down haha, but finally managed to make it work! :tada: 

Turns out the `triggerFocus` method was the root of all evil: We called it in the same tick as the decorators were applied by `draft-js-plugins`, so the decorators were overridden with nothing.

This fixes it by delaying the focus for a tick.

![screen shot 2017-11-13 at 11 47 33 am](https://user-images.githubusercontent.com/7525670/32722046-e82197bc-c868-11e7-9631-05a510f12471.png)
