### PR TITLE
Implement Apollo Engine

### DIFF
--- a/iris/routes/api/graphiql.js
+++ b/iris/routes/api/graphiql.js
@@ -1,5 +1,5 @@
 // @flow
-import { graphiqlExpress } from 'graphql-server-express';
+import { graphiqlExpress } from 'apollo-server-express';
 
 export default graphiqlExpress({
   endpointURL: '/api',

--- a/iris/routes/api/graphql.js
+++ b/iris/routes/api/graphql.js
@@ -1,5 +1,5 @@
 // @flow
-import { graphqlExpress } from 'graphql-server-express';
+import { graphqlExpress } from 'apollo-server-express';
 import createLoaders from '../../loaders/';
 
 import createErrorFormatter from '../../utils/create-graphql-error-formatter';
@@ -7,6 +7,8 @@ import schema from '../../schema';
 
 export default graphqlExpress(req => ({
   schema,
+  tracing: true,
+  cacheControl: true,
   formatError: createErrorFormatter(req),
   context: {
     user: req.user,

--- a/iris/routes/middlewares/compression.js
+++ b/iris/routes/middlewares/compression.js
@@ -1,0 +1,4 @@
+// @flow
+import compression from 'compression';
+
+export default compression();

--- a/iris/routes/middlewares/engine.js
+++ b/iris/routes/middlewares/engine.js
@@ -1,0 +1,21 @@
+// @flow
+import { Engine } from 'apollo-engine';
+
+const engine = new Engine({
+  engineConfig: {
+    apiKey: process.env.APOLLO_ENGINE_API_KEY,
+    sessionAuth: {
+      cookie: 'connect.sid',
+    },
+    logging: {
+      level: 'ERROR',
+    },
+  },
+  graphqlPort: 3001,
+  endpoint: '/api',
+});
+
+console.log('Apollo Engine started, proxying requests to the GraphQL API');
+engine.start();
+
+export default engine.expressMiddleware();

--- a/iris/routes/middlewares/index.js
+++ b/iris/routes/middlewares/index.js
@@ -12,6 +12,8 @@ if (process.env.NODE_ENV === 'production' && !process.env.FORCE_DEV) {
   const raven = require('./raven').default;
   middlewares.use(raven);
 }
+const engine = require('./engine').default;
+middlewares.use(engine);
 
 // Cross origin request support
 import cors from './cors';
@@ -36,5 +38,8 @@ middlewares.use(passport.session());
 // This needs to come after passport otherwise we'll always redirect logged-in users
 import threadParamRedirect from './thread-param';
 middlewares.use(threadParamRedirect);
+
+import compression from './compression';
+middlewares.use(compression);
 
 export default middlewares;

--- a/now.json
+++ b/now.json
@@ -23,6 +23,7 @@
 		"SLACK_SECRET": "@slack-secret",
 		"POSTMARK_SERVER_KEY": "@postmark-server-key",
 		"EMAIL_JWT_SIGNATURE": "@email-jwt-signature",
-		"PERSPECTIVE_API_KEY": "@perspective-api-key"
+		"PERSPECTIVE_API_KEY": "@perspective-api-key",
+        "APOLLO_ENGINE_API_KEY": "@apollo-engine-api-key"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "write-file-webpack-plugin": "^4.1.0"
   },
   "dependencies": {
+    "apollo-engine": "^0.5.4",
     "apollo-local-query": "^0.3.0",
+    "apollo-server-express": "^1.2.0",
     "apollo-upload-client": "^5.1.0",
     "apollo-upload-server": "^2.0.4",
     "axios": "^0.16.2",
@@ -51,6 +53,7 @@
     "body-parser": "^1.17.1",
     "bull": "3.3.1",
     "casual": "^1.5.12",
+    "compression": "^1.7.1",
     "cookie-parser": "^1.4.3",
     "cors": "^2.8.3",
     "dataloader": "^1.3.0",
@@ -75,7 +78,6 @@
     "flow-typed": "^2.1.5",
     "graphql-date": "^1.0.3",
     "graphql-log": "0.1.2",
-    "graphql-server-express": "0.8.x",
     "graphql-subscriptions": "0.4.x",
     "graphql-tools": "^0.11.0",
     "highlight.js": "^9.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,19 +8,6 @@
   dependencies:
     nan "^2.4.0"
 
-"@types/express-serve-static-core@*":
-  version "4.0.52"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.0.52.tgz#77ab67fffc402ff6e480c87c71d799ba79880223"
-  dependencies:
-    "@types/node" "*"
-
-"@types/express@^4.0.35":
-  version "4.0.37"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.0.37.tgz#625ac3765169676e01897ca47011c26375784971"
-  dependencies:
-    "@types/express-serve-static-core" "*"
-    "@types/serve-static" "*"
-
 "@types/graphql@0.10.2":
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.10.2.tgz#d7c79acbaa17453b6681c80c34b38fcb10c4c08c"
@@ -29,10 +16,6 @@
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.9.4.tgz#cdeb6bcbef9b6c584374b81aa7f48ecf3da404fa"
 
-"@types/mime@*":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.1.tgz#2cf42972d0931c1060c7d5fa6627fce6bd876f2f"
-
 "@types/node@*":
   version "8.0.28"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.28.tgz#86206716f8d9251cf41692e384264cbd7058ad60"
@@ -40,13 +23,6 @@
 "@types/node@^6.0.46":
   version "6.0.88"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
-
-"@types/serve-static@*":
-  version "1.7.32"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.7.32.tgz#0f6732e4dab0813771dd8fc8fe14940f34728b4c"
-  dependencies:
-    "@types/express-serve-static-core" "*"
-    "@types/mime" "*"
 
 "@types/ws@^3.0.0":
   version "3.0.2"
@@ -62,7 +38,7 @@ abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
 
-accepts@~1.3.3:
+accepts@~1.3.3, accepts@~1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.4.tgz#86246758c7dd6d21a6474ff084a4740ec05eb21f"
   dependencies:
@@ -221,6 +197,12 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
+apollo-cache-control@^0.0.x:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.0.7.tgz#ffef56413a429a1ce204be5b78d248c4fe3b67ac"
+  dependencies:
+    graphql-extensions "^0.0.x"
+
 apollo-client@^1.4.0, apollo-client@^1.9.1:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-1.9.2.tgz#a95b38ca846e881bba1b59b0e3fbf82abfd7f23d"
@@ -235,6 +217,29 @@ apollo-client@^1.4.0, apollo-client@^1.9.1:
   optionalDependencies:
     "@types/graphql" "0.10.2"
 
+apollo-engine-binary-darwin@^0.2017.11-40-g9585bfc6:
+  version "0.2017.11-59-g4ff40ec30"
+  resolved "https://registry.yarnpkg.com/apollo-engine-binary-darwin/-/apollo-engine-binary-darwin-0.2017.11-59-g4ff40ec30.tgz#cd9fd14befe98d6cb2a3ff3fb865e051a0f2d531"
+
+apollo-engine-binary-linux@^0.2017.11-40-g9585bfc6:
+  version "0.2017.11-59-g4ff40ec30"
+  resolved "https://registry.yarnpkg.com/apollo-engine-binary-linux/-/apollo-engine-binary-linux-0.2017.11-59-g4ff40ec30.tgz#90fcc36b3de538eb5231ed217ee8cdf1b052bbaa"
+
+apollo-engine-binary-windows@^0.2017.11-40-g9585bfc6:
+  version "0.2017.11-59-g4ff40ec30"
+  resolved "https://registry.yarnpkg.com/apollo-engine-binary-windows/-/apollo-engine-binary-windows-0.2017.11-59-g4ff40ec30.tgz#2723645fa314633a2def155e8d8d961de35b9028"
+
+apollo-engine@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/apollo-engine/-/apollo-engine-0.5.4.tgz#0679d3e802389f1dd5808540f09b6543e9aabe23"
+  dependencies:
+    request "^2.81.0"
+    stream-line-wrapper "^0.1.1"
+  optionalDependencies:
+    apollo-engine-binary-darwin "^0.2017.11-40-g9585bfc6"
+    apollo-engine-binary-linux "^0.2017.11-40-g9585bfc6"
+    apollo-engine-binary-windows "^0.2017.11-40-g9585bfc6"
+
 apollo-link-core@^0.5.0:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/apollo-link-core/-/apollo-link-core-0.5.4.tgz#8efd4cd747959872a32f313f0ccfc2a76b396668"
@@ -248,6 +253,31 @@ apollo-local-query@^0.3.0:
   resolved "https://registry.yarnpkg.com/apollo-local-query/-/apollo-local-query-0.3.0.tgz#8f4be210a6a1d07caf61662a555c6c38e2ac2858"
   dependencies:
     debug "2.3.3"
+
+apollo-server-core@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-1.2.0.tgz#e851c47444991b6f89f88529237076b83e01e8ee"
+  dependencies:
+    apollo-cache-control "^0.0.x"
+    apollo-tracing "^0.1.0"
+    graphql-extensions "^0.0.x"
+
+apollo-server-express@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-1.2.0.tgz#026b12b453b8ecac6044b205b6a85fe596fb5f9e"
+  dependencies:
+    apollo-server-core "^1.2.0"
+    apollo-server-module-graphiql "^1.2.0"
+
+apollo-server-module-graphiql@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-module-graphiql/-/apollo-server-module-graphiql-1.2.0.tgz#899d84f3b747795dbbfc8354aa51622ef038151c"
+
+apollo-tracing@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.1.1.tgz#7a5707543fc102f81cda7ba45b98331a82a6750b"
+  dependencies:
+    graphql-extensions "^0.0.x"
 
 apollo-upload-client@^5.1.0:
   version "5.1.1"
@@ -458,6 +488,10 @@ async@^2.1.2, async@^2.1.4, async@^2.4.1:
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
     lodash "^4.14.0"
+
+async@~0.2.10:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -2155,6 +2189,12 @@ compressible@~2.0.10:
   dependencies:
     mime-db ">= 1.29.0 < 2"
 
+compressible@~2.0.11:
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.12.tgz#c59a5c99db76767e9876500e271ef63b3493bd66"
+  dependencies:
+    mime-db ">= 1.30.0 < 2"
+
 compression@^1.5.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.0.tgz#030c9f198f1643a057d776a738e922da4373012d"
@@ -2166,6 +2206,18 @@ compression@^1.5.2:
     on-headers "~1.0.1"
     safe-buffer "5.1.1"
     vary "~1.1.1"
+
+compression@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.1.tgz#eff2603efc2e22cf86f35d2eb93589f9875373db"
+  dependencies:
+    accepts "~1.3.4"
+    bytes "3.0.0"
+    compressible "~2.0.11"
+    debug "2.6.9"
+    on-headers "~1.0.1"
+    safe-buffer "5.1.1"
+    vary "~1.1.2"
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -2265,7 +2317,7 @@ core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
@@ -4335,32 +4387,19 @@ graphql-date@^1.0.3:
   dependencies:
     assert-err "^1.0.0"
 
+graphql-extensions@^0.0.x:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.0.5.tgz#63bc4a3fd31aab12bfadf783cbc038a9a6937cf0"
+  dependencies:
+    core-js "^2.5.1"
+    source-map-support "^0.5.0"
+
 graphql-log@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/graphql-log/-/graphql-log-0.1.2.tgz#d733fc58b14cbb336effa2bb355274d13683c6b5"
   dependencies:
     deep-for-each "^1.0.6"
     is-function "^1.0.1"
-
-graphql-server-core@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/graphql-server-core/-/graphql-server-core-0.8.5.tgz#6d03e9d7d0ceebdbcfbad57c9f8a61eb0d3fb6da"
-  optionalDependencies:
-    "@types/graphql" "^0.9.0"
-
-graphql-server-express@0.8.x:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/graphql-server-express/-/graphql-server-express-0.8.5.tgz#e5038d914166479b9a5a75bacde287eb56ff291d"
-  dependencies:
-    graphql-server-core "^0.8.5"
-    graphql-server-module-graphiql "^0.8.5"
-  optionalDependencies:
-    "@types/express" "^4.0.35"
-    "@types/graphql" "^0.9.1"
-
-graphql-server-module-graphiql@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/graphql-server-module-graphiql/-/graphql-server-module-graphiql-0.8.5.tgz#bf43caa20e7e7f912003a67bb31710c6ebc7ab18"
 
 graphql-subscriptions@0.4.x, graphql-subscriptions@^0.4.3:
   version "0.4.4"
@@ -6812,6 +6851,10 @@ miller-rabin@^4.0.0:
 "mime-db@>= 1.29.0 < 2", mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+
+"mime-db@>= 1.30.0 < 2":
+  version "1.31.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.31.0.tgz#a49cd8f3ebf3ed1a482b60561d9105ad40ca74cb"
 
 mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.7:
   version "2.1.17"
@@ -9325,6 +9368,12 @@ source-map-resolve@^0.5.0:
   dependencies:
     source-map "^0.5.6"
 
+source-map-support@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.0.tgz#2018a7ad2bdf8faf2691e5fddab26bed5a2bacab"
+  dependencies:
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -9342,6 +9391,10 @@ source-map@^0.4.4:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spawn-sync@^1.0.15:
   version "1.0.15"
@@ -9472,6 +9525,12 @@ stream-http@^2.3.1:
     readable-stream "^2.2.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-line-wrapper@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/stream-line-wrapper/-/stream-line-wrapper-0.1.1.tgz#3e2be1d368c6356f90aeef64786683f3eee3eea7"
+  dependencies:
+    async "~0.2.10"
 
 stream-to-buffer@~0.0.1:
   version "0.0.1"
@@ -10235,6 +10294,10 @@ value-equal@^0.4.0:
 vary@^1, vary@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
+
+vary@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
 vendors@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Engine supports query batching since the last release (yay!), so I
figured we might as well implement it now.

Note that this does not implement any caching yet, it just enables
Engine so we can get the nice performance overviews again that we had
with Optics. I'll do the caching stuff in another PR.