### PR TITLE
First implementation of platform level blocking

### DIFF
--- a/api/queries/user/rootCurrentUser.js
+++ b/api/queries/user/rootCurrentUser.js
@@ -1,4 +1,5 @@
 // @flow
 import type { GraphQLContext } from '../../';
 
-export default (_: any, __: any, { user }: GraphQLContext) => user;
+export default (_: any, __: any, { user }: GraphQLContext) =>
+  user ? (user.bannedAt ? null : user) : null;

--- a/api/routes/api/graphql.js
+++ b/api/routes/api/graphql.js
@@ -14,7 +14,7 @@ export default graphqlExpress(req => ({
   formatError: createErrorFormatter(req),
   tracing: true,
   context: {
-    user: req.user,
+    user: req.user ? (req.user.bannedAt ? null : req.user) : null,
     loaders: createLoaders(),
   },
   validationRules: [

--- a/docs/operations/banning-users.md
+++ b/docs/operations/banning-users.md
@@ -1,0 +1,54 @@
+[Table of contents](../readme.md) / [Operations](./index.md)
+
+# Banning users
+
+Occassionally bad actors will show up on Spectrum and become toxic, spam communities, harass others, or violate our code of conduct. We have a safe way to ban these users in a way that respects the integrity of data across the rest of the database.
+
+**Do NOT ever `.delete()` a user record from the database!!**
+
+Follow these steps to safely ban a user from Spectrum:
+
+1. Find the user in the database
+2. Update the user with the following fields:
+```
+r.db('spectrum')
+.table('users')
+.get(ID)
+.update({
+  bannedAt: new Date(),
+  bannedBy: YOUR_USER_ID,
+  bannedReason: "Reason for ban here"
+})
+```
+4. Remove that user as a member from all communities and channels:
+```
+// usersCommunities
+.table('usersCommunities')
+.getAll(ID, { index: 'userId' })
+.update({
+  isOwner: false,
+  isModerator: false,
+  isMember: false,
+  receiveNotifications: false
+})
+
+// usersChannels
+.table('usersChannels')
+.getAll(ID, { index: 'userId' })
+.update({
+  isOwner: false,
+  isModerator: false,
+  isMember: false,
+  receiveNotifications: false,
+})
+```
+5. Remove all notifications from threads to save worker processing:
+```
+// usersThreads
+.table('usersThreads')
+.getAll(ID, { index: 'userId' })
+.update({
+  receiveNotifications: false,
+})
+```
+6. Done! The user now can't be messaged, searched for, or re-logged into. The banned user no longer affects community or channel member counts, and will not ever get pulled into Athena for notifications processing.

--- a/docs/operations/deleting-users.md
+++ b/docs/operations/deleting-users.md
@@ -1,4 +1,4 @@
-[Table of contents](../readme.md)
+[Table of contents](../readme.md) / [Operations](./index.md)
 
 # Deleting users
 

--- a/docs/operations/deleting-users.md
+++ b/docs/operations/deleting-users.md
@@ -35,6 +35,8 @@ r.db('spectrum')
 .table('usersCommunities')
 .getAll(ID, { index: 'userId' })
 .update({
+  isOwner: false,
+  isModerator: false,
   isMember: false,
   receiveNotifications: false
 })
@@ -43,6 +45,8 @@ r.db('spectrum')
 .table('usersChannels')
 .getAll(ID, { index: 'userId' })
 .update({
+  isOwner: false,
+  isModerator: false,
   isMember: false,
   receiveNotifications: false,
 })

--- a/docs/operations/importing-rethinkdb-backups.md
+++ b/docs/operations/importing-rethinkdb-backups.md
@@ -1,4 +1,4 @@
-[Table of contents](../readme.md)
+[Table of contents](../readme.md) / [Operations](./index.md)
 
 # Importing production data locally
 

--- a/docs/operations/intro.md
+++ b/docs/operations/intro.md
@@ -3,5 +3,6 @@
 This directory is for docs related to operating the Spectrum platform. Common questions about how to perform non-code-related tasks should go here.
 
 Learn more about:
+- [Banning users](banning-users.md)
 - [Deleting users](deleting-users.md)
 - [Importing a RethinkDB backup locally](importing-rethinkdb-backups.md)

--- a/pluto/changefeeds/privateChannel.js
+++ b/pluto/changefeeds/privateChannel.js
@@ -81,7 +81,7 @@ export const privateChannelArchived = () =>
 
 export const privateChannelRestored = () =>
   listenToDeletedFieldIn(db, 'archivedAt')('channels', (channel: DBChannel) => {
-    debug('Channel archived');
+    debug('Channel restored');
 
     if (channel.isPrivate && channel.archivedAt) {
       debug(`Private channel ${channel.name} archived`);

--- a/shared/changefeed-utils/index.js
+++ b/shared/changefeed-utils/index.js
@@ -42,8 +42,12 @@ export const hasDeletedField = (db: any, field: string) =>
   db
     .row('old_val')
     .hasFields(field)
-    .and(db.row('new_val').hasFields(field))
-    .not();
+    .and(
+      db
+        .row('new_val')
+        .hasFields(field)
+        .not()
+    );
 
 export const createChangefeed = (
   getChangefeed: () => Promise<Cursor>,

--- a/vulcan/index.js
+++ b/vulcan/index.js
@@ -14,7 +14,13 @@ import {
   editedCommunity,
 } from './models/community';
 import { newMessage, deletedMessage } from './models/message';
-import { newUser, deletedUser, editedUser } from './models/user';
+import {
+  newUser,
+  deletedUser,
+  editedUser,
+  bannedUser,
+  unbannedUser,
+} from './models/user';
 import createServer from './server';
 
 console.log('\n✉️ Vulcan, the search worker, is starting...');
@@ -39,6 +45,8 @@ editedCommunity();
 
 newUser();
 deletedUser();
+bannedUser();
+unbannedUser();
 editedUser();
 
 newMessage();
@@ -47,8 +55,9 @@ deletedMessage();
 const server = createServer();
 server.listen(PORT, 'localhost', () => {
   console.log(
-    `💉 Healthcheck server running at ${server.address()
-      .address}:${server.address().port}`
+    `💉 Healthcheck server running at ${server.address().address}:${
+      server.address().port
+    }`
   );
 });
 

--- a/vulcan/index.js
+++ b/vulcan/index.js
@@ -23,11 +23,11 @@ import {
 } from './models/user';
 import createServer from './server';
 
-console.log('\n✉️ Vulcan, the search worker, is starting...');
+debug('\n✉️ Vulcan, the search worker, is starting...');
 debug('Logging with debug enabled!');
-console.log('');
+debug('');
 
-console.log(
+debug(
   `🗄 Vulcan open for business ${(process.env.NODE_ENV === 'production' &&
     // $FlowIssue
     `at ${process.env.COMPOSE_REDIS_URL}:${process.env.COMPOSE_REDIS_PORT}`) ||
@@ -54,7 +54,7 @@ deletedMessage();
 
 const server = createServer();
 server.listen(PORT, 'localhost', () => {
-  console.log(
+  debug(
     `💉 Healthcheck server running at ${server.address().address}:${
       server.address().port
     }`


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

@mxstbr I was about to severely over-complicate this task before realizing we can handle banning users at a platform level quite easily. Basically we just don't want someone who is banned to:
- query things they shouldn't be able to query
- perform any mutations
- sign in

My first attempt was to add some express middleware that would intercept `req.user`, determine if the user was blocked, and then send a failure status or a `res.redirect()` to the client - that worked fine enough, except for the `apollo-link-retry` logic which would try and query `getCurrentUser` 6 times due to a "Failure to fetch" response from the initial query.

To get around this, I've just moved the banning logic to two places:
1. During context setting, we just return null if the user in the db has a `bannedAt` field - this means that all downstream queries + mutations *already* handle the logic of not serving queries/mutations if there is no `context.user` present
2. To prevent `apollo-link-retry` from performing its 6 retries, I simply resolve the `getCurrentUser` (the first query that runs on app load to auth user) based on the presence of the `bannedAt` field.

This has the intended effect of banned users never being able to perform any queries or mutations, and will be stuck in an infinite sign in loop because auth will fail each time.

Let me know if this makes sense or if you can think of any holes that might be present.

