### PR TITLE
Add a nice lil' animation to the dashboard thread feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "react-app-rewired": "^1.0.5",
     "react-clipboard.js": "^1.1.3",
     "react-dom": "^15.4.1",
+    "react-flip-move": "^2.10.1",
     "react-helmet": "5.x",
     "react-infinite-scroller-with-scroll-element": "^1.0.4",
     "react-loadable": "5.2.2",

--- a/src/views/dashboard/components/threadFeed.js
+++ b/src/views/dashboard/components/threadFeed.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 // NOTE(@mxstbr): This is a custom fork published of off this (as of this writing) unmerged PR: https://github.com/CassetteRocks/react-infinite-scroller/pull/38
 // I literally took it, renamed the package.json and published to add support for scrollElement since our scrollable container is further outside
 import InfiniteList from 'react-infinite-scroller-with-scroll-element';
+import FlipMove from 'react-flip-move';
 import { sortByDate } from '../../../helpers/utils';
 import { LoadingInboxThread } from '../../../components/loading';
 import { changeActiveThread } from '../../../actions/dashboardFeed';
@@ -255,17 +256,19 @@ class ThreadFeed extends React.Component<Props, State> {
           scrollElement={scrollElement}
           threshold={750}
         >
-          {filteredThreads.map(thread => {
-            return (
-              <InboxThread
-                key={thread.id}
-                data={thread}
-                active={selectedId === thread.id}
-                hasActiveCommunity={this.props.hasActiveCommunity}
-                hasActiveChannel={this.props.hasActiveChannel}
-              />
-            );
-          })}
+          <FlipMove duration={350}>
+            {filteredThreads.map(thread => {
+              return (
+                <InboxThread
+                  key={thread.id}
+                  data={thread}
+                  active={selectedId === thread.id}
+                  hasActiveCommunity={this.props.hasActiveCommunity}
+                  hasActiveChannel={this.props.hasActiveChannel}
+                />
+              );
+            })}
+          </FlipMove>
         </InfiniteList>
       </div>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8261,6 +8261,10 @@ react-error-overlay@^2.0.1:
     settle-promise "1.0.0"
     source-map "0.5.6"
 
+react-flip-move@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/react-flip-move/-/react-flip-move-2.10.1.tgz#a641ad897cecff2b81520062cebfec286cf11261"
+
 react-helmet@5.x:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"


### PR DESCRIPTION
You'll see a nice little animation when a message is posted thread moves to the top or a new
thread is published!

Up for discussion whether you want this, but I saw `react-flip-move` and it's just so simple to integrate I couldn't resist.

## Release notes

- Add some nice animations to the thread list in the dashboard
  