### PR TITLE
Fix flashing favicon

### DIFF
--- a/src/components/head/index.js
+++ b/src/components/head/index.js
@@ -4,12 +4,11 @@ import Helmet from 'react-helmet';
 type Props = {
   title?: string,
   description?: string,
-  showUnreadFavicon?: boolean,
   image?: string,
+  children?: any,
 };
 
-let renderCount = 0;
-export default ({ title, description, showUnreadFavicon, image }: Props) => {
+export default ({ title, description, image, children }: Props) => {
   return (
     <Helmet>
       <title>{title}</title>
@@ -34,21 +33,7 @@ export default ({ title, description, showUnreadFavicon, image }: Props) => {
             : 'https://spectrum.chat/img/apple-icon-144x144-precomposed.png'
         }
       />
-
-      {showUnreadFavicon ? (
-        <link
-          rel="shortcut icon"
-          id="dynamic-favicon"
-          href={`${process.env
-            .PUBLIC_URL}/img/favicon_unread.ico?v=${renderCount++}`}
-        />
-      ) : (
-        <link
-          rel="shortcut icon"
-          id="dynamic-favicon"
-          href={`${process.env.PUBLIC_URL}/img/favicon.ico?v=${renderCount++}`}
-        />
-      )}
+      {children}
     </Helmet>
   );
 };

--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -436,7 +436,21 @@ class Navbar extends Component {
 
       return (
         <Nav hideOnMobile={hideNavOnMobile}>
-          <Head showUnreadFavicon={showUnreadFavicon} />
+          <Head>
+            {showUnreadFavicon ? (
+              <link
+                rel="shortcut icon"
+                id="dynamic-favicon"
+                href={`${process.env.PUBLIC_URL}/img/favicon_unread.ico`}
+              />
+            ) : (
+              <link
+                rel="shortcut icon"
+                id="dynamic-favicon"
+                href={`${process.env.PUBLIC_URL}/img/favicon.ico`}
+              />
+            )}
+          </Head>
 
           <Section left hideOnMobile>
             <LogoLink to="/">


### PR DESCRIPTION
Due to a misunderstanding of how `react-helmet` works I had to do an
ugly hack to make sure that our dynamic favicon updates correctly. That
hack resulted in the favicon flashing every time it would update, which
is suboptimal to say the least.

This patch fixes the dynamic favicon once and for all by correctly using
`react-helmet`.

The issue was that `react-helmet` only renders the latest version of a
certain tag if there's duplicates. For example, let's say you have
ComponentA which renders `<link rel="icon" href="a.ico" />` and
you have ComponentB which renders `<link rel="icon" href="b.ico" />`.

Depending on the order they're rendered in either `href="a.ico"` or `href="b.ico"` will be actually rendered to the browser DOM.

Due to us using a reusable `Head` component everytime we used that
component it would render a link to the favicon. In hindsight, it makes
total sense that this would break the favicon, as that means whatever is
the last component to render determines which favicon is selected: As
only the navbar actually knows if the unread favicon should be rendered
it was highly unlikely that the unread favicon would show at all. (I'm
kind of surprised that it has ever worked tbh, even with the hack)

This patch resolves it by only rendering any kind of favicon link from
the navbar, meaning nothing else will override it.

Closes #1865, this will likely have a small conflict with @brianlovin's ongoing work
in #2010 (sorry Brian!) I was just too excited that I finally figured
out why this didn't work as expected so I just had to knock the patch out.