### PR TITLE
Update PR template and add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--
+FILL OUT THE FORM BELOW OR THE ISSUE WILL BE AUTO-CLOSED
+
+**Issue Type (check one)**
+
+- [ ] Bug Report
+- [ ] Feature Idea
+- [ ] Technical Discussion
+- [ ] Question (these will be auto-closed, please ask them on Spectrum instead https://spectrum.chat/spectrum/open)
+-->
+
+**Description (type any text below)**
+
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,22 @@
-### Deploy after merge (delete what needn't be deployed)
-- iris
-- hyperion
+<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
+**Status**
+- [ ] WIP
+- [ ] Ready for review
+- [ ] Needs testing
+
+**Deploy after merge (delete what needn't be deployed)**
+- iris (api)
+- hyperion (frontend)
 - athena
 - vulcan
 - mercury
 - hermes
 - chronos
+- mobile
 
-### Run database migrations (delete if not)
+**Run database migrations (delete if no migration was added)**
 YES
 
-## Release notes
+**Release notes for users (delete if codebase-only change)**
 -
 
-<!--
-### Labels
-
-Please check the checkboxes below for any labels you want assigned to the PR:
-
-- [ ] WIP
-- [ ] Ready for review
-- [ ] Needs testing
-
--->


### PR DESCRIPTION
Make the PR and issue templates more clear to outside contributors when they come. Note that all of this required/auto-close stuff will be waived for us three and any future employees, and also isn't implemented yet.

Changed PR Template:

```md
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [ ] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- iris (api)
- hyperion (frontend)
- athena
- vulcan
- mercury
- hermes
- chronos
- mobile

**Run database migrations (delete if no migration was added)**
YES

**Release notes for users (delete if codebase-only change)**
-
```

Added issue template:

```
<!--
FILL OUT THE FORM BELOW OR THE ISSUE WILL BE AUTO-CLOSED

**Issue Type (check one)**

- [ ] Bug Report
- [ ] Feature Idea
- [ ] Technical Discussion
- [ ] Question (these will be auto-closed, please ask them on Spectrum instead https://spectrum.chat/spectrum/open)
-->

**Description (type any text below)**


```