### PR TITLE
Fix Iris connecting to the db twice

### DIFF
--- a/athena/utils/push-notifications/send-web-push-notification.js
+++ b/athena/utils/push-notifications/send-web-push-notification.js
@@ -1,51 +1,17 @@
 // @flow
 const debug = require('debug')('athena:utils:web-push');
-import webPush from 'web-push';
+import sendWebPush from 'shared/send-web-push-notification';
 import { removeSubscription } from '../../models/web-push-subscription';
-
-try {
-  webPush.setVapidDetails(
-    'https://spectrum.chat',
-    process.env.VAPID_PUBLIC_KEY,
-    process.env.VAPID_PRIVATE_KEY
-  );
-  console.log('Web push notifications enabled!');
-} catch (err) {}
 
 export const sendWebPushNotification = (
   subscription: any,
   payload: Object | string,
   options?: ?Object
-): Promise<Object> => {
-  if (!subscription || !payload) {
-    debug(
-      'No subscription or payload provided to sendWebPushNotification, not pushing anything.'
-    );
-    return Promise.resolve({});
-  }
-  if (process.env.NODE_ENV === 'development') {
-    debug('not sending web push notification in development');
-    return Promise.resolve({});
-  } else {
-    debug('send web push notification');
-  }
-
-  const pl =
-    typeof payload === 'string'
-      ? payload
-      : JSON.stringify({
-          ...payload,
-          raw: undefined,
-        });
-  return webPush
-    .sendNotification(subscription, pl, {
-      TTL: 86400, // Default TTL: One day
-      ...options,
-    })
-    .catch(err => {
-      if (err.statusCode === 410 && err.endpoint) {
-        debug(`old subscription found (${err.endpoint}), removing`, err);
-        return removeSubscription(err.endpoint);
-      }
-    });
+): Promise<?Object> => {
+  return sendWebPush(subscription, payload, options).catch(err => {
+    if (err.statusCode === 410 && err.endpoint) {
+      debug(`old subscription found (${err.endpoint}), removing`, err);
+      return removeSubscription(err.endpoint);
+    }
+  });
 };

--- a/iris/mutations/user/subscribeWebPush.js
+++ b/iris/mutations/user/subscribeWebPush.js
@@ -3,7 +3,7 @@ import type { GraphQLContext } from '../../';
 import type { WebPushSubscription } from './';
 import UserError from '../../utils/UserError';
 import { storeSubscription } from '../../models/web-push-subscription';
-import { sendWebPushNotification } from 'athena/utils/push-notifications/send-web-push-notification';
+import sendWebPushNotification from 'shared/send-web-push-notification';
 
 export default (
   _: any,

--- a/shared/send-web-push-notification.js
+++ b/shared/send-web-push-notification.js
@@ -1,0 +1,43 @@
+// @flow
+const debug = require('debug')('shared:send-web-push');
+import webPush from 'web-push';
+
+try {
+  webPush.setVapidDetails(
+    'https://spectrum.chat',
+    process.env.VAPID_PUBLIC_KEY,
+    process.env.VAPID_PRIVATE_KEY
+  );
+  console.log('Web push notifications enabled!');
+} catch (err) {}
+
+export default (
+  subscription: any,
+  payload: Object | string,
+  options?: ?Object
+): Promise<Object> => {
+  if (!subscription || !payload) {
+    debug(
+      'No subscription or payload provided to sendWebPushNotification, not pushing anything.'
+    );
+    return Promise.resolve({});
+  }
+  if (process.env.NODE_ENV === 'development') {
+    debug('not sending web push notification in development');
+    return Promise.resolve({});
+  } else {
+    debug('send web push notification');
+  }
+
+  const pl =
+    typeof payload === 'string'
+      ? payload
+      : JSON.stringify({
+          ...payload,
+          raw: undefined,
+        });
+  return webPush.sendNotification(subscription, pl, {
+    TTL: 86400, // Default TTL: One day
+    ...options,
+  });
+};


### PR DESCRIPTION
\### Deploy after merge (delete what needn't be deployed)
- iris

We were importing a file from athena in iris which was importing a db
query in athena which was importing `athena/models/db`. That's bad
because it means we were connecting to RethinkDB twice unnecessarily.

Fixed by moving that file to shared. We should really finally move our db queries from iris to shared eh...