### PR TITLE
Fix community image order

### DIFF
--- a/shared/graphql/fragments/user/userCommunityConnection.js
+++ b/shared/graphql/fragments/user/userCommunityConnection.js
@@ -6,9 +6,6 @@ import type { CommunityInfoType } from '../community/communityInfo';
 type Edge = {
   node: {
     ...$Exact<CommunityInfoType>,
-    hasFeatures: {
-      analytics: boolean,
-    },
     contextPermissions: {
       communityId: string,
       isOwner: boolean,
@@ -38,9 +35,6 @@ export default gql`
       edges {
         node {
           ...communityInfo
-          hasFeatures {
-            analytics
-          }
           contextPermissions {
             communityId
             isOwner

--- a/src/views/dashboard/components/communityList.js
+++ b/src/views/dashboard/components/communityList.js
@@ -80,6 +80,13 @@ class CommunityList extends React.Component<Props> {
     const sortedCommunities = communities.slice().sort((a, b) => {
       const bc = parseInt(b.communityPermissions.reputation, 10);
       const ac = parseInt(a.communityPermissions.reputation, 10);
+
+      // sort same-reputation communities alphabetically
+      if (ac === bc) {
+        return a.name.toUpperCase() <= b.name.toUpperCase() ? -1 : 1;
+      }
+
+      // otherwise sort by reputation
       return bc <= ac ? -1 : 1;
     });
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Fixes a bug where community images would be matched to the wrong community in the inbox view

Closes #2711 - note: I did not dig into the `avatar/image.js` component, but that bad boy is going to need a refactor at some point soon regardless because it's using `componentWillReceiveProps` which is about to be deprecated.

This still should fix the problem by always sorting the community list by reputation first, then by alphabetical name.

