### PR TITLE
Fix pagination bug on website

### DIFF
--- a/src/views/thread/index.js
+++ b/src/views/thread/index.js
@@ -404,6 +404,7 @@ class ThreadContainer extends React.Component<Props, State> {
                     scrollContainer={this.state.messagesContainer}
                     currentUser={currentUser}
                     lastSeen={thread.currentUserLastSeen}
+                    lastActive={thread.lastActive}
                     forceScrollToBottom={this.forceScrollToBottom}
                     forceScrollToTop={this.forceScrollToTop}
                     contextualScrollToBottom={this.contextualScrollToBottom}


### PR DESCRIPTION
\### Deploy after merge (delete what needn't be deployed)
- hyperion

\## Release notes
- Fixed a bug where pagination would hide messages outside of watercooler threads

This would cause only watercoolers to be properly paginated by `lastSeen`.