### PR TITLE
Paste image from clipboard into chat input

### DIFF
--- a/src/components/chatInput/components/mediaUploader.js
+++ b/src/components/chatInput/components/mediaUploader.js
@@ -123,7 +123,7 @@ class MediaUploader extends React.Component<Props> {
         <MediaLabel>
           <MediaInput
             type="file"
-            accept={'.png, .jpg, .jpeg, .gif, .mp4'}
+            accept={'.png, .jpg, .jpeg, .gif'}
             multiple={false}
             onChange={this.onChange}
           />

--- a/src/components/chatInput/components/mediaUploader.js
+++ b/src/components/chatInput/components/mediaUploader.js
@@ -83,7 +83,7 @@ class MediaUploader extends React.Component<Props> {
     return this.clearForm();
   }
 
-  onPaste = event => {
+  onPaste = (event: any) => {
     if (!this.props.isFocused) {
       return;
     }

--- a/src/components/chatInput/components/mediaUploader.js
+++ b/src/components/chatInput/components/mediaUploader.js
@@ -15,7 +15,7 @@ type Props = {
   onError: Function,
   currentUser: ?Object,
   isSendingMediaMessage: boolean,
-  isFocused: boolean,
+  inputFocused: boolean,
 };
 
 class MediaUploader extends React.Component<Props> {
@@ -55,6 +55,8 @@ class MediaUploader extends React.Component<Props> {
       return this.props.onError(validationResult);
     }
     this.props.onError('');
+    // clear the form so that another image can be uploaded
+    this.clearForm();
     // send back the validated file
     return this.props.onValidated(file);
   };
@@ -84,11 +86,15 @@ class MediaUploader extends React.Component<Props> {
   }
 
   onPaste = (event: any) => {
-    if (!this.props.isFocused) {
+    // Ensure that the image is only pasted if user focuses input
+    if (!this.props.inputFocused) {
       return;
     }
     const items = (event.clipboardData || event.originalEvent.clipboardData)
       .items;
+    if (!items) {
+      return;
+    }
     for (let item of items) {
       if (item.kind === 'file' && item.type.includes('image/')) {
         this.validatePreview({ valid: true }, item.getAsFile());

--- a/src/components/chatInput/components/mediaUploader.js
+++ b/src/components/chatInput/components/mediaUploader.js
@@ -123,7 +123,7 @@ class MediaUploader extends React.Component<Props> {
         <MediaLabel>
           <MediaInput
             type="file"
-            accept={'.png, .jpg, .jpeg, .gif'}
+            accept={'.png, .jpg, .jpeg, .gif .mp4'}
             multiple={false}
             onChange={this.onChange}
           />

--- a/src/components/chatInput/components/mediaUploader.js
+++ b/src/components/chatInput/components/mediaUploader.js
@@ -11,8 +11,7 @@ import {
 } from 'src/helpers/images';
 
 type Props = {
-  onValidatedUpload: Function,
-  onValidatedPreview: Function,
+  onValidated: Function,
   onError: Function,
   currentUser: ?Object,
   isSendingMediaMessage: boolean,
@@ -50,18 +49,6 @@ class MediaUploader extends React.Component<Props> {
     return null;
   };
 
-  validateUpload = (validity: Object, file: ?Object) => {
-    const validationResult = this.validate(validity, file);
-    if (validationResult !== null) {
-      return this.props.onError(validationResult);
-    }
-    this.props.onError('');
-    // send back the validated file
-    this.props.onValidatedUpload(file);
-    // clear the form so that another image can be uploaded
-    return this.clearForm();
-  };
-
   validatePreview = (validity: Object, file: ?Object) => {
     const validationResult = this.validate(validity, file);
     if (validationResult !== null) {
@@ -69,7 +56,7 @@ class MediaUploader extends React.Component<Props> {
     }
     this.props.onError('');
     // send back the validated file
-    return this.props.onValidatedPreview(file);
+    return this.props.onValidated(file);
   };
 
   onChange = (e: any) => {
@@ -77,7 +64,7 @@ class MediaUploader extends React.Component<Props> {
 
     if (!file) return;
 
-    return this.validateUpload(validity, file);
+    return this.validatePreview(validity, file);
   };
 
   clearForm = () => {

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -32,7 +32,7 @@ type State = {
   code: boolean,
   isSendingMediaMessage: boolean,
   imagePreview: string,
-  imagePreviewFile: object,
+  imagePreviewFile: Blob,
 };
 
 type Props = {
@@ -80,14 +80,14 @@ class ChatInput extends React.Component<Props, State> {
     photoSizeError: '',
     code: false,
     isSendingMediaMessage: false,
-    imagePreview: null,
-    imagePreviewFile: null,
+    imagePreview: '',
+    imagePreviewFile: new Blob(),
   };
 
   editor: any;
 
   componentDidMount() {
-    document.addEventListener('keydown', this.handleKeydown, true);
+    document.addEventListener('keydown', this.handleKeyDown, true);
     this.props.onRef(this);
   }
 
@@ -111,11 +111,11 @@ class ChatInput extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('keydown', this.handleKeydown);
+    document.removeEventListener('keydown', this.handleKeyDown);
     this.props.onRef(undefined);
   }
 
-  handleKeydown = event => {
+  handleKeyDown = (event: any) => {
     const key = event.keyCode || event.charCode;
     // Detect esc key or backspace key (and empty message) to remove
     // the previewed image
@@ -124,8 +124,7 @@ class ChatInput extends React.Component<Props, State> {
       ((key === 8 || key === 46) && toPlainText(this.props.state).length === 0)
     ) {
       this.setState({
-        imagePreview: null,
-        imagePreviewFile: null,
+        imagePreview: '',
       });
     }
   };
@@ -228,7 +227,7 @@ class ChatInput extends React.Component<Props, State> {
       forceScrollToBottom();
     }
 
-    if (this.state.imagePreviewFile !== null) {
+    if (this.state.imagePreview.length) {
       this.sendMediaMessage(this.state.imagePreviewFile);
     }
 
@@ -322,10 +321,10 @@ class ChatInput extends React.Component<Props, State> {
     return 'not-handled';
   };
 
-  sendMediaMessage = file => {
+  sendMediaMessage = (file: Blob) => {
     this.setState({
-      imagePreview: null,
-      imagePreviewFile: null,
+      imagePreview: '',
+      imagePreviewFile: new Blob(),
     });
 
     // eslint-disable-next-line
@@ -487,7 +486,7 @@ class ChatInput extends React.Component<Props, State> {
     const reader = new FileReader();
     reader.onload = () =>
       this.setState({
-        imagePreview: reader.result,
+        imagePreview: reader.result.toString(),
         isSendingMediaMessage: false,
       });
     reader.readAsDataURL(blob);

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -538,8 +538,7 @@ class ChatInput extends React.Component<Props, State> {
           <MediaUploader
             isSendingMediaMessage={isSendingMediaMessage}
             currentUser={currentUser}
-            onValidatedUpload={this.sendMediaMessage}
-            onValidatedPreview={this.previewMedia}
+            onValidated={this.previewMedia}
             onError={this.setMediaMessageError}
             isFocused={isFocused}
           />

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -31,8 +31,8 @@ type State = {
   photoSizeError: string,
   code: boolean,
   isSendingMediaMessage: boolean,
-  imagePreview: string,
-  imagePreviewFile: Blob,
+  mediaPreview: string,
+  mediaPreviewFile: Blob,
 };
 
 type Props = {
@@ -80,8 +80,8 @@ class ChatInput extends React.Component<Props, State> {
     photoSizeError: '',
     code: false,
     isSendingMediaMessage: false,
-    imagePreview: '',
-    imagePreviewFile: new Blob(),
+    mediaPreview: '',
+    mediaPreviewFile: new Blob(),
   };
 
   editor: any;
@@ -105,7 +105,7 @@ class ChatInput extends React.Component<Props, State> {
     if (curr.state !== next.state) return true;
     if (currState.isSendingMediaMessage !== nextState.isSendingMediaMessage)
       return true;
-    if (currState.imagePreview !== nextState.imagePreview) return true;
+    if (currState.mediaPreview !== nextState.mediaPreview) return true;
 
     return false;
   }
@@ -123,9 +123,7 @@ class ChatInput extends React.Component<Props, State> {
       key === 27 ||
       ((key === 8 || key === 46) && toPlainText(this.props.state).length === 0)
     ) {
-      this.setState({
-        imagePreview: '',
-      });
+      this.removeMediaPreview();
     }
   };
 
@@ -227,8 +225,8 @@ class ChatInput extends React.Component<Props, State> {
       forceScrollToBottom();
     }
 
-    if (this.state.imagePreview.length) {
-      this.sendMediaMessage(this.state.imagePreviewFile);
+    if (this.state.mediaPreview.length) {
+      this.sendMediaMessage(this.state.mediaPreviewFile);
     }
 
     // If the input is empty don't do anything
@@ -321,11 +319,15 @@ class ChatInput extends React.Component<Props, State> {
     return 'not-handled';
   };
 
-  sendMediaMessage = (file: Blob) => {
+  removeMediaPreview = () => {
     this.setState({
-      imagePreview: '',
-      imagePreviewFile: new Blob(),
+      mediaPreview: '',
+      mediaPreviewFile: new Blob(),
     });
+  };
+
+  sendMediaMessage = (file: Blob) => {
+    this.removeMediaPreview();
 
     // eslint-disable-next-line
     let reader = new FileReader();
@@ -481,12 +483,12 @@ class ChatInput extends React.Component<Props, State> {
     }
     this.setState({
       isSendingMediaMessage: true,
-      imagePreviewFile: blob,
+      mediaPreviewFile: blob,
     });
     const reader = new FileReader();
     reader.onload = () =>
       this.setState({
-        imagePreview: reader.result.toString(),
+        mediaPreview: reader.result.toString(),
         isSendingMediaMessage: false,
       });
     reader.readAsDataURL(blob);
@@ -504,7 +506,7 @@ class ChatInput extends React.Component<Props, State> {
       photoSizeError,
       code,
       isSendingMediaMessage,
-      imagePreview,
+      mediaPreview,
     } = this.state;
 
     const networkDisabled =
@@ -539,7 +541,7 @@ class ChatInput extends React.Component<Props, State> {
             currentUser={currentUser}
             onValidated={this.previewMedia}
             onError={this.setMediaMessageError}
-            isFocused={isFocused}
+            inputFocused={isFocused}
           />
         )}
         <IconButton
@@ -553,7 +555,8 @@ class ChatInput extends React.Component<Props, State> {
         />
         <Form focus={isFocused}>
           <Input
-            imagePreview={imagePreview}
+            mediaPreview={mediaPreview}
+            onRemoveMedia={this.removeMediaPreview}
             focus={isFocused}
             placeholder={`Your ${code ? 'code' : 'message'} here...`}
             editorState={state}

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -17,7 +17,7 @@ import 'prismjs/components/prism-ruby';
 import 'prismjs/components/prism-swift';
 import createPrismPlugin from 'draft-js-prism-plugin';
 
-import { InputWrapper } from './style';
+import { InputWrapper, Image } from './style';
 
 type Props = {
   editorState: Object,
@@ -29,6 +29,7 @@ type Props = {
   readOnly?: boolean,
   editorRef?: any => void,
   networkDisabled: boolean,
+  imagePreview?: string,
 };
 
 type State = {
@@ -97,12 +98,14 @@ class Input extends React.Component<Props, State> {
       editorRef,
       code,
       networkDisabled,
+      imagePreview,
       ...rest
     } = this.props;
     const { plugins } = this.state;
 
     return (
       <InputWrapper code={code} focus={focus} networkDisabled={networkDisabled}>
+        {imagePreview && <Image src={imagePreview} />}
         <DraftEditor
           editorState={editorState}
           onChange={onChange}

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -17,7 +17,7 @@ import 'prismjs/components/prism-ruby';
 import 'prismjs/components/prism-swift';
 import createPrismPlugin from 'draft-js-prism-plugin';
 
-import { InputWrapper, ImagePreview } from './style';
+import { InputWrapper, MediaPreview } from './style';
 
 type Props = {
   editorState: Object,
@@ -29,7 +29,8 @@ type Props = {
   readOnly?: boolean,
   editorRef?: any => void,
   networkDisabled: boolean,
-  imagePreview?: string,
+  mediaPreview?: string,
+  onRemoveMedia: Object => void,
 };
 
 type State = {
@@ -98,14 +99,20 @@ class Input extends React.Component<Props, State> {
       editorRef,
       code,
       networkDisabled,
-      imagePreview,
+      mediaPreview,
+      onRemoveMedia,
       ...rest
     } = this.props;
     const { plugins } = this.state;
 
     return (
       <InputWrapper code={code} focus={focus} networkDisabled={networkDisabled}>
-        {imagePreview && <ImagePreview src={imagePreview} />}
+        {mediaPreview && (
+          <MediaPreview>
+            <img src={mediaPreview} alt="" />
+            <button onClick={onRemoveMedia} />
+          </MediaPreview>
+        )}
         <DraftEditor
           editorState={editorState}
           onChange={onChange}

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -17,7 +17,7 @@ import 'prismjs/components/prism-ruby';
 import 'prismjs/components/prism-swift';
 import createPrismPlugin from 'draft-js-prism-plugin';
 
-import { InputWrapper, Image } from './style';
+import { InputWrapper, ImagePreview } from './style';
 
 type Props = {
   editorState: Object,
@@ -105,7 +105,7 @@ class Input extends React.Component<Props, State> {
 
     return (
       <InputWrapper code={code} focus={focus} networkDisabled={networkDisabled}>
-        {imagePreview && <Image src={imagePreview} />}
+        {imagePreview && <ImagePreview src={imagePreview} />}
         <DraftEditor
           editorState={editorState}
           onChange={onChange}

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -195,3 +195,13 @@ export const PhotoSizeError = styled.div`
     align-self: center;
   }
 `;
+
+export const Image = styled.img`
+  display: block;
+  clear: both;
+  flex: 0 0 auto;
+  vertical-align: middle;
+  border-radius: 16px;
+  max-width: 37%;
+  padding-bottom: 10px;
+`;

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -196,7 +196,7 @@ export const PhotoSizeError = styled.div`
   }
 `;
 
-export const Image = styled.img`
+export const ImagePreview = styled.img`
   display: block;
   clear: both;
   flex: 0 0 auto;

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -196,12 +196,46 @@ export const PhotoSizeError = styled.div`
   }
 `;
 
-export const ImagePreview = styled.img`
-  display: block;
-  clear: both;
-  flex: 0 0 auto;
-  vertical-align: middle;
-  border-radius: 16px;
-  max-width: 37%;
+export const MediaPreview = styled.div`
+  padding-top: 8px;
   padding-bottom: 10px;
+
+  & > img {
+    border-radius: 16px;
+    max-width: 37%;
+    opacity: 0.2;
+  }
+
+  button {
+    position: relative;
+    top: -5px;
+    left: -25px;
+    vertical-align: top;
+    background: #16171a;
+    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.15);
+    transition: box-shadow 0.3s ease-in-out;
+    border: none;
+    border-radius: 40px;
+    outline: none;
+    width: 32px;
+    height: 32px;
+    cursor: pointer;
+  }
+
+  button:after {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    content: '\\d7';
+    font-size: 21px;
+    color: #fff;
+    line-height: 28px;
+    text-align: center;
+  }
+
+  button:hover {
+    box-shadow: 0px 8px 8px rgba(0, 0, 0, 0.15);
+  }
 `;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [x] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This change enables users to paste images directly into the chat input (Ctrl + V) as requested in https://github.com/withspectrum/spectrum/issues/2755. The image is previewed before it can be posted with an optional message as shown in the GIF below.

![kapture 2018-04-07 at 15 16 10](https://user-images.githubusercontent.com/5003405/38455320-b98c0722-3a76-11e8-8ea7-a693b3d7611f.gif)

