### PR TITLE
Fix subscriptions 

### DIFF
--- a/iris/package.json
+++ b/iris/package.json
@@ -110,7 +110,7 @@
     "stripe": "^4.15.0",
     "striptags": "2.x",
     "styled-components": "2.1.2",
-    "subscriptions-transport-ws": "0.8",
+    "subscriptions-transport-ws": "^0.9.5",
     "sw-precache-webpack-plugin": "^0.11.4",
     "then-queue": "^1.3.0",
     "validator": "^9.0.0",

--- a/iris/yarn.lock
+++ b/iris/yarn.lock
@@ -3209,7 +3209,7 @@ graphql-server-express@1.3.0:
   dependencies:
     apollo-server-express "^1.3.0"
 
-graphql-subscriptions@0.4.x, graphql-subscriptions@^0.4.4:
+graphql-subscriptions@0.4.x:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-0.4.4.tgz#39cff32d08dd3c990113864bab77154403727e9b"
   dependencies:
@@ -6772,14 +6772,12 @@ stylis@^3.0.0, stylis@^3.2.1, stylis@^3.4.0:
   version "3.4.8"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.8.tgz#94380babbcd4c75726215794ca985b38ec96d1a3"
 
-subscriptions-transport-ws@0.8:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.8.3.tgz#d4b22db7f5951bd30e7c6f4dc4774d34ed9f1751"
+subscriptions-transport-ws@^0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.5.tgz#faa9eb1230d5f2efe355368cd973b867e4483c53"
   dependencies:
     backo2 "^1.0.2"
     eventemitter3 "^2.0.3"
-    graphql-subscriptions "^0.4.4"
-    graphql-tag "^2.4.2"
     iterall "^1.1.1"
     lodash.assign "^4.2.0"
     lodash.isobject "^3.0.2"


### PR DESCRIPTION
This fixes the "Cannot read property 'then' of undefined" error we've
been getting in prod constantly. Ref issue: apollographql/subscriptions-transport-ws#277

Fixes #2305, fixes #2310

I'm going to fast-forward deploy this change so we can be sure it works.