### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,14 @@
-### Deployment notes
-- 
+### Deploy after merge (delete what needn't be deployed)
+- iris
+- hyperion
+- athena
+- vulcan
+- mercury
+- hermes
+- chronos
 
-### Will deploy
-- [ ] iris
-- [ ] hyperion
-- [ ] athena
-- [ ] vulcan
-- [ ] mercury
-- [ ] hermes
-- [ ] chronos
-
-### Run database migration?
-- [ ] yes
-- [ ] no
+### Run database migrations (delete if not)
+YES
 
 ## Release notes
 -


### PR DESCRIPTION
The checklist-style for deployment made the pr overview screen really
useless because every PR now had a checklist associated with it.

Instead, let's just delete the servers that don't need deployment from
the list. Same thing for the db migrations, if people need to run one
after merging leave the section in, otherwise delete it.

This is what it looks like when rendered:

- iris
- hyperion
- athena
- vulcan
- mercury
- hermes
- chronos

YES

-