### PR TITLE
Update dev secrets

### DIFF
--- a/iris/authentication.js
+++ b/iris/authentication.js
@@ -7,11 +7,39 @@ const { Strategy: GoogleStrategy } = require('passport-google-oauth2');
 const { Strategy: GitHubStrategy } = require('passport-github2');
 const { getUser, createOrFindUser } = require('./models/user');
 
-let TWITTER_OAUTH_CLIENT_SECRET = process.env.TWITTER_OAUTH_CLIENT_SECRET;
-let FACEBOOK_OAUTH_CLIENT_ID = process.env.FACEBOOK_OAUTH_CLIENT_ID;
-let FACEBOOK_OAUTH_CLIENT_SECRET = process.env.FACEBOOK_OAUTH_CLIENT_SECRET;
-let GOOGLE_OAUTH_CLIENT_SECRET = process.env.GOOGLE_OAUTH_CLIENT_SECRET;
-let GITHUB_OAUTH_CLIENT_SECRET = process.env.GITHUB_OAUTH_CLIENT_SECRET;
+const IS_PROD = !process.env.FORCE_DEV && process.env.NODE_ENV === 'production';
+
+const TWITTER_OAUTH_CLIENT_SECRET = IS_PROD
+  ? process.env.TWITTER_OAUTH_CLIENT_SECRET
+  : process.env.TWITTER_OAUTH_CLIENT_SECRET_DEVELOPMENT;
+
+const FACEBOOK_OAUTH_CLIENT_ID = IS_PROD
+  ? process.env.FACEBOOK_OAUTH_CLIENT_ID
+  : process.env.FACEBOOK_OAUTH_CLIENT_SECRET_DEVELOPMENT;
+
+const FACEBOOK_OAUTH_CLIENT_SECRET = IS_PROD
+  ? process.env.FACEBOOK_OAUTH_CLIENT_SECRET
+  : process.env.FACEBOOK_OAUTH_CLIENT_SECRET_DEVELOPMENT;
+
+const GOOGLE_OAUTH_CLIENT_SECRET = IS_PROD
+  ? process.env.GOOGLE_OAUTH_CLIENT_SECRET
+  : process.env.GOOGLE_OAUTH_CLIENT_SECRET_DEVELOPMENT;
+
+const GITHUB_OAUTH_CLIENT_SECRET = IS_PROD
+  ? process.env.GITHUB_OAUTH_CLIENT_SECRET
+  : process.env.GITHUB_OAUTH_CLIENT_SECRET_DEVELOPMENT;
+
+const TWITTER_OAUTH_CLIENT_ID = IS_PROD
+  ? 'vxmsICGyIIoT5NEYi1I8baPrf'
+  : 'Qk7BWFe44JKswEw2sNaDAA4x7';
+
+const GOOGLE_OAUTH_CLIENT_ID = IS_PROD
+  ? '923611718470-chv7p9ep65m3fqqjr154r1p3a5j6oidc.apps.googleusercontent.com'
+  : '923611718470-hjribk5128dr3s26cbp5cbdecigrsjsp.apps.googleusercontent.com';
+
+const GITHUB_OAUTH_CLIENT_ID = IS_PROD
+  ? '208a2e8684d88883eded'
+  : 'ed3e924f4a599313c83b';
 
 const init = () => {
   // Setup use serialization
@@ -35,7 +63,7 @@ const init = () => {
   passport.use(
     new TwitterStrategy(
       {
-        consumerKey: 'vxmsICGyIIoT5NEYi1I8baPrf',
+        consumerKey: TWITTER_OAUTH_CLIENT_ID,
         consumerSecret: TWITTER_OAUTH_CLIENT_SECRET,
         callbackURL: '/auth/twitter/callback',
         includeEmail: true,
@@ -163,8 +191,7 @@ const init = () => {
   passport.use(
     new GoogleStrategy(
       {
-        clientID:
-          '923611718470-chv7p9ep65m3fqqjr154r1p3a5j6oidc.apps.googleusercontent.com',
+        clientID: GOOGLE_OAUTH_CLIENT_ID,
         clientSecret: GOOGLE_OAUTH_CLIENT_SECRET,
         callbackURL: '/auth/google/callback',
       },
@@ -230,7 +257,7 @@ const init = () => {
   passport.use(
     new GitHubStrategy(
       {
-        clientID: '208a2e8684d88883eded',
+        clientID: GITHUB_OAUTH_CLIENT_ID,
         clientSecret: GITHUB_OAUTH_CLIENT_SECRET,
         callbackURL: '/auth/github/callback',
         scope: ['user'],

--- a/now.json
+++ b/now.json
@@ -23,6 +23,11 @@
 		"FACEBOOK_OAUTH_CLIENT_SECRET": "@facebook-oauth-client-secret",
 		"GOOGLE_OAUTH_CLIENT_SECRET": "@google-oauth-client-secret",
 		"GITHUB_OAUTH_CLIENT_SECRET": "@github-oauth-client-secret",
+		"TWITTER_OAUTH_CLIENT_SECRET_DEVELOPMENT": "@twitter-oauth-client-secret-development",
+		"FACEBOOK_OAUTH_CLIENT_ID_DEVELOPMENT": "@facebook-oauth-client-id-development",
+		"FACEBOOK_OAUTH_CLIENT_SECRET_DEVELOPMENT": "@facebook-oauth-client-secret-development",
+		"GOOGLE_OAUTH_CLIENT_SECRET_DEVELOPMENT": "@google-oauth-client-secret-development",
+		"GITHUB_OAUTH_CLIENT_SECRET_DEVELOPMENT": "@github-oauth-client-secret-development",
 		"SLACK_SECRET": "@slack-secret",
 		"POSTMARK_SERVER_KEY": "@postmark-server-key",
 		"EMAIL_JWT_SIGNATURE": "@email-jwt-signature",
@@ -30,6 +35,6 @@
 		"SESSION_COOKIE_SECRET": "@session-cookie-secret",
 		"ALGOLIA_APP_ID": "@algolia-app-id",
 		"ALGOLIA_API_SECRET": "@algolia-api-secret",
-        "APOLLO_ENGINE_API_KEY": "@apollo-engine-api-key"
+		"APOLLO_ENGINE_API_KEY": "@apollo-engine-api-key"
 	}
 }


### PR DESCRIPTION
Hey guys, have had a long-running thread with the Google Verification team because some of our users were seeing warnings that we were an unverified developer; anyways, they *finally* told me that they couldn't verify us because we had `localhost` as a valid callback url which they can't verify what we're doing with the data. Kinda makes sense, I guess? Whatever.

I've gone ahead and went through our oAuth methods and created a *separate* development application with their own secrets and client ids. These are what will be used to sign in locally, and shouldn't impact production in any way.

Secrets have already been added to now, you'll want to grab the latest `now-secrets` off of 1Password.

Local FB auth still doesn't work for me, but I don't give a shit that much right now :P