### PR TITLE
Fix error when community exists but not members

### DIFF
--- a/shared/graphql/queries/community/getCommunityMembers.js
+++ b/shared/graphql/queries/community/getCommunityMembers.js
@@ -60,7 +60,10 @@ const getcommunityMembersOptions = {
       loading,
       community,
       networkStatus: networkStatus,
-      hasNextPage: community ? community.members.pageInfo.hasNextPage : false,
+      hasNextPage:
+        community && community.members
+          ? community.members.pageInfo.hasNextPage
+          : false,
       fetchMore: () =>
         fetchMore({
           query: LoadMoreMembers,

--- a/src/views/community/components/moderatorList.js
+++ b/src/views/community/components/moderatorList.js
@@ -46,7 +46,7 @@ class CommunityModeratorList extends React.Component<Props> {
   render() {
     const { data: { community }, isLoading, currentUser } = this.props;
 
-    if (community) {
+    if (community && community.members) {
       const { edges: members } = community.members;
       const nodes = members.map(member => member && member.node);
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Bit of a strange bug which can cause community view to fail if it has a community but no members

