### PR TITLE
Fix Tooltip "arrow" bottom position

### DIFF
--- a/src/components/globals/index.js
+++ b/src/components/globals/index.js
@@ -442,8 +442,8 @@ const returnTooltip = props => {
           top: calc(100% + 3px);
           left: 50%;
           transform: translateX(-50%);
-          border-bottom-width: 0;
-          border-top-color: ${
+          border-top-width: 0;
+          border-bottom-color: ${
             props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
           };
         }


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Really like your tooltip behavior and style, so I played with it and found that.

the current behavior:
<img width="294" alt="screen shot 2018-04-03 at 13 57 14" src="https://user-images.githubusercontent.com/3066423/38245600-6ca45568-3747-11e8-963b-ce06c61fbed7.png">
