### PR TITLE
Add development tokens for stripe

### DIFF
--- a/now-secrets.example.json
+++ b/now-secrets.example.json
@@ -4,5 +4,6 @@
   "@facebook-oauth-client-secret-development": "0c3a5b3521fe79636b568f3f4db67f2b",
   "@google-oauth-client-secret-development": "i7H7ZLfntkIEp7kyyNsvyH3O",
   "@github-oauth-client-secret-development": "789f3a4b5772e978acd135fe7c86886e62f688c7",
-  "@session-cookie-secret": "this-is-an-example-secret"
+  "@session-cookie-secret": "this-is-an-example-secret",
+  "@stripe-token-development": "sk_test_EoC6py6fkeUHZJrEPffsGP0z"
 }

--- a/now.json
+++ b/now.json
@@ -18,6 +18,7 @@
 		"VAPID_PRIVATE_KEY": "@vapid-private-key",
     "OPTICS_API_KEY": "@optics-api-key",
 		"STRIPE_TOKEN": "@stripe-token",
+		"STRIPE_TOKEN_DEVELOPMENT": "@stripe-token-development",
 		"TWITTER_OAUTH_CLIENT_SECRET": "@twitter-oauth-client-secret",
 		"FACEBOOK_OAUTH_CLIENT_ID": "@facebook-oauth-client-id",
 		"FACEBOOK_OAUTH_CLIENT_SECRET": "@facebook-oauth-client-secret",

--- a/shared/stripe/index.js
+++ b/shared/stripe/index.js
@@ -1,5 +1,8 @@
 require('now-env');
-const STRIPE_TOKEN = process.env.STRIPE_TOKEN;
+const IS_PROD = process.env.NODE_ENV === 'production';
+const STRIPE_TOKEN = IS_PROD
+  ? process.env.STRIPE_TOKEN
+  : process.env.STRIPE_TOKEN_DEVELOPMENT;
 const STRIPE_WEBHOOK_SIGNING_SECRET = process.env.STRIPE_WEBHOOK_SIGNING_SECRET;
 export const stripe = require('stripe')(STRIPE_TOKEN);
 export const stripeWebhookSigningSecret = STRIPE_WEBHOOK_SIGNING_SECRET;

--- a/src/api/constants.js
+++ b/src/api/constants.js
@@ -1,16 +1,15 @@
-export const SERVER_URL =
-  process.env.NODE_ENV === 'production'
-    ? // In production we want to redirect to /whatever
-      ``
-    : // In development we gotta redirect to localhost:3001/whatever tho
-      'http://localhost:3001';
+const IS_PROD = process.env.NODE_ENV === 'production';
 
-export const CLIENT_URL =
-  process.env.NODE_ENV === 'production'
-    ? `${window.location.protocol}//${window.location.host}`
-    : 'http://localhost:3000';
+export const SERVER_URL = IS_PROD
+  ? // In production we want to redirect to /whatever
+    ``
+  : // In development we gotta redirect to localhost:3001/whatever tho
+    'http://localhost:3001';
 
-export const PUBLIC_STRIPE_KEY =
-  process.env.NODE_ENV === 'production'
-    ? 'pk_live_viV7X5XXD1sw8aN2NgQjiff6'
-    : 'pk_test_8aqk2JeScufGk1zAMe5GxaRq';
+export const CLIENT_URL = IS_PROD
+  ? `${window.location.protocol}//${window.location.host}`
+  : 'http://localhost:3000';
+
+export const PUBLIC_STRIPE_KEY = IS_PROD
+  ? 'pk_live_viV7X5XXD1sw8aN2NgQjiff6'
+  : 'pk_test_sXi0YoSKMnTkLSDdso2tJOvh';


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

This adds a separate development Stripe account to prevent errors from being thrown as contributors use the app locally. Doing any sort of local payments testing will require additional configuration in the future.