### PR TITLE
Dont show new messages badge when thread is active

### DIFF
--- a/src/views/dashboard/components/inboxThread.js
+++ b/src/views/dashboard/components/inboxThread.js
@@ -87,6 +87,8 @@ class InboxThread extends React.Component<Props> {
     }
 
     if (currentUserLastSeen && lastActive && currentUserLastSeen < lastActive) {
+      if (active) return defaultMessageCountString;
+
       return (
         <MetaTextPill offset={participants.length} active={active} new>
           New messages!


### PR DESCRIPTION
### Deploy after merge (delete what needn't be deployed)
- hyperion

Annoying to see 'new messages' when you're viewing the thread