### PR TITLE
Restrict deployments to SFO

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,4 +1,5 @@
 {
+  "regions": ["sfo1"],
 	"env": {
 		"S3_TOKEN": "@s3-token",
 		"S3_SECRET": "@s3-secret",


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

This should ensure none of our deployments go to BRU (or any other
future region), which we don't want given our database is only hosted in
SFO.

/cc @javivelasco is this correct? I couldn't find any docs for the
`regions` option but it's mentioned in the release blog post and it
seems to work?