### PR TITLE
Move Danger plugin labels

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -4,7 +4,6 @@ import { warn, fail, message, markdown, schedule, danger } from 'danger';
 import yarn from 'danger-plugin-yarn';
 import jest from 'danger-plugin-jest';
 import flow from 'danger-plugin-flow';
-import labels from 'danger-plugin-labels';
 import noTestShortcuts from 'danger-plugin-no-test-shortcuts';
 import noConsole from 'danger-plugin-no-console';
 
@@ -25,17 +24,6 @@ const APP_FOLDERS = [
 if (danger.github.pr.body.length < 10) {
   fail('Please add a description to your PR.');
 }
-
-// Add automatic labels to the PR
-schedule(
-  labels({
-    labels: {
-      wip: 'WIP: Building',
-      'needs testing': 'WIP: Needs Testing',
-      'ready for review': 'WIP: Ready for Review',
-    },
-  })
-);
 
 // Make sure the yarn.lock file is updated when dependencies get added and log any added dependencies
 APP_FOLDERS.forEach(folder => {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

This was moved to the new peril-settings repo: https://github.com/withspectrum/peril-settings 

All the other stuff is PR specific so it stays, but that part can happen earlier so let's make it happen earlier!