### PR TITLE
Dont fetch deleted messages when loading image gallery

### DIFF
--- a/api/models/message.js
+++ b/api/models/message.js
@@ -104,6 +104,7 @@ export const getMediaMessagesForThread = (
     .table('messages')
     .getAll(threadId, { index: 'threadId' })
     .filter({ messageType: 'media' })
+    .filter(db.row.hasFields('deletedAt').not())
     .run();
 };
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

**Release notes for users (delete if codebase-only change)**
- Fixes a bug where deleted image messages would show up in the image gallery

Closes #2734 

