### PR TITLE
Add timeout to prevent disconnected status bar flashing

### DIFF
--- a/src/views/status/index.js
+++ b/src/views/status/index.js
@@ -56,6 +56,7 @@ class Status extends React.Component<Props, State> {
 
   handleWsChange = () => {
     const { websocketConnection } = this.props;
+
     if (websocketConnection === 'connected') {
       return setTimeout(() => this.setState(this.initialState), 1000);
     }
@@ -65,6 +66,7 @@ class Status extends React.Component<Props, State> {
         color: 'special',
         label: 'Reconnecting to server...',
         wsConnected: false,
+        hidden: false,
       });
     }
 
@@ -72,6 +74,7 @@ class Status extends React.Component<Props, State> {
       this.setState({
         color: 'success',
         label: 'Reconnected!',
+        hidden: false,
       });
 
       return setTimeout(() => this.setState(this.initialState), 1000);
@@ -82,6 +85,16 @@ class Status extends React.Component<Props, State> {
     const curr = this.props;
 
     if (prevProps.websocketConnection !== curr.websocketConnection) {
+      this.setState({
+        hidden: true,
+      });
+
+      if (curr.websocketConnection === 'disconnected') {
+        return setTimeout(() => {
+          return this.handleWsChange();
+        }, 5000);
+      }
+
       return this.handleWsChange();
     }
   }


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Fixes cases where the API status bar flash a disconnected and reconnected state

Note:
Until we can figure out why the api has frequent disconnect/reconnect cycles, this PR sets a timeout so that the disconnect bar only shows up after 5 seconds, but will not show at all if a reconnection is successful in that time period. The timeout does *not* affect the logic we have in the thread composer and chat input which prevents content from being sent to the api in the case of a disconnect (e.g. users still cant post content to the api while they are in a disconnected state, even if the disconnect is only for a second)

Closes #2606 

