### PR TITLE
Mention and link "good first issue" label in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ If you found a technical bug on Spectrum or have ideas for features we should im
 
 If you find a bug on Spectrum and open a PR that fixes it we'll review it as soon as possible to ensure it matches our engineering standards. If you want implement a new feature, open an issue first to discuss what it'd look like and to ensure it fits in our roadmap and plans for the app.
 
+If you want to contribute but are unsure to start, we have [a "good first issue" label](https://github.com/withspectrum/spectrum/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) which is applied to newcomer-friendly issues. Take a look at [the full list of good first issues](https://github.com/withspectrum/spectrum/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) and pick something you like!
+
 Want to fix a bug or implement an agreed-upon feature? Great, jump to the [local setup instructions](#first-time-setup)!
 
 <div align="center">


### PR DESCRIPTION
I've added a `good first issue` label and assigned it to a bunch of
small-ish, self-contained tasks that would be great for new
contributors.

This PR adds a note about said label and a link to the list of issues
with said label to the README

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing