### PR TITLE
Adds channel pill to thread view sidebar component

### DIFF
--- a/src/views/thread/components/sidebar.js
+++ b/src/views/thread/components/sidebar.js
@@ -1,18 +1,19 @@
 // @flow
 import * as React from 'react';
 import replace from 'string-replace-to-array';
-import { Button, TextButton } from '../../../components/buttons';
+import { Button, TextButton } from 'src/components/buttons';
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
 import {
   LoadingProfileThreadDetail,
   LoadingListThreadDetail,
-} from '../../../components/loading';
-import ToggleCommunityMembership from '../../../components/toggleCommunityMembership';
+} from 'src/components/loading';
+import ToggleCommunityMembership from 'src/components/toggleCommunityMembership';
 import Link from 'src/components/link';
 import getCommunityThreads from 'shared/graphql/queries/community/getCommunityThreadConnection';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import { CLIENT_URL } from 'src/api/constants';
+import Icon from 'src/components/icons';
 import {
   SidebarSection,
   SidebarSectionTitle,
@@ -28,6 +29,10 @@ import {
   SidebarRelatedThread,
   RelatedTitle,
   RelatedCount,
+  PillLink,
+  PillLabel,
+  Lock,
+  SidebarChannelPill,
 } from '../style';
 
 type RecommendedThread = {
@@ -120,6 +125,19 @@ class Sidebar extends React.Component<Props> {
               src={thread.community.profilePhoto}
             />
             <SidebarCommunityName>{thread.community.name}</SidebarCommunityName>
+
+            <SidebarChannelPill>
+              <PillLink to={`/${thread.community.slug}/${thread.channel.slug}`}>
+                {thread.channel.isPrivate && (
+                  <Lock>
+                    <Icon glyph="private" size={12} />
+                  </Lock>
+                )}
+                <PillLabel isPrivate={thread.channel.isPrivate}>
+                  {thread.channel.name}
+                </PillLabel>
+              </PillLink>
+            </SidebarChannelPill>
           </Link>
 
           <SidebarCommunityDescription>

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -1,3 +1,4 @@
+// @flow
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import Avatar from '../../components/avatar';

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -546,6 +546,12 @@ export const PillLabel = styled.span`
     `};
 `;
 
+export const SidebarChannelPill = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 8px 16px 16px;
+`;
+
 export const Lock = styled.span`
   margin-right: 4px;
 `;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Makes it easier to see what channel a thread was posted in when viewing the thread detail page

<img width="313" alt="screenshot 2018-04-04 16 20 34" src="https://user-images.githubusercontent.com/1923260/38339657-4455f688-3824-11e8-858a-6236bdfbac2c.png">

Closes #2695 

