### PR TITLE
Add client side thread deduplication in feeds

### DIFF
--- a/src/components/threadFeed/index.js
+++ b/src/components/threadFeed/index.js
@@ -234,6 +234,10 @@ class ThreadFeedPure extends Component {
       );
     }
 
+    const uniqueThreads = filteredThreads.filter(
+      (val, i, self) => self.indexOf(val) === i
+    );
+
     if (dataExists) {
       return (
         <Threads data-e2e-id="thread-feed">
@@ -276,7 +280,7 @@ class ThreadFeedPure extends Component {
             scrollElement={scrollElement}
             threshold={750}
           >
-            {filteredThreads.map(thread => {
+            {uniqueThreads.map(thread => {
               return (
                 <InboxThread
                   key={thread.id}

--- a/src/views/dashboard/components/threadFeed.js
+++ b/src/views/dashboard/components/threadFeed.js
@@ -273,6 +273,10 @@ class ThreadFeed extends React.Component<Props, State> {
       );
     }
 
+    const uniqueThreads = filteredThreads.filter(
+      (val, i, self) => self.indexOf(val) === i
+    );
+
     return (
       <div
         data-e2e-id="inbox-thread-feed"
@@ -309,7 +313,7 @@ class ThreadFeed extends React.Component<Props, State> {
           threshold={750}
         >
           <FlipMove duration={350}>
-            {filteredThreads.map(thread => {
+            {uniqueThreads.map(thread => {
               return (
                 <InboxThread
                   key={thread.id}


### PR DESCRIPTION
### Deploy after merge (delete what needn't be deployed)
- hyperion

## Release notes
- Fixes a bug where threads would appear twice in the inbox feed

---

This is a bit hard to test, but I *think* this works.

