### PR TITLE
Fix URL and Mentions regexps

### DIFF
--- a/shared/regexps.js
+++ b/shared/regexps.js
@@ -1,4 +1,4 @@
 // @flow
 
-module.exports.MENTIONS = /\B@[a-z0-9_-]+/gi;
-module.exports.URL = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-]*)?\??(?:[\-\+=&;%@\.\w]*)#?(?:[\.\!\/\\\w]*))?)/g;
+module.exports.MENTIONS = /(\s|^)@[a-z0-9_-]+/gi;
+module.exports.URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/gi;

--- a/src/components/draftjs-editor/mentions-decorator.js
+++ b/src/components/draftjs-editor/mentions-decorator.js
@@ -8,7 +8,22 @@ const mentionDecorator = {
   strategy: (
     contentBlock: ContentBlock,
     callback: (...args?: Array<any>) => any
-  ) => findWithRegex(MENTIONS, contentBlock, callback),
+  ) => {
+    // -> "@brian_lovin, what's up with @mxstbr?"
+    const text = contentBlock.getText();
+    // -> ["@brian_lovin", " @mxstbr"];
+    const matches = text.match(MENTIONS);
+    if (!matches || matches.length === 0) return;
+
+    matches.forEach(match => {
+      // Because JS Regexps don't have lookbehinds we have to include the whitespace before the mention in the regex match
+      // The .trim here makes sure we don't highlight that whitespace as a mention
+      // -> " @mxstbr" -> "@mxstbr"
+      const mention = match.trim();
+      const start = text.indexOf(mention);
+      callback(start, start + mention.length);
+    });
+  },
   component: Mention,
 };
 


### PR DESCRIPTION
This fixes issues with Medium URLs which would highlight as a mention
instead of as a URL.

Closes #1993, also closes #1833