### PR TITLE
Fix DraftJS on Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "cors": "^2.8.3",
     "dataloader": "^1.3.0",
     "debug": "^2.6.8",
-    "draft-js": "^0.10.2",
+    "draft-js": "npm:draft-js-fork-mxstbr",
     "draft-js-code-editor-plugin": "0.2.1",
     "draft-js-drag-n-drop-plugin": "2.0.0-rc9",
     "draft-js-embed-plugin": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3001,7 +3001,15 @@ draft-js@0.x:
     immutable "~3.7.4"
     object-assign "^4.1.0"
 
-draft-js@^0.10.2, draft-js@~0.10.0, draft-js@~0.10.1:
+"draft-js@npm:draft-js-fork-mxstbr":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/draft-js-fork-mxstbr/-/draft-js-fork-mxstbr-0.10.4.tgz#4c8258799280f7cf66a2aa54fb094965389348ab"
+  dependencies:
+    fbjs "^0.8.15"
+    immutable "~3.7.4"
+    object-assign "^4.1.0"
+
+draft-js@~0.10.0, draft-js@~0.10.1:
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.2.tgz#b722613cb306cfee910f9de1789f2cc3023772e7"
   dependencies:


### PR DESCRIPTION
Somebody submitted 5 line patch upstream to DraftJS which (should) fix
DraftJS on Android. (https://github.com/facebook/draft-js/pull/1500)

I tested this locally and it works super well on my phone, so I pulled
the repo locally and deployed a quick fork. This PR just sets the
package `draft-js` to install the fork based on that PR instead.

Note that this isn't any kind of long-term solution, but it finally
fixes the problem and let's me respond to messages from my phone, so I
say fuck long-term and let's ship this.