### PR TITLE
Track userThreadLastSeen on new message in subscription and message send

### DIFF
--- a/api/mutations/message/addMessage.js
+++ b/api/mutations/message/addMessage.js
@@ -11,6 +11,7 @@ import {
   createParticipantWithoutNotificationsInThread,
 } from '../../models/usersThreads';
 import addCommunityMember from '../communityMember/addCommunityMember';
+import { trackUserThreadLastSeenQueue } from 'shared/bull/queues';
 import type { FileUpload } from 'shared/types';
 
 type AddMessageInput = {
@@ -168,6 +169,12 @@ export default async (
           : false,
         isOwner: communityPermissions ? communityPermissions.isOwner : false,
       };
+
+      trackUserThreadLastSeenQueue.add({
+        userId: currentUser.id,
+        threadId: message.threadId,
+        timestamp: Date.now(),
+      });
 
       return {
         ...dbMessage,

--- a/api/subscriptions/message.js
+++ b/api/subscriptions/message.js
@@ -57,7 +57,18 @@ module.exports = {
         debug(`${moniker} listening to new messages in ${thread}`);
         try {
           return addMessageListener({
-            filter: message => message.threadId === thread,
+            filter: message => {
+              if (message.threadId === thread) {
+                trackUserThreadLastSeenQueue.add({
+                  userId: user.id,
+                  threadId: message.threadId,
+                  timestamp: new Date(message.timestamp).getTime() + 100,
+                });
+                return true;
+              }
+
+              return false;
+            },
             onError: err => {
               // Don't crash the whole API server on error in the listener
               console.error(err);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

**Release notes for users (delete if codebase-only change)**
- Fixed a bug where we weren't recording thread visits correctly

NOTE: This is untested atm