### PR TITLE
Mention to setup the testing database before running cypress tests

### DIFF
--- a/docs/testing/integration.md
+++ b/docs/testing/integration.md
@@ -2,7 +2,16 @@
 
 # Integration tests
 
-We use [Cypress](https://cypress.io) to run our integration tests, which gives you a nice GUI that you can use for your test runs. To run integration tests you have to have both api and the client running. You also need API to be connected to the test database, which you do by setting `TEST_DB`:
+We use [Cypress](https://cypress.io) to run our integration tests, which gives you a nice GUI that you can use for your test runs.
+
+If you're running the tests for the first time, make sure to set up the testing database, by setting `NODE_ENV` to `test` and running the migration script:
+
+```sh
+# One-time test database setup
+NODE_ENV=test yarn run db:migrate
+```
+
+Next, you have to have both api and the client running. You'll also need the API connected to the test database, which you do by setting `TEST_DB`:
 
 ```sh
 # In one tab
@@ -66,4 +75,3 @@ it('should render', () => {
   cy.get('[data-cy="home-page"]').should('be.visible');
 });
 ```
-


### PR DESCRIPTION
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

### Changes
- Adds instructions on how to set up the testing database in the integration test docs

### Context
I had issues with running the cypress tests and talked with @mxstbr about it [here](https://spectrum.chat/spectrum/open?thread=2e712f69-78df-41c8-b248-7816b2176d04). In short, I was getting this error: `ReqlOpFailedError: Database testing does not exist in: ...` for both `TEST_DB=true yarn dev:api` and `yarn run cypress:open`.

He mentioned the migration script, so I took a look at it and noticed that it runs for the `testing`  database when the`NODE_ENV` flag is set to `test`. So I ran the migration script again for the testing database and everything was good. Was this just a thing missing in the docs? Or do we still need to update that `setup.js` file?