### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2018 Space Program Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -254,3 +254,7 @@ Refer to [the Expo documentation on how to install the simulators](https://docs.
   <img height="200px" src="public/img/connect.svg" />
 </div>
 
+## License 
+
+BSD 3-Clause, see the [LICENSE](./LICENSE) file.
+


### PR DESCRIPTION
This adds a BSD 3-Clause license to the repo, which effectively makes
the repo an open source project.

**Why not a copyleft license?**

In general, there are two big groups of open source licenses: permissive
and copyleft ones. (see [the list of all OSS licenses](https://opensource.org/licenses)) Permissive licenses (such as BSD, MIT, Apache,...) are, as the name suggests, permissive—they allow users to redistribute the code however they want.

Copyleft licenses (most notoriously GPL) require users who want to use
the code to also release their code under the same license, i.e. as open
source. Other than that they pass the same rights on to the user.

Since nobody will use our code as a library, it doesn't make any sense
to license it as GPL—nobody's going to "use Spectrum to build their own
app" (contrary to e.g. styled-components) and then have to open source
their app. It really doesn't make sense for us to license with a copyleft
license, on top of which they're a bit frowned upon nowadays. (if
styled-components was GPL licensed you couldn't use it in any apps that
weren't open source, how does that make any sense?)

**Why not MIT?**

The default license for most open source projects these days is the MIT
license. It's simple and permissive, and works well for libraries.
(Artsy uses MIT for all their open source apps etc)

The important difference between the BSD 3-Clause and the MIT license is
that the MIT license does not have this clause about advertising:

> Neither the name of the organization nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.

Other than that they mostly grant the same rights. (use, redistribution, modification,...) I figure it's best to err on the side of safety with legal stuff, so the BSD 3-Clause seems like the better option for us. (it's also what Sentry uses for all their stuff)

**Couldn't somebody take our code, deploy it as "myownspectrum.chat" and
steal all our money?**

The short answer is: not really. The only thing that's licensed openly
is the code, but all the assets (including images, icons, brand assets,
illustrations, etc) are all still Copyright Space Program Inc. and nobody except for us
can use them.

So essentially, whoever wanted to clone Spectrum would have to go
through and replace every single image used anywhere on the site with
their own, which is already very unlikely.

On top of that, they'd have to give us attribution and they'd also not
have any of our data, they'd start right back from a clean slate.

While I can't say it won't happen at all that people will clone
Spectrum, it's very unlikely to ever hurt us.