### PR TITLE
Fix invalid token response when using accessToken authentication

### DIFF
--- a/api/routes/auth/create-signin-routes.js
+++ b/api/routes/auth/create-signin-routes.js
@@ -10,7 +10,7 @@
 import passport from 'passport';
 import { URL } from 'url';
 import isSpectrumUrl from '../../utils/is-spectrum-url';
-import { signCookie } from 'shared/cookie-utils';
+import { signCookie, getCookies } from 'shared/cookie-utils';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
 const FALLBACK_URL = IS_PROD
@@ -63,11 +63,13 @@ export const createSigninRoutes = (
           req.cookies.session &&
           req.cookies['session.sig']
         ) {
+          const cookies = getCookies(req.session.passport);
+
           redirectUrl.searchParams.append(
             'accessToken',
             signCookie(
-              `session=${req.cookies.session}; session.sig=${
-                req.cookies['session.sig']
+              `session=${cookies.session}; session.sig=${
+                cookies['session.sig']
               }`
             )
           );


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

This change is required because without it, the cookies are outdated on subsequent authentication attempts. An example is while being logged in, and then going to `/auth/PROVIDER?r=https://spectrum.chat/home&authType=token`, `req.cookies` will be outdated until `res.redirect(...)` is called, due to `cookie-session` updating cookies on header change (uses `on-headers` under the hood). By using the `getCookies` function written, it'll always be up-to-date. 

Please let me know if I should provide any more details as to why this is required! :)

