### PR TITLE
Improve NavBar’s a11y

### DIFF
--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { Link, withRouter } from 'react-router-dom';
 import { createLocation } from 'history';
+import LINK_PROPS from './props';
 
 type Props = {
   onClick?: Function,
@@ -12,24 +13,38 @@ type Props = {
   history: Object,
 };
 
-// Filter the withRouter props from being passed through to <Link />
-export default withRouter(
-  ({ staticContext, history, location, match, ...rest }: Props) => (
-    <Link
-      {...rest}
-      onClick={evt => {
-        if (rest.onClick) rest.onClick(evt);
-        if (evt.metaKey || evt.ctrlKey) return;
-        if (window.appUpdateAvailable === true) {
-          evt.preventDefault();
-          // This is copied from react-router's <Link /> component and is basically what it does internally
-          const location =
-            typeof rest.to === 'string'
-              ? createLocation(rest.to, null, null, history.location)
-              : rest.to;
-          return (window.location = history.createHref(location));
-        }
-      }}
-    />
-  )
-);
+// Filter out all props that are invalid on an `a` element.
+const filterProps = (props: Object) => {
+  const addToProps = (acc, prop) => {
+    acc[prop] = props[prop];
+
+    return acc;
+  };
+
+  // All attributes starting with `data-` are valid HTML5 attributes.
+  const dataAttributesProps = Object.keys(props).filter(propName =>
+    propName.startsWith('data-')
+  );
+  const allowedProps = LINK_PROPS.reduce(addToProps, {});
+
+  return dataAttributesProps.reduce(addToProps, allowedProps);
+};
+
+export default withRouter((props: Props) => (
+  <Link
+    {...filterProps(props)}
+    onClick={evt => {
+      if (props.onClick) props.onClick(evt);
+      if (evt.metaKey || evt.ctrlKey) return;
+      if (window.appUpdateAvailable === true) {
+        evt.preventDefault();
+        // This is copied from react-router's <Link /> component and is basically what it does internally
+        const location =
+          typeof props.to === 'string'
+            ? createLocation(props.to, null, null, props.history.location)
+            : props.to;
+        return (window.location = props.history.createHref(location));
+      }
+    }}
+  />
+));

--- a/src/components/link/props.js
+++ b/src/components/link/props.js
@@ -1,0 +1,49 @@
+// @flow
+// This file exports an array of all props that are valid on an `a` (anchor)
+// element. We need to do that so that we don’t spread invalid props on React
+// Router’s `<Link>` component, which would trigger an error.
+
+const BASE_PROPS = [
+  'id',
+  'className',
+  'tabIndex',
+  'lang',
+  'aria-hidden',
+  'children',
+];
+const FOCUS_EVENTS = ['onFocus', 'onBlur'];
+const MOUSE_EVENTS = [
+  'onClick',
+  'onContextMenu',
+  'onDoubleClick',
+  'onDrag',
+  'onDragEnd',
+  'onDragEnter',
+  'onDragExit',
+  'onDragLeave',
+  'onDragOver',
+  'onDragStart',
+  'onDrop',
+  'onMouseDown',
+  'onMouseEnter',
+  'onMouseLeave',
+  'onMouseMove',
+  'onMouseOut',
+  'onMouseOver',
+  'onMouseUp',
+];
+
+const LINK_PROPS = [
+  'href',
+  'hrefLang',
+  'rel',
+  'target',
+  'autoFocus',
+  'aria-label',
+  'aria-current',
+  'to',
+  'download',
+  'title',
+];
+
+export default [...BASE_PROPS, ...LINK_PROPS, ...FOCUS_EVENTS, ...MOUSE_EVENTS];

--- a/src/components/menu/index.js
+++ b/src/components/menu/index.js
@@ -16,13 +16,13 @@ class Menu extends Component {
   }
 
   render() {
-    const { hasNavBar, darkContext, hasTabBar } = this.props;
+    const { hasNavBar, darkContext } = this.props;
     const { menuIsOpen } = this.state;
     return (
       <Wrapper darkContext={darkContext}>
         <IconButton glyph={'menu'} onClick={() => this.toggleMenu()} />
         <Absolute open={this.state.menuIsOpen} hasNavBar={hasNavBar}>
-          <MenuContainer hasNavBar={hasNavBar} hasTabBar={hasTabBar}>
+          <MenuContainer hasNavBar={hasNavBar}>
             {menuIsOpen && this.props.children}
           </MenuContainer>
           <IconButton

--- a/src/components/menu/style.js
+++ b/src/components/menu/style.js
@@ -57,7 +57,7 @@ export const MenuContainer = styled.div`
   left: 0;
   top: 0;
   bottom: 0;
-  height: ${props => (props.hasTabBar ? 'calc(100% - 48px)' : '100%')};
+  height: 100%;
   width: 300px;
   color: ${props => props.theme.brand.alt};
   background-color: ${props => props.theme.bg.default};

--- a/src/routes.js
+++ b/src/routes.js
@@ -136,6 +136,11 @@ const Body = styled(FlexCol)`
   }
 `;
 
+const Main = styled.main`
+  display: flex;
+  flex: 1 1 100%;
+`;
+
 const DashboardFallback = signedOutFallback(Dashboard, Pages);
 const HomeFallback = signedOutFallback(Dashboard, () => <Redirect to="/" />);
 const NewCommunityFallback = signedOutFallback(NewCommunity, () => (
@@ -203,7 +208,7 @@ class Routes extends React.Component<{}> {
               <Route component={ThreadSlider} />
 
               {/* This id is needed for the “Skip to content” button in the NavBar. */}
-              <main id="main">
+              <Main id="main">
                 {/*
                   Switch only renders the first match. Subrouting happens downstream
                   https://reacttraining.com/react-router/web/api/Switch
@@ -225,7 +230,10 @@ class Routes extends React.Component<{}> {
                   <Route path="/features" component={Pages} />
 
                   {/* App Pages */}
-                  <Route path="/new/community" component={NewCommunityFallback} />
+                  <Route
+                    path="/new/community"
+                    component={NewCommunityFallback}
+                  />
                   <Route path="/new/thread" component={ComposerFallback} />
                   <Route path="/new/search" component={Search} />
 
@@ -244,7 +252,11 @@ class Routes extends React.Component<{}> {
                   <Route path="/messages" component={MessagesFallback} />
                   <Route path="/thread/:threadId" component={Thread} />
                   <Route path="/thread" render={() => <Redirect to="/" />} />
-                  <Route exact path="/users" render={() => <Redirect to="/" />} />
+                  <Route
+                    exact
+                    path="/users"
+                    render={() => <Redirect to="/" />}
+                  />
                   <Route exact path="/users/:username" component={UserView} />
                   <Route
                     exact
@@ -287,7 +299,7 @@ class Routes extends React.Component<{}> {
                   />
                   <Route path="/:communitySlug" component={CommunityView} />
                 </Switch>
-              </main>
+              </Main>
             </Body>
           </ScrollManager>
         </ErrorBoundary>

--- a/src/routes.js
+++ b/src/routes.js
@@ -202,89 +202,92 @@ class Routes extends React.Component<{}> {
               <Route component={Gallery} />
               <Route component={ThreadSlider} />
 
-              {/*
-                Switch only renders the first match. Subrouting happens downstream
-                https://reacttraining.com/react-router/web/api/Switch
-              */}
-              <Switch>
-                <Route exact path="/" component={DashboardFallback} />
-                <Route exact path="/home" component={HomeFallback} />
-
-                {/* Public Business Pages */}
-                <Route path="/about" component={Pages} />
-                <Route path="/contact" component={Pages} />
-                <Route path="/terms" component={Pages} />
-                <Route path="/privacy" component={Pages} />
-                <Route path="/terms.html" component={Pages} />
-                <Route path="/privacy.html" component={Pages} />
-                <Route path="/code-of-conduct" component={Pages} />
-                <Route path="/pricing" component={Pages} />
-                <Route path="/support" component={Pages} />
-                <Route path="/features" component={Pages} />
-
-                {/* App Pages */}
-                <Route path="/new/community" component={NewCommunityFallback} />
-                <Route path="/new/thread" component={ComposerFallback} />
-                <Route path="/new/search" component={Search} />
-
-                <Route
-                  path="/new"
-                  render={() => <Redirect to="/new/community" />}
-                />
-
-                <Route path="/login" component={Login} />
-                <Route path="/explore" component={Explore} />
-                <Route path="/messages/new" component={MessagesFallback} />
-                <Route
-                  path="/messages/:threadId"
-                  component={MessagesFallback}
-                />
-                <Route path="/messages" component={MessagesFallback} />
-                <Route path="/thread/:threadId" component={Thread} />
-                <Route path="/thread" render={() => <Redirect to="/" />} />
-                <Route exact path="/users" render={() => <Redirect to="/" />} />
-                <Route exact path="/users/:username" component={UserView} />
-                <Route
-                  exact
-                  path="/users/:username/settings"
-                  component={UserSettingsFallback}
-                />
-                <Route
-                  path="/notifications"
-                  component={NotificationsFallback}
-                />
-
+              {/* This id is needed for the “Skip to content” button in the NavBar. */}
+              <main id="main">
                 {/*
-                  We check communitySlug last to ensure none of the above routes
-                  pass. We handle null communitySlug values downstream by either
-                  redirecting to home or showing a 404
+                  Switch only renders the first match. Subrouting happens downstream
+                  https://reacttraining.com/react-router/web/api/Switch
                 */}
-                <Route
-                  path="/:communitySlug/:channelSlug/settings"
-                  component={ChannelSettingsFallback}
-                />
-                <Route
-                  path="/:communitySlug/:channelSlug/join/:token"
-                  component={PrivateChannelJoin}
-                />
-                <Route
-                  path="/:communitySlug/:channelSlug/join"
-                  component={PrivateChannelJoin}
-                />
-                <Route
-                  path="/:communitySlug/settings"
-                  component={CommunitySettingsFallback}
-                />
-                <Route
-                  path="/:communitySlug/login"
-                  component={CommunityLoginView}
-                />
-                <Route
-                  path="/:communitySlug/:channelSlug"
-                  component={ChannelView}
-                />
-                <Route path="/:communitySlug" component={CommunityView} />
-              </Switch>
+                <Switch>
+                  <Route exact path="/" component={DashboardFallback} />
+                  <Route exact path="/home" component={HomeFallback} />
+
+                  {/* Public Business Pages */}
+                  <Route path="/about" component={Pages} />
+                  <Route path="/contact" component={Pages} />
+                  <Route path="/terms" component={Pages} />
+                  <Route path="/privacy" component={Pages} />
+                  <Route path="/terms.html" component={Pages} />
+                  <Route path="/privacy.html" component={Pages} />
+                  <Route path="/code-of-conduct" component={Pages} />
+                  <Route path="/pricing" component={Pages} />
+                  <Route path="/support" component={Pages} />
+                  <Route path="/features" component={Pages} />
+
+                  {/* App Pages */}
+                  <Route path="/new/community" component={NewCommunityFallback} />
+                  <Route path="/new/thread" component={ComposerFallback} />
+                  <Route path="/new/search" component={Search} />
+
+                  <Route
+                    path="/new"
+                    render={() => <Redirect to="/new/community" />}
+                  />
+
+                  <Route path="/login" component={Login} />
+                  <Route path="/explore" component={Explore} />
+                  <Route path="/messages/new" component={MessagesFallback} />
+                  <Route
+                    path="/messages/:threadId"
+                    component={MessagesFallback}
+                  />
+                  <Route path="/messages" component={MessagesFallback} />
+                  <Route path="/thread/:threadId" component={Thread} />
+                  <Route path="/thread" render={() => <Redirect to="/" />} />
+                  <Route exact path="/users" render={() => <Redirect to="/" />} />
+                  <Route exact path="/users/:username" component={UserView} />
+                  <Route
+                    exact
+                    path="/users/:username/settings"
+                    component={UserSettingsFallback}
+                  />
+                  <Route
+                    path="/notifications"
+                    component={NotificationsFallback}
+                  />
+
+                  {/*
+                    We check communitySlug last to ensure none of the above routes
+                    pass. We handle null communitySlug values downstream by either
+                    redirecting to home or showing a 404
+                  */}
+                  <Route
+                    path="/:communitySlug/:channelSlug/settings"
+                    component={ChannelSettingsFallback}
+                  />
+                  <Route
+                    path="/:communitySlug/:channelSlug/join/:token"
+                    component={PrivateChannelJoin}
+                  />
+                  <Route
+                    path="/:communitySlug/:channelSlug/join"
+                    component={PrivateChannelJoin}
+                  />
+                  <Route
+                    path="/:communitySlug/settings"
+                    component={CommunitySettingsFallback}
+                  />
+                  <Route
+                    path="/:communitySlug/login"
+                    component={CommunityLoginView}
+                  />
+                  <Route
+                    path="/:communitySlug/:channelSlug"
+                    component={ChannelView}
+                  />
+                  <Route path="/:communitySlug" component={CommunityView} />
+                </Switch>
+              </main>
             </Body>
           </ScrollManager>
         </ErrorBoundary>

--- a/src/views/dashboard/index.js
+++ b/src/views/dashboard/index.js
@@ -149,7 +149,7 @@ class Dashboard extends React.Component<Props, State> {
         <DashboardWrapper data-cy="inbox-view">
           <Head title={title} description={description} />
           <Titlebar hasChildren hasSearch filter={searchFilter}>
-            <Menu darkContext hasTabBar>
+            <Menu darkContext>
               <CommunityList
                 communities={communities}
                 user={user}

--- a/src/views/directMessages/style.js
+++ b/src/views/directMessages/style.js
@@ -5,10 +5,9 @@ export const View = styled(FlexRow)`
   align-items: stretch;
   background: #fff;
   flex: auto;
-  max-height: calc(100% - 48px);
+  max-height: 100%;
 
   @media (max-width: 768px) {
-    max-height: 100%;
     flex-direction: column;
     flex: auto;
   }
@@ -45,7 +44,11 @@ export const MessagesContainer = styled(FlexCol)`
   flex: auto;
 
   @media (max-width: 768px) {
-    ${props => props.hideOnMobile && css`display: none;`};
+    ${props =>
+      props.hideOnMobile &&
+      css`
+        display: none;
+      `};
   }
 `;
 

--- a/src/views/navbar/components/messagesTab.js
+++ b/src/views/navbar/components/messagesTab.js
@@ -203,6 +203,7 @@ class MessagesTab extends React.Component<Props, State> {
     return (
       <Tab
         data-active={active}
+        aria-current={active ? 'page' : undefined}
         to="/messages"
         rel="nofollow"
         onClick={this.markAllAsSeen}

--- a/src/views/navbar/components/notificationsTab.js
+++ b/src/views/navbar/components/notificationsTab.js
@@ -384,6 +384,7 @@ class NotificationsTab extends React.Component<Props, State> {
       <NotificationTab padOnHover onMouseOver={this.setHover}>
         <Tab
           data-active={active}
+          aria-current={active ? 'page' : undefined}
           to="/notifications"
           rel="nofollow"
           onClick={this.markAllAsSeen}

--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -88,6 +88,13 @@ class Navbar extends React.Component<Props, State> {
   handleSkipLinkFocus = () => this.setState({ isSkipLinkFocused: true });
   handleSkipLinkBlur = () => this.setState({ isSkipLinkFocused: false });
 
+  getTabProps(isActive: boolean) {
+    return {
+      'data-active': isActive,
+      'aria-current': isActive ? 'page' : undefined,
+    };
+  }
+
   render() {
     const { history, match, currentUser, notificationCounts } = this.props;
 
@@ -168,7 +175,10 @@ class Navbar extends React.Component<Props, State> {
             Skip to content
           </SkipLink>
 
-          <HomeTab data-active={match.url === '/' && match.isExact} to="/">
+          <HomeTab
+            {...this.getTabProps(match.url === '/' && match.isExact)}
+            to="/"
+          >
             <Icon glyph="home" />
             <Label>Home</Label>
           </HomeTab>
@@ -178,7 +188,7 @@ class Navbar extends React.Component<Props, State> {
           />
 
           <ExploreTab
-            data-active={history.location.pathname === '/explore'}
+            {...this.getTabProps(history.location.pathname === '/explore')}
             to="/explore"
           >
             <Icon glyph="explore" />
@@ -194,9 +204,9 @@ class Navbar extends React.Component<Props, State> {
           <ProfileDrop>
             <Tab
               className={'hideOnMobile'}
-              data-active={
+              {...this.getTabProps(
                 history.location.pathname === `/users/${loggedInUser.username}`
-              }
+              )}
               to={
                 loggedInUser.username ? `/users/${loggedInUser.username}` : '/'
               }
@@ -212,9 +222,9 @@ class Navbar extends React.Component<Props, State> {
 
           <ProfileTab
             className={'hideOnDesktop'}
-            data-active={
+            {...this.getTabProps(
               history.location.pathname === `/users/${loggedInUser.username}`
-            }
+            )}
             to={loggedInUser.username ? `/users/${loggedInUser.username}` : '/'}
           >
             <Icon glyph="profile" />
@@ -246,14 +256,14 @@ class Navbar extends React.Component<Props, State> {
 
           <HomeTab
             className={'hideOnDesktop'}
-            data-active={match.url === '/' && match.isExact}
+            {...this.getTabProps(match.url === '/' && match.isExact)}
             to="/"
           >
             <Icon glyph="logo" />
             <Label>About</Label>
           </HomeTab>
           <ExploreTab
-            data-active={history.location.pathname === '/explore'}
+            {...this.getTabProps(history.location.pathname === '/explore')}
             to="/explore"
             loggedOut={!loggedInUser}
           >
@@ -261,14 +271,14 @@ class Navbar extends React.Component<Props, State> {
             <Label>Explore</Label>
           </ExploreTab>
           <SupportTab
-            data-active={history.location.pathname === '/support'}
+            {...this.getTabProps(history.location.pathname === '/support')}
             to="/support"
           >
             <Icon glyph="like" />
             <Label>Support</Label>
           </SupportTab>
           <PricingTab
-            data-active={history.location.pathname === '/pricing'}
+            {...this.getTabProps(history.location.pathname === '/pricing')}
             to="/pricing"
           >
             <Icon glyph="payment" />

--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -135,7 +135,7 @@ class Navbar extends React.Component<Props> {
             )}
           </Head>
 
-          <Logo to="/">
+          <Logo to="/" aria-hidden tabIndex="-1">
             <Icon glyph="logo" size={28} />
           </Logo>
 
@@ -198,7 +198,7 @@ class Navbar extends React.Component<Props> {
     if (!loggedInUser) {
       return (
         <Nav hideOnMobile={hideNavOnMobile} loggedOut={!loggedInUser}>
-          <Logo to="/">
+          <Logo to="/" aria-hidden tabIndex="-1">
             <Icon glyph="logo" size={28} />
           </Logo>
           <HomeTab

--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -20,6 +20,7 @@ import {
   Tab,
   Label,
   Navatar,
+  SkipLink,
 } from './style';
 
 type Props = {
@@ -36,9 +37,21 @@ type Props = {
   activeInboxThread: ?string,
 };
 
-class Navbar extends React.Component<Props> {
-  shouldComponentUpdate(nextProps) {
+type State = {
+  isSkipLinkFocused: boolean,
+};
+
+class Navbar extends React.Component<Props, State> {
+  state = {
+    isSkipLinkFocused: false,
+  };
+
+  shouldComponentUpdate(nextProps, nextState) {
     const currProps = this.props;
+
+    // If the update was caused by the focus on the skip link
+    if (nextState.isSkipLinkFocused !== this.state.isSkipLinkFocused)
+      return true;
 
     // if route changes
     if (currProps.location.pathname !== nextProps.location.pathname)
@@ -71,6 +84,9 @@ class Navbar extends React.Component<Props> {
 
     return false;
   }
+
+  handleSkipLinkFocus = () => this.setState({ isSkipLinkFocused: true });
+  handleSkipLinkBlur = () => this.setState({ isSkipLinkFocused: false });
 
   render() {
     const { history, match, currentUser, notificationCounts } = this.props;
@@ -135,9 +151,22 @@ class Navbar extends React.Component<Props> {
             )}
           </Head>
 
-          <Logo to="/" aria-hidden tabIndex="-1">
+          <Logo
+            to="/"
+            aria-hidden
+            tabIndex="-1"
+            isHidden={this.state.isSkipLinkFocused}
+          >
             <Icon glyph="logo" size={28} />
           </Logo>
+
+          <SkipLink
+            href="#main"
+            onFocus={this.handleSkipLinkFocus}
+            onBlur={this.handleSkipLinkBlur}
+          >
+            Skip to content
+          </SkipLink>
 
           <HomeTab data-active={match.url === '/' && match.isExact} to="/">
             <Icon glyph="home" />
@@ -198,9 +227,23 @@ class Navbar extends React.Component<Props> {
     if (!loggedInUser) {
       return (
         <Nav hideOnMobile={hideNavOnMobile} loggedOut={!loggedInUser}>
-          <Logo to="/" aria-hidden tabIndex="-1">
+          <Logo
+            to="/"
+            aria-hidden
+            tabIndex="-1"
+            isHidden={this.state.isSkipLinkFocused}
+          >
             <Icon glyph="logo" size={28} />
           </Logo>
+
+          <SkipLink
+            href="#main"
+            onFocus={this.handleSkipLinkFocus}
+            onBlur={this.handleSkipLinkBlur}
+          >
+            Skip to content
+          </SkipLink>
+
           <HomeTab
             className={'hideOnDesktop'}
             data-active={match.url === '/' && match.isExact}

--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -100,13 +100,15 @@ export const Tab = styled(Link)`
       color: ${props => props.theme.text.reverse};
       transition: ${Transition.hover.on};
 
-      &:hover {
+      &:hover,
+      &:focus {
         box-shadow: inset 0 -6px 0 ${({ theme }) => theme.text.reverse};
         transition: ${Transition.hover.on};
       }
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       box-shadow: inset 0 -4px 0 ${({ theme }) => (process.env.NODE_ENV === 'production' ? theme.text.placeholder : theme.warn.border)};
       color: ${props => props.theme.text.reverse};
       transition: ${Transition.hover.on};

--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -199,7 +199,9 @@ export const Logo = styled(Tab)`
   @media (max-width: 768px) {
     display: none;
   }
-`;
+
+  ${props => props.isHidden && css`display: none;`}
+`
 
 export const HomeTab = styled(Tab)`grid-area: home;`;
 
@@ -346,5 +348,19 @@ export const MarkAllSeen = styled.span`
   &:hover {
     color: ${props =>
       props.isActive ? props.theme.brand.default : props.theme.text.alt};
+  }
+`;
+
+// We make it a real link element because anchor links don’t work properly with React Router.
+// Ref: https://github.com/ReactTraining/react-router/issues/394.
+export const SkipLink = Tab.withComponent('a').extend`
+  grid-area: logo;
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+
+  &:focus {
+    height: auto;
+    width: auto;
   }
 `;

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -205,7 +205,7 @@ class NotificationsPure extends React.Component<Props, State> {
     const { scrollElement } = this.state;
 
     return (
-      <FlexCol style={{ flex: '1 1 auto', maxHeight: 'calc(100% - 48px)' }}>
+      <FlexCol style={{ flex: '1 1 auto', maxHeight: '100%' }}>
         <Head title={title} description={description} />
         <Titlebar title={'Notifications'} provideBack={false} noComposer />
         <AppViewWrapper>

--- a/src/views/thread/index.js
+++ b/src/views/thread/index.js
@@ -335,10 +335,6 @@ class ThreadContainer extends React.Component<Props, State> {
         return (
           <ThreadViewContainer
             threadViewContext={threadViewContext}
-            constrain={
-              threadViewContext === 'slider' ||
-              threadViewContext === 'fullscreen'
-            }
             data-cy="blocked-thread-view"
           >
             <ThreadContentView slider={slider}>
@@ -359,10 +355,6 @@ class ThreadContainer extends React.Component<Props, State> {
           <ThreadViewContainer
             data-cy="thread-view"
             threadViewContext={threadViewContext}
-            constrain={
-              threadViewContext === 'slider' ||
-              threadViewContext === 'fullscreen'
-            }
           >
             {shouldRenderThreadSidebar && (
               <Sidebar
@@ -444,9 +436,6 @@ class ThreadContainer extends React.Component<Props, State> {
         <ThreadViewContainer
           data-cy="thread-view"
           threadViewContext={threadViewContext}
-          constrain={
-            threadViewContext === 'slider' || threadViewContext === 'fullscreen'
-          }
         >
           {shouldRenderThreadSidebar && (
             <Sidebar

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -18,14 +18,13 @@ export const ThreadViewContainer = styled.div`
   display: flex;
   width: 100%;
   height: 100%;
-  max-height: ${props => (props.constrain ? 'calc(100% - 48px)' : '100%')};
+  max-height: 100%;
   max-width: 1024px;
   background-color: ${({ theme }) => theme.bg.wash};
   margin: ${props =>
     props.threadViewContext === 'fullscreen' ? '0 auto' : '0'};
 
   @media (max-width: 1024px) {
-    max-height: 100%;
     flex-direction: column;
     overflow: hidden;
   }


### PR DESCRIPTION
# Focus styles:
![kapture 2018-04-05 at 22 57 51](https://user-images.githubusercontent.com/9154236/38391570-e2686062-3924-11e8-85bf-392a2ed0fafa.gif)

# Skip link “in action”:
![kapture 2018-04-05 at 23 30 01](https://user-images.githubusercontent.com/9154236/38392883-589d6ed6-3929-11e8-975c-22a247fdaed4.gif)

# PR Description

Heyo. Here are the list of changes this PR introduce (you can browse the PR commit by commit, that could help you make sense of it):
- Add focus styles to the NavBar 4edab0d71803cd6ca98e2ca7db9cce0190b52862.
- Remove the ability to focus the logo (it links to the same page as the next item in the navbar and it’s just a meaningless icon anyway. It’s still clickable.) edae63007b0c6af31fe95bba301dc31a87543e94.
- Add a skip link 2bb3b8e1c7917460529ebe2f42e93fafaa658c96. [Why you might want that](https://a11yproject.com/posts/skip-nav-links/).
- Add `aria-current="page"` to the link of the current page c485a9632888ad24d389f5e0419ef8f9557732b7. [What it communicates](https://tink.uk/using-the-aria-current-attribute/).
- Filter out invalid props from `<Link>` component a5d5f54571c7d52f33cf2e0a91a34f512cb7bbca. This PR added warnings for the `isHidden` prop but there was already a warning for the `loggedOut` prop on the unauthenticated header. This commit fixes that.

I didn’t touch the `ProfileDropdown`.

**Status**
- [ ] WIP
- [ ] Ready for review
- [x] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Add focus styles to the nav bar
- Add skip link to the nav bar
- Improve overall accessibility of the navbar

