### PR TITLE
Plug the memory leak and stop the db connections from crashing

### DIFF
--- a/iris/models/directMessageThread.js
+++ b/iris/models/directMessageThread.js
@@ -80,9 +80,7 @@ const hasChanged = (field: string) =>
     .ne(db.row('new_val')(field));
 const THREAD_LAST_ACTIVE_CHANGED = hasChanged('threadLastActive');
 
-const listenToUpdatedDirectMessageThreads = (userId: string) => (
-  cb: Function
-): Function => {
+const listenToUpdatedDirectMessageThreads = (cb: Function): Function => {
   return db
     .table('directMessageThreads')
     .changes({
@@ -90,7 +88,6 @@ const listenToUpdatedDirectMessageThreads = (userId: string) => (
     })
     .filter(NEW_DOCUMENTS.or(THREAD_LAST_ACTIVE_CHANGED))('new_val')
     .eqJoin('id', db.table('usersDirectMessageThreads'), { index: 'threadId' })
-    .filter({ right: { userId } })
     .without({
       right: ['id', 'createdAt', 'threadId', 'lastActive', 'lastSeen'],
     })

--- a/iris/models/message.js
+++ b/iris/models/message.js
@@ -149,13 +149,9 @@ export const storeMessage = (
     });
 };
 
-export const listenToNewMessagesInThread = (threadId: string) => (
-  cb: Function
-): Function => {
+export const listenToNewMessages = (cb: Function): Function => {
   return db
     .table('messages')
-    .getAll(threadId, { index: 'threadId' })
-    .filter(db.row.hasFields('deletedAt').not())
     .changes({
       includeInitial: false,
     })

--- a/iris/models/notification.js
+++ b/iris/models/notification.js
@@ -62,16 +62,13 @@ const hasChanged = (field: string) =>
 
 const MODIFIED_AT_CHANGED = hasChanged('entityAddedAt');
 
-export const listenToNewNotifications = (userId: string) => (
-  cb: Function
-): Function => {
+export const listenToNewNotifications = (cb: Function): Function => {
   return db
     .table('usersNotifications')
     .changes({
       includeInitial: false,
     })
     .filter(NEW_DOCUMENTS.or(MODIFIED_AT_CHANGED))('new_val')
-    .filter({ userId })
     .eqJoin('notificationId', db.table('notifications'))
     .without({
       left: ['notificationId', 'createdAt', 'id', 'entityAddedAt'],
@@ -81,16 +78,13 @@ export const listenToNewNotifications = (userId: string) => (
     .run(eachAsyncNewValue(cb));
 };
 
-export const listenToNewDirectMessageNotifications = (userId: string) => (
-  cb: Function
-) => {
+export const listenToNewDirectMessageNotifications = (cb: Function) => {
   return db
     .table('usersNotifications')
     .changes({
       includeInitial: false,
     })
     .filter(NEW_DOCUMENTS.or(MODIFIED_AT_CHANGED))('new_val')
-    .filter({ userId })
     .eqJoin('notificationId', db.table('notifications'))
     .without({
       left: ['notificationId', 'createdAt', 'id', 'entityAddedAt'],

--- a/iris/models/thread.js
+++ b/iris/models/thread.js
@@ -505,17 +505,12 @@ const hasChanged = (field: string) =>
     .ne(db.row('new_val')(field));
 const LAST_ACTIVE_CHANGED = hasChanged('lastActive');
 
-export const listenToUpdatedThreads = (channelIds: Array<string>) => (
-  cb: Function
-): Function => {
+export const listenToUpdatedThreads = (cb: Function): Function => {
   return db
     .table('threads')
     .changes({
       includeInitial: false,
     })
-    .filter(NEW_DOCUMENTS.or(LAST_ACTIVE_CHANGED))
-    .filter(thread =>
-      db.expr(channelIds).contains(thread('new_val')('channelId'))
-    )('new_val')
+    .filter(NEW_DOCUMENTS.or(LAST_ACTIVE_CHANGED))('new_val')
     .run(eachAsyncNewValue(cb));
 };


### PR DESCRIPTION
**TL;DR: Rework our asyncify util and all the subscriptions once more to
both plug the memory leak and stop our db connections from crashing.**

Yesterday, while just sitting around and daydreaming I finally saw the
light and understood why the shit that has been happening with our API
has been happening.

There are two phases to this story: The first phase is the
phase of memory leaks and the second phase is the more recent one of
database connection errors.

We had those memory leaks, investigated them and implemented a bunch of  (mostly) superficial patches (toobusy handling, better errors, connection status indicator on website, etc.) on top because we couldn't get to the bottom of the issue.

Then I reworked our entire subscriptions setup so that each user would get one changefeed per subscription. That worked beautifully to fix the memory leaks,
but unfortunately we started getting errors of db connections dropping. Thanks to @thelinuxlich I
realized that those were happening because it turns out changefeeds
don't scale well, especially not to hundreds at a time.

This patch fixes the connection dropping by reverting back to a setup
similar to our earlier version where we only have 4 changefeeds total
and then filter the live results on the server per listener.

Now you might be thinking "Hold on but didn't we have memory leaks
then?", and we totally did and the great thing is that I realised why:
The old `asyncify` util would buffer incoming live results. It would
buffer all incoming results for any subscriber that came after. That
means after six hours of production traffic we'd have buffered hundreds
of messages and threads in memory, which led to the server running out
of memory, which led to it crashing.

So this time, I've reworked our asyncify util again but without that
buffering, which means we'll have the stability of the connections by
only having 4 changefeed open, but we also won't have memory leaks. Win
win! :tada:

### Deploy after merge (delete what needn't be deployed)
- iris

## Release notes
- Further improved stability of the site