### PR TITLE
Ensure that localStorage is in scope anywhere we get or set an item

### DIFF
--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -67,9 +67,9 @@ if (localStorage) {
 }
 
 const forcePersist = content =>
-  localStorage.setItem(LS_KEY, JSON.stringify(toJSON(content)));
+  localStorage && localStorage.setItem(LS_KEY, JSON.stringify(toJSON(content)));
 const persistContent = debounce(content => {
-  localStorage.setItem(LS_KEY, JSON.stringify(toJSON(content)));
+  localStorage && localStorage.setItem(LS_KEY, JSON.stringify(toJSON(content)));
 }, 500);
 
 class ChatInput extends React.Component<Props, State> {

--- a/src/components/composer/index.js
+++ b/src/components/composer/index.js
@@ -315,6 +315,7 @@ class ComposerWithData extends Component<Props, State> {
   };
 
   persistBodyToLocalStorageWithDebounce = body => {
+    if (!localStorage) return;
     return localStorage.setItem(
       LS_BODY_KEY,
       JSON.stringify(toJSON(this.state.body))
@@ -322,14 +323,17 @@ class ComposerWithData extends Component<Props, State> {
   };
 
   persistTitleToLocalStorageWithDebounce = title => {
+    if (!localStorage) return;
     return localStorage.setItem(LS_TITLE_KEY, this.state.title);
   };
 
   persistTitleToLocalStorage = title => {
+    if (!localStorage) return;
     return localStorage.setItem(LS_TITLE_KEY, this.state.title);
   };
 
   persistBodyToLocalStorage = body => {
+    if (!localStorage) return;
     return localStorage.setItem(
       LS_BODY_KEY,
       JSON.stringify(toJSON(this.state.body))

--- a/src/components/threadComposer/components/composer.js
+++ b/src/components/threadComposer/components/composer.js
@@ -88,13 +88,17 @@ if (localStorage) {
   }
 }
 
-const persistTitle = debounce((title: string) => {
-  localStorage.setItem(LS_TITLE_KEY, title);
-}, 500);
+const persistTitle =
+  localStorage &&
+  debounce((title: string) => {
+    localStorage.setItem(LS_TITLE_KEY, title);
+  }, 500);
 
-const persistBody = debounce(body => {
-  localStorage.setItem(LS_BODY_KEY, JSON.stringify(toJSON(body)));
-}, 500);
+const persistBody =
+  localStorage &&
+  debounce(body => {
+    localStorage.setItem(LS_BODY_KEY, JSON.stringify(toJSON(body)));
+  }, 500);
 
 class ThreadComposerWithData extends React.Component<Props, State> {
   constructor(props) {

--- a/src/helpers/localStorage.js
+++ b/src/helpers/localStorage.js
@@ -1,6 +1,8 @@
 export const clearStorage = () => localStorage.clear();
 
 export const getItemFromStorage = (key: string) => {
+  if (!localStorage) return;
+
   try {
     return JSON.parse(localStorage.getItem(key));
   } catch (err) {
@@ -9,6 +11,8 @@ export const getItemFromStorage = (key: string) => {
 };
 
 export const storeItem = (key: string, item: any) => {
+  if (!localStorage) return;
+
   try {
     return localStorage.setItem(key, JSON.stringify(item));
   } catch (err) {
@@ -17,6 +21,8 @@ export const storeItem = (key: string, item: any) => {
 };
 
 export const removeItemFromStorage = (key: string) => {
+  if (!localStorage) return;
+
   try {
     return localStorage.removeItem(key);
   } catch (err) {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Noticed some Sentry errors coming in where it could not evaluate `setItem` of null - so just went through `src` and made sure that `localStorage` is in scope whenever we use it :)
