### PR TITLE
Cleanup pending message state

### DIFF
--- a/src/components/message/index.js
+++ b/src/components/message/index.js
@@ -52,6 +52,7 @@ class Message extends Component {
       context,
       selectedId,
       changeSelection,
+      pending,
     } = this.props;
 
     const parsedMessage =
@@ -61,8 +62,6 @@ class Message extends Component {
     const emojiOnly = parsedMessage && onlyContainsEmoji(parsedMessage);
     const actionable = context !== 'notification';
     const shareable = message.threadType !== 'directMessageThread';
-    const reactable = typeof message.id === 'string';
-    const hideIndicator = !reactable && !shareable && !canModerate;
 
     return (
       <Wrapper
@@ -74,7 +73,6 @@ class Message extends Component {
           id={message.id}
           me={me}
           type={emojiOnly ? 'emoji' : message.messageType}
-          pending={message.id < 0}
           openGallery={() => this.toggleOpenGallery(message.id)}
           message={emojiOnly ? parsedMessage : message.content}
         />
@@ -85,20 +83,18 @@ class Message extends Component {
             currentUser={currentUser}
             canModerate={canModerate}
             deleteMessage={this.deleteMessage}
-            hideIndicator={hideIndicator}
-            isOptimisticMessage={message.id < 0}
+            isOptimisticMessage={pending}
           >
-            {reaction &&
-              reactable && (
-                <Reaction
-                  message={message}
-                  toggleReaction={toggleReaction}
-                  me={me}
-                  currentUser={currentUser}
-                  dispatch={dispatch}
-                  reaction={reaction}
-                />
-              )}
+            {reaction && (
+              <Reaction
+                message={message}
+                toggleReaction={toggleReaction}
+                me={me}
+                currentUser={currentUser}
+                dispatch={dispatch}
+                reaction={reaction}
+              />
+            )}
           </Actions>
         )}
       </Wrapper>

--- a/src/components/message/view.js
+++ b/src/components/message/view.js
@@ -36,40 +36,29 @@ const messageRenderer = {
 };
 
 export const Body = props => {
-  const { message, openGallery, pending, type, me } = props;
+  const { message, openGallery, type, me } = props;
 
   switch (type) {
     case 'text':
     default:
-      return (
-        <Text me={me} pending={pending}>
-          {message.body}
-        </Text>
-      );
+      return <Text me={me}>{message.body}</Text>;
     case 'media':
       return (
         <Image
           onClick={openGallery}
-          pending={pending}
-          src={`${message.body}${pending
-            ? ''
-            : `?max-w=${window.innerWidth * 0.6}`}`}
+          src={`${message.body}?max-w=${window.innerWidth * 0.6}`}
         />
       );
     case 'emoji':
-      return <Emoji pending={pending}>{message}</Emoji>;
+      return <Emoji>{message}</Emoji>;
     case 'draftjs':
       const body = JSON.parse(message.body);
       const isCode = body.blocks[0].type === 'code-block';
 
       if (isCode) {
-        return <Code pending={pending}>{redraft(body, codeRenderer)}</Code>;
+        return <Code>{redraft(body, codeRenderer)}</Code>;
       } else {
-        return (
-          <Text me={me} pending={pending}>
-            {redraft(body, messageRenderer)}
-          </Text>
-        );
+        return <Text me={me}>{redraft(body, messageRenderer)}</Text>;
       }
   }
 };
@@ -120,8 +109,7 @@ export const Actions = props => {
         !isOptimisticMessage && (
           <Action me={me} action={'delete'} deleteMessage={deleteMessage} />
         )}
-      {hideIndicator ||
-        (!isOptimisticMessage && <Indicator reaction={reaction} me={me} />)}
+      <Indicator reaction={reaction} me={me} />
     </ActionUI>
   );
 };


### PR DESCRIPTION
Rather than hiding the action indicator when a message isn't yet
persisted to the server, we now only hide the "delete" button since you
can't delete a message that hasn't persisted yet.

This means it's much less obvious that a message wasn't sent yet unless
you hover over it and check if the delete button is there, making the
mutation feel much much faster.

Also did a bunch of cleanup of passing that prop around and computing it
again when we weren't even using it anymore in any of the
view-components apart from the actions.

## Will deploy

- [ ] iris
- [x] hyperion
- [ ] athena
- [ ] vulcan
- [ ] mercury
- [ ] hermes
- [ ] chronos