### PR TITLE
Prevent disaster

### DIFF
--- a/admin/src/components/globals/index.js
+++ b/admin/src/components/globals/index.js
@@ -49,7 +49,8 @@ export const Transition = {
 };
 
 export const fontStack = css`
-	font-family: -apple-system, BlinkMacSystemFont, 'Helvetica', 'Segoe', sans-serif
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica', 'Segoe',
+    sans-serif;
 `;
 
 const spin = keyframes`
@@ -59,7 +60,7 @@ const spin = keyframes`
 export const Spinner = styled.span`
   width: ${props => (props.size ? `${props.size}px` : '32px')};
   height: ${props => (props.size ? `${props.size}px` : '32px')};
-  
+
   &:before {
     content: '';
     box-sizing: border-box;
@@ -74,8 +75,11 @@ export const Spinner = styled.span`
     margin-left: ${props =>
       props.size !== undefined ? `-${props.size / 2}px` : '-8px'};
     border-radius: 50%;
-    border: ${props => '2px'} solid ${props =>
-  props.color ? eval(`props.theme.${props.color}`) : props.theme.brand.alt};
+    border: ${props => '2px'} solid
+      ${props =>
+        props.color
+          ? eval(`props.theme.${props.color}`)
+          : props.theme.brand.alt};
     border-top-color: transparent;
     border-right-color: ${props =>
       props.color ? `props.theme.${props.color}` : props.theme.brand.alt};
@@ -94,9 +98,9 @@ export const Label = styled.label`
   letter-spacing: -0.4px;
   color: ${({ theme }) => theme.text.default};
 
-	&:not(:first-of-type) {
-		margin-top: 1.5rem;
-	}
+  &:not(:first-of-type) {
+    margin-top: 1.5rem;
+  }
 
   a {
     text-decoration: underline;
@@ -113,7 +117,7 @@ export const PrefixLabel = styled.label`
   color: ${({ theme }) => theme.text.placeholder};
 
   > input {
-  	margin-left: 2px;
+    margin-left: 2px;
   }
 `;
 
@@ -132,16 +136,21 @@ export const Input = styled.input`
   ${props =>
     props.type === 'checkbox' &&
     css`
-    flex: initial;
-    width: initial;
-    margin-right: 0.5rem;
-  `}
-
-  &::placeholder { color: ${({ theme }) => theme.text.placeholder} }
-  &::-webkit-input-placeholder { color: ${({ theme }) =>
-    theme.text.placeholder} }
-  &:-moz-placeholder { color: ${({ theme }) => theme.text.placeholder} }
-  &:-ms-input-placeholder { color: ${({ theme }) => theme.text.placeholder} }
+      flex: initial;
+      width: initial;
+      margin-right: 0.5rem;
+    `} &::placeholder {
+    color: ${({ theme }) => theme.text.placeholder};
+  }
+  &::-webkit-input-placeholder {
+    color: ${({ theme }) => theme.text.placeholder};
+  }
+  &:-moz-placeholder {
+    color: ${({ theme }) => theme.text.placeholder};
+  }
+  &:-ms-input-placeholder {
+    color: ${({ theme }) => theme.text.placeholder};
+  }
 
   &:focus {
     border-color: ${({ theme }) => theme.brand.default};
@@ -149,8 +158,8 @@ export const Input = styled.input`
 `;
 
 export const TextArea = styled.textarea`
-	flex: 1 0 auto;
-	width: 100%;
+  flex: 1 0 auto;
+  width: 100%;
   background: ${({ theme }) => theme.bg.default};
   font-weight: 500;
   font-size: 0.875rem;
@@ -160,11 +169,18 @@ export const TextArea = styled.textarea`
   margin-top: 0.125rem;
   box-shadow: none;
 
-  &::placeholder { color: ${({ theme }) => theme.text.placeholder} }
-  &::-webkit-input-placeholder { color: ${({ theme }) =>
-    theme.text.placeholder} }
-  &:-moz-placeholder { color: ${({ theme }) => theme.text.placeholder} }
-  &:-ms-input-placeholder { color: ${({ theme }) => theme.text.placeholder} }
+  &::placeholder {
+    color: ${({ theme }) => theme.text.placeholder};
+  }
+  &::-webkit-input-placeholder {
+    color: ${({ theme }) => theme.text.placeholder};
+  }
+  &:-moz-placeholder {
+    color: ${({ theme }) => theme.text.placeholder};
+  }
+  &:-ms-input-placeholder {
+    color: ${({ theme }) => theme.text.placeholder};
+  }
 
   &:focus {
     border-color: ${({ theme }) => theme.brand.default};
@@ -172,10 +188,10 @@ export const TextArea = styled.textarea`
 `;
 
 export const UnderlineInput = styled.input`
-		font-size: inherit;
-		font-weight: inherit;
-		color: ${({ theme }) => theme.text.default};
-    border-bottom: 0.125rem solid ${({ theme }) => theme.inactive};
+  font-size: inherit;
+  font-weight: inherit;
+  color: ${({ theme }) => theme.text.default};
+  border-bottom: 0.125rem solid ${({ theme }) => theme.inactive};
 
   &:focus {
     border-color: ${({ theme }) => theme.brand.default};
@@ -183,91 +199,91 @@ export const UnderlineInput = styled.input`
 `;
 
 export const H1 = styled.h1`
-	${fontStack};
-	color: ${({ theme }) => theme.text.default};
-	font-weight: 900;
-	font-size: 1.5rem;
-	line-height: 1.25;
-	margin: 0;
-	padding: 0;
+  ${fontStack};
+  color: ${({ theme }) => theme.text.default};
+  font-weight: 900;
+  font-size: 1.5rem;
+  line-height: 1.25;
+  margin: 0;
+  padding: 0;
 `;
 
 export const H2 = styled.h2`
-	color: ${({ theme }) => theme.text.default};
-	${fontStack};
-	font-weight: 700;
-	font-size: 1.25rem;
-	line-height: 1.25;
-	margin: 0;
-	padding: 0;
+  color: ${({ theme }) => theme.text.default};
+  ${fontStack};
+  font-weight: 700;
+  font-size: 1.25rem;
+  line-height: 1.25;
+  margin: 0;
+  padding: 0;
 `;
 
 export const H3 = styled.h3`
-	color: ${({ theme }) => theme.text.default};
-	${fontStack};
-	font-weight: 500;
-	font-size: 1rem;
-	line-height: 1.5;
-	margin: 0;
-	padding: 0;
+  color: ${({ theme }) => theme.text.default};
+  ${fontStack};
+  font-weight: 500;
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0;
 `;
 
 export const H4 = styled.h4`
-	color: ${({ theme }) => theme.text.default};
-	${fontStack};
-	font-weight: 500;
-	font-size: 0.875rem;
-	line-height: 1.4;
-	margin: 0;
-	padding: 0;
+  color: ${({ theme }) => theme.text.default};
+  ${fontStack};
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  margin: 0;
+  padding: 0;
 `;
 
 export const H5 = styled.h5`
-	color: ${({ theme }) => theme.text.default};
-	${fontStack};
-	font-weight: 500;
-	font-size: 0.75rem;
-	line-height: 1.4;
-	margin: 0;
-	padding: 0;
+  color: ${({ theme }) => theme.text.default};
+  ${fontStack};
+  font-weight: 500;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  margin: 0;
+  padding: 0;
 `;
 
 export const H6 = styled.h6`
-	color: ${({ theme }) => theme.text.default};
-	${fontStack};
-	font-weight: 600;
-	text-transform: uppercase;
-	font-size: 0.675rem;
-	line-height: 1.5;
-	margin: 0;
-	padding: 0;
+  color: ${({ theme }) => theme.text.default};
+  ${fontStack};
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.675rem;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0;
 `;
 
 export const P = styled.p`
-	color: ${({ theme }) => theme.text.default};
-	${fontStack};
-	font-weight: 400;
-	font-size: 0.875rem;
-	line-height: 1.4;
-	margin: 0;
-	padding: 0;
+  color: ${({ theme }) => theme.text.default};
+  ${fontStack};
+  font-weight: 400;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  margin: 0;
+  padding: 0;
 `;
 
 export const Span = styled.span`
-	color: ${({ theme }) => theme.text.default};
-	${fontStack};
-	font-weight: 400;
-	font-size: 0.875rem;
-	line-height: 1.4;
-	margin: 0;
-	padding: 0;
+  color: ${({ theme }) => theme.text.default};
+  ${fontStack};
+  font-weight: 400;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  margin: 0;
+  padding: 0;
 `;
 
 export const FlexRow = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-  align-items: center
+  align-items: center;
 `;
 
 export const FlexCol = styled.div`
@@ -289,9 +305,9 @@ const returnTooltip = props => {
             right: calc(50% - 5px);
             bottom: 100%
       	    border-bottom-width: 0;
-      	    border-top-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+      	    border-top-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'top-right':
@@ -304,9 +320,9 @@ const returnTooltip = props => {
             left: calc(50% - 5px);
             bottom: 100%;
       	    border-bottom-width: 0;
-      	    border-top-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+      	    border-top-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'right':
@@ -321,9 +337,9 @@ const returnTooltip = props => {
             left: 100%;
             top: calc(50% - 5px);
             border-left-width: 0;
-            border-right-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+            border-right-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'bottom-left':
@@ -336,9 +352,9 @@ const returnTooltip = props => {
             right: calc(50% - 5px);
             top: 100%
       	    border-top-width: 0;
-      	    border-bottom-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+      	    border-bottom-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'bottom-right':
@@ -351,9 +367,9 @@ const returnTooltip = props => {
             right: calc(50% - 5px);
             top: 100%;
       	    border-top-width: 0;
-      	    border-bottom-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+      	    border-bottom-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'left':
@@ -367,41 +383,43 @@ const returnTooltip = props => {
             right: 100%;
             top: calc(50% - 5px);
             border-right-width: 0;
-            border-left-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+            border-left-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
   }
 };
 
 export const Tooltip = props => css`
-	position: relative;
+  position: relative;
 
-	&:after,
-	&:before {
-		line-height: 1;
+  &:after,
+  &:before {
+    line-height: 1;
     user-select: none;
     pointer-events: none;
     position: absolute;
     opacity: 0;
     display: block;
     text-transform: none;
-	}
+  }
 
-	&:before {
-		content: '';
+  &:before {
+    content: '';
     z-index: 9999;
     border: 5px solid transparent;
   }
 
-	&:after {
-		content: ${props.tipText && !props.onboarding ? `'${props.tipText}'` : `''`};
+  &:after {
+    content: ${props.tipText && !props.onboarding
+      ? `'${CSS.escape(props.tipText)}'`
+      : `''`};
     z-index: 9998;
     ${fontStack};
     font-size: 14px;
     font-weight: 500;
-		min-width: 3em;
+    min-width: 3em;
     max-width: 21em;
     white-space: nowrap;
     overflow: hidden;
@@ -411,14 +429,14 @@ export const Tooltip = props => css`
     box-shadow: ${Shadow.mid} ${hexa(props.theme.bg.reverse, 0.25)};
     background: ${props.theme.bg.reverse};
     color: ${props.theme.text.reverse};
-	}
+  }
 
   ${props.tipText && !props.onboarding ? returnTooltip(props) : ''};
 
-	&:hover:after,
-	&:hover:before {
-		opacity: 1;
-		transition: all 0.1s ease-in 0.1s;
+  &:hover:after,
+  &:hover:before {
+    opacity: 1;
+    transition: all 0.1s ease-in 0.1s;
   }
 `;
 
@@ -456,8 +474,8 @@ export const Onboarding = props => css`
     padding-left: 20px;
     border-radius: 12px;
     background-color: ${props.theme.bg.default};
-    background: ${props.theme.bg
-      .default} url(/img/goopy-top.svg) center top no-repeat;
+    background: ${props.theme.bg.default} url(/img/goopy-top.svg) center top
+      no-repeat;
     background-size: 100%;
     color: ${props.theme.text.default};
     box-shadow: 0 8px 32px rgba(23, 26, 33, 0.35);
@@ -491,5 +509,4 @@ export const HorizontalRule = styled(FlexRow)`
   div {
     margin: 0 16px;
   }
-
 `;

--- a/src/components/globals/index.js
+++ b/src/components/globals/index.js
@@ -343,9 +343,9 @@ const returnTooltip = props => {
             right: 0;
             transform: translateX(-100%);
       	    border-bottom-width: 0;
-      	    border-top-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+      	    border-top-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'top-right':
@@ -359,9 +359,9 @@ const returnTooltip = props => {
             left: 0;
             transform: translateX(100%);
       	    border-bottom-width: 0;
-      	    border-top-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+      	    border-top-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'top':
@@ -376,9 +376,9 @@ const returnTooltip = props => {
             left: 50%;
             transform: translateX(-50%);
             border-bottom-width: 0;
-            border-top-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+            border-top-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'right':
@@ -393,9 +393,9 @@ const returnTooltip = props => {
             top: calc(50% - 5px);
             left: 100%;
             border-left-width: 0;
-            border-right-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+            border-right-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'bottom-left':
@@ -409,9 +409,9 @@ const returnTooltip = props => {
             right: 0;
             transform: translateX(-100%);
       	    border-top-width: 0;
-      	    border-bottom-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+      	    border-bottom-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'bottom-right':
@@ -425,9 +425,9 @@ const returnTooltip = props => {
             left: 0;
             transform: translateX(100%);
       	    border-top-width: 0;
-      	    border-bottom-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+      	    border-bottom-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
     case 'bottom':
@@ -442,9 +442,9 @@ const returnTooltip = props => {
           left: 50%;
           transform: translateX(-50%);
           border-bottom-width: 0;
-          border-top-color: ${props.onboarding
-            ? props.theme.brand.alt
-            : props.theme.bg.reverse};
+          border-top-color: ${
+            props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+          };
         }
       `;
     case 'left':
@@ -458,9 +458,9 @@ const returnTooltip = props => {
             right: 100%;
             top: calc(50% - 5px);
             border-right-width: 0;
-            border-left-color: ${props.onboarding
-              ? props.theme.brand.alt
-              : props.theme.bg.reverse};
+            border-left-color: ${
+              props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
+            };
           }
       `;
   }
@@ -488,7 +488,7 @@ export const Tooltip = props => css`
 
   &:after {
     content: ${props.tipText && !props.onboarding
-      ? `'${props.tipText}'`
+      ? `'${CSS.escape(props.tipText)}'`
       : `''`};
     z-index: ${zIndex.tooltip};
     ${fontStack};


### PR DESCRIPTION
@uberbryn @mxstbr - we were putting user generated input into the css directly, so the apostrophe stopped styles from loading; this is why I saw the crazy weird behavior I did in those videos and screenshots. This resolves the issue, and babel should be doing it's job to backfill the `CSS.escape()` function for unsupported browsers (I tested this in Safari, which is unsupported, but it worked because babel)

