### PR TITLE
Disable Engine reporting in dev properly

### DIFF
--- a/iris/index.js
+++ b/iris/index.js
@@ -20,6 +20,12 @@ const engine = new ApolloEngine({
     level: 'WARN',
   },
   apiKey: process.env.APOLLO_ENGINE_API_KEY,
+  // Only send perf data to the remote server in production
+  reporting: {
+    disabled: process.env.NODE_ENV !== 'production',
+    hostname: process.env.NOW_URL || undefined,
+    privateHeaders: ['authorization', 'Authorization', 'AUTHORIZATION'],
+  },
 });
 
 // Initialize authentication

--- a/iris/routes/api/graphql.js
+++ b/iris/routes/api/graphql.js
@@ -12,9 +12,7 @@ import schema from '../../schema';
 export default graphqlExpress(req => ({
   schema,
   formatError: createErrorFormatter(req),
-  // Only add tracing information in production, otherwise Apollo Engine would send
-  // performance data of development machines to the remote server which is not what we want
-  tracing: process.env.NODE_ENV === 'production',
+  tracing: true,
   context: {
     user: req.user,
     loaders: createLoaders(),


### PR DESCRIPTION
Based on reports by @glasser in the Apollo Slack this is the right way
:tm: to turn off Engine perf reporting in dev

Also makes sure we don't send sensitive headers to Engine.