### PR TITLE
Remove error'ed queues from async iterators

### DIFF
--- a/iris/utils/asyncify.js
+++ b/iris/utils/asyncify.js
@@ -6,7 +6,7 @@ const asyncify = (
   listener: (...args: any[]) => any,
   onError?: Error => void
 ) => {
-  const queues = [];
+  let queues = [];
   listener((...args) => queues.map(q => q.push(...args)));
 
   return () => {
@@ -21,6 +21,8 @@ const asyncify = (
           yield await queue.pop();
         }
       } catch (err) {
+        // Remove the error'ing queue from the queues array
+        queues = queues.filter(q => q !== queue);
         onError && onError(err);
       }
     }


### PR DESCRIPTION
According to @ForbesLindsay (the author of `then-queue` and who helped me write our `asyncify` util in the first place) this is the only thing that jumps out to him in our code that might leak memory: We never remove queues if they error.

He also said that the code Babel generates from Async Iterators might not handle infinite (or at least very long) streams well, so I might investigate that later if #2379 doesn't fix our memory leak issues.

Ref #2375 

### Deploy after merge (delete what needn't be deployed)
- iris

