### PR TITLE
Cache all public files

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -96,8 +96,8 @@ module.exports = function override(config, env) {
     plugin => !isServiceWorkerPlugin(plugin)
   );
   // Get all public files so they're cached by the SW
-  let externals = ['./public/install-raven.js'];
-  walkFolder('./public/img/', file => {
+  let externals = [];
+  walkFolder('./public/', file => {
     externals.push(file.replace(/public/, ''));
   });
   config.plugins.push(


### PR DESCRIPTION
This will make it so the ServiceWorker caches all the public files, not just the images. This is necessary for the `manifest.json` to be served correctly, which makes the app "Add to homescreen"-able.

Previously you'd get a parsing error for the manifest.json file because the ServiceWorker would go to the SSR server to get it, which would return a HTML file instead. 

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)