### PR TITLE
Parallelise thread.creator

### DIFF
--- a/iris/queries/thread/creator.js
+++ b/iris/queries/thread/creator.js
@@ -7,11 +7,9 @@ export default async (
   _: any,
   { loaders }: GraphQLContext
 ) => {
-  const creator = await loaders.user.load(creatorId);
-
-  const permissions = await loaders.userPermissionsInCommunity.load([
-    creatorId,
-    communityId,
+  const [creator, permissions] = await Promise.all([
+    loaders.user.load(creatorId),
+    loaders.userPermissionsInCommunity.load([creatorId, communityId]),
   ]);
 
   return {


### PR DESCRIPTION
This can be fetched in parallel. Looking at our Engine stats, `thread.creator` is one of the slower parts of the system, likely due to the staggered nature of these two queries. (this is based on #2256)