### PR TITLE
Start Apollo engine after webserver

### DIFF
--- a/iris/index.js
+++ b/iris/index.js
@@ -10,6 +10,7 @@ import { createServer } from 'http';
 import express from 'express';
 import Raven from 'shared/raven';
 import { init as initPassport } from './authentication.js';
+import engine from './routes/middlewares/engine';
 const PORT = 3001;
 import type { DBUser } from 'shared/types';
 
@@ -50,9 +51,13 @@ const subscriptionsServer = createSubscriptionsServer(server, '/websocket');
 
 // Start webserver
 server.listen(PORT);
-
-// Start database listeners
 console.log(`GraphQL server running at http://localhost:${PORT}/api`);
+
+if (process.env.NODE_ENV === 'production') {
+  // Start Apollo Engine
+  console.log('Apollo Engine starting...');
+  engine.start();
+}
 
 process.on('unhandledRejection', async err => {
   console.error('Unhandled rejection', err);

--- a/iris/routes/middlewares/index.js
+++ b/iris/routes/middlewares/index.js
@@ -10,8 +10,6 @@ if (process.env.NODE_ENV === 'development') {
 // Start apollo engine
 if (process.env.NODE_ENV === 'production' && !process.env.FORCE_DEV) {
   const engine = require('./engine').default;
-  console.log('Apollo Engine starting...');
-  engine.start();
   middlewares.use(engine.expressMiddleware());
 }
 


### PR DESCRIPTION
Zeit ends the deployment process as soon as a port is opened. Apollo
Engine opens a port to proxy the requests through to the API, but really
we don't want Zeit to finish the deployment process until the whole
server is instantiated and the API is running.

This patch moves Apollo Engine starting to happen after the API server
is already running.

- [x] iris
- [ ] hyperion
- [ ] athena
- [ ] vulcan
- [ ] mercury
- [ ] hermes
- [ ] chronos