### PR TITLE
Send more metadata to Spectrum AI for moderation

### DIFF
--- a/athena/queues/moderationEvents/message.js
+++ b/athena/queues/moderationEvents/message.js
@@ -42,8 +42,11 @@ export default async (job: JobData) => {
     joinedCommunityAt: permissions.createdAt,
     joinedSpectrumAt: user.createdAt,
     reputation: permissions.reputation,
-    communityRole:
-      permissions.isOwner || permissions.isModerator || permissions.isMember,
+    communityRole: permissions.isOwner
+      ? 'owner'
+      : permissions.isModerator
+        ? 'moderator'
+        : permissions.isMember ? 'member' : null,
   };
 
   const scores = await Promise.all([

--- a/athena/queues/moderationEvents/message.js
+++ b/athena/queues/moderationEvents/message.js
@@ -42,6 +42,8 @@ export default async (job: JobData) => {
     joinedCommunityAt: permissions.createdAt,
     joinedSpectrumAt: user.createdAt,
     reputation: permissions.reputation,
+    communityRole:
+      permissions.isOwner || permissions.isModerator || permissions.isMember,
   };
 
   const scores = await Promise.all([

--- a/athena/queues/moderationEvents/spectrum.js
+++ b/athena/queues/moderationEvents/spectrum.js
@@ -1,7 +1,7 @@
 // @flow
 import axios from 'axios';
 
-export default async (text: string, contextId: string, userId: string) => {
+export default async (text: string, contextId: string, meta: Object) => {
   const request = await axios({
     method: 'post',
     url: 'https://api.prod.getspectrum.io/api/v1/classification',
@@ -15,7 +15,7 @@ export default async (text: string, contextId: string, userId: string) => {
       params: {
         text: text,
         meta: {
-          authorId: userId,
+          ...meta,
         },
       },
       id: contextId,

--- a/athena/queues/moderationEvents/thread.js
+++ b/athena/queues/moderationEvents/thread.js
@@ -44,6 +44,8 @@ export default async (job: JobData) => {
     joinedCommunityAt: permissions.createdAt,
     joinedSpectrumAt: user.createdAt,
     reputation: permissions.reputation,
+    communityRole:
+      permissions.isOwner || permissions.isModerator || permissions.isMember,
   };
 
   const scores = await Promise.all([

--- a/athena/queues/moderationEvents/thread.js
+++ b/athena/queues/moderationEvents/thread.js
@@ -44,8 +44,11 @@ export default async (job: JobData) => {
     joinedCommunityAt: permissions.createdAt,
     joinedSpectrumAt: user.createdAt,
     reputation: permissions.reputation,
-    communityRole:
-      permissions.isOwner || permissions.isModerator || permissions.isMember,
+    communityRole: permissions.isOwner
+      ? 'owner'
+      : permissions.isModerator
+        ? 'moderator'
+        : permissions.isMember ? 'member' : null,
   };
 
   const scores = await Promise.all([


### PR DESCRIPTION
### Deploy after merge (delete what needn't be deployed)
- athena

Note @mxstbr @uberbryn  -

I had lunch today with the other Spectrum guys (for moderation stuff). We were just talking through how everything is going so far - overall I told them that our models with them are too sensitive still, so they'll keep working on it.

But we also came up with some interesting data points we could use to start training our model better. Specifically the following:
- by sending a `communityId` along with each message and thread, we can build models around which communities are most toxic over time
- by sending a `joinedCommunityAt` timestamp we can model a score based on how long that user was in the community (where more recent timestamps have a higher negative impact on the score)
- by sending a `joinedSpectrumAt` timestamp - same as above
- by sending a `reputation` score, we can model around the context of the user in particular where lower scores have a negative impact on the toxicity calculation
- by sending a `role` score we can model around that user's particular role in a community; e.g. 'owner' might carry more positive weight than 'member'

Overall I'm pretty excited about this kind of stuff - eventually what we're working towards is a pretty powerful and comprehensive way to slice and dice our moderation tooling; as we add more capabilities on our end we can feed that data into their models (for example, when we have the ability to report content on spectrum, we can pass a `reporterId` to their algorithm to start to surface patterns around who is reporting what)

This requires some API work on their end to accept the extra metadata, so just hold this PR for now