### PR TITLE
Fix queues

### DIFF
--- a/shared/bull/queues.js
+++ b/shared/bull/queues.js
@@ -115,7 +115,7 @@ EventEmitter.defaultMaxListeners =
 // Create all the queues, export an object with all the queues
 const queues: Queues = Object.keys(exports.QUEUE_NAMES).reduce(
   (queues, name) => {
-    queues[name] = createQueue(name);
+    queues[name] = createQueue(exports.QUEUE_NAMES[name]);
     return queues;
   },
   {}


### PR DESCRIPTION
### Deploy after merge (delete what needn't be deployed)
- iris

@mxstbr note the change in queues logic - we were creating queues with the name like `sendEmailValidationEmailQueue` instead of `send email validation email`

This meant that every queue listener in the workers wasn't receiving events because the names were mismatched.

