### PR TITLE
Fix composer on mobile

### DIFF
--- a/src/components/composer/index.js
+++ b/src/components/composer/index.js
@@ -73,6 +73,7 @@ type Props = {
   history: Object,
   location: Object,
   activeCommunity?: string,
+  activeCommunityId: ?string,
   activeChannel?: string,
   threadSliderIsOpen?: boolean,
   isInbox: boolean,
@@ -171,6 +172,10 @@ class ComposerWithData extends Component<Props, State> {
     if (activeSlug) {
       community = communities.find(
         community => community.slug.toLowerCase() === activeSlug.toLowerCase()
+      );
+    } else if (props.activeCommunityId) {
+      community = communities.find(
+        community => community.id === props.activeCommunityId
       );
     } else {
       community = communities && communities.length > 0 ? communities[0] : null;
@@ -713,6 +718,7 @@ const mapStateToProps = state => ({
   threadSliderIsOpen: state.threadSlider.isOpen,
   websocketConnection: state.connectionStatus.websocketConnection,
   networkOnline: state.connectionStatus.networkOnline,
+  activeCommunityId: state.dashboardFeed.activeCommunity,
 });
 
 // $FlowIssue


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Certainly a naive approach for that fix.
On desktop we rely on the slug, can not we rely on community id instead ?
What do you think ?

close: #2683
