### PR TITLE
Consistent linkification in messages

### DIFF
--- a/shared/clients/draft-js/links-decorator/core.js
+++ b/shared/clients/draft-js/links-decorator/core.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
-import findWithRegex from 'find-with-regex';
-import { URL } from 'shared/regexps';
+import linkStrategy from 'draft-js-linkify-plugin/lib/linkStrategy';
 import normalizeUrl from '../../../normalize-url';
 import type { ContentBlock } from 'draft-js/lib/ContentBlock';
 import type { ComponentType, Node } from 'react';
@@ -20,10 +19,7 @@ let i = 0;
 const createLinksDecorator = (
   Component: ComponentType<LinksDecoratorComponentProps>
 ) => ({
-  strategy: (
-    contentBlock: ContentBlock,
-    callback: (...args?: Array<any>) => any
-  ) => findWithRegex(URL, contentBlock, callback),
+  strategy: linkStrategy,
   component: ({ decoratedText, children }: DecoratorComponentProps) => (
     <Component
       href={normalizeUrl(decoratedText)}


### PR DESCRIPTION
\### Deploy after merge (delete what needn't be deployed)
- hyperion

\## Release notes
- Improved URL detection for linkification in message bubbles

Previously, linkification in rendered (!) messages was totally different
from linkification in the chat input and the thread editor.

This makes them consistent, so if you type github.com/bla in a message
it gets rendered as a link in both the chat input and the rendered
bubble.

Note that this uses a list of TLDs under the hood, so things like
"spectrum.chat/figma" are linkified while "nota.urlextensions" won't be.