### PR TITLE
Display sign in buttons in a grid

### DIFF
--- a/src/components/loginButtonSet/style.js
+++ b/src/components/loginButtonSet/style.js
@@ -3,9 +3,13 @@ import styled from 'styled-components';
 import { zIndex } from '../globals';
 
 export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-gap: 16px;
+  align-items: flex-end;
   padding: 16px 0;
+  @media (min-width: 768px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
 `;
 
 export const A = styled.a`
@@ -27,9 +31,9 @@ export const SigninButton = styled.div`
   font-size: 15px;
   font-weight: 600;
   position: relative;
-  margin: 8px 0;
   width: 100%;
-  margin-top: ${props => (props.showAfter ? '40px' : '8px')};
+  cursor: pointer;
+  ${props => props.showAfter && `margin-top: 32px`};
 
   ${props =>
     props.showAfter &&
@@ -48,20 +52,6 @@ export const SigninButton = styled.div`
 			}
 		`} svg {
     fill: currentColor !important;
-  }
-
-  @media (max-width: 768px) {
-    margin: 16px 0;
-
-    ${props =>
-      props.showAfter &&
-      `
-        margin: 48px 0 16px 0;
-      `};
-  }
-
-  &:hover {
-    cursor: pointer;
   }
 `;
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Display sign in buttons in a grid

The current sign in buttons feel a little awkward in a single column:
<img width="732" alt="screen shot 2018-04-07 at 5 41 30 pm" src="https://user-images.githubusercontent.com/5074763/38460608-26b43310-3a8b-11e8-98ef-30c6bb553c46.png">

The new grid:
<img width="756" alt="screen shot 2018-04-07 at 5 40 59 pm" src="https://user-images.githubusercontent.com/5074763/38460607-26a57e1a-3a8b-11e8-931c-e9081c808f65.png">

When there's a preferred method:
<img width="748" alt="screen shot 2018-04-07 at 5 40 41 pm" src="https://user-images.githubusercontent.com/5074763/38460606-26935c9e-3a8b-11e8-8b22-64119507753b.png">

The column remains the same on mobile.
