### PR TITLE
Clear search input after user switches between communities

### DIFF
--- a/src/reducers/dashboardFeed.js
+++ b/src/reducers/dashboardFeed.js
@@ -22,6 +22,10 @@ export default function dashboardFeed(state = initialState, action) {
     case 'SELECT_FEED_CHANNEL':
       return Object.assign({}, state, {
         activeChannel: action.channelId,
+        search: {
+          ...state.search,
+          queryString: '',
+        },
       });
     case 'REMOVE_MOUNTED_THREAD_ID':
       return Object.assign({}, state, {

--- a/src/views/dashboard/components/threadSearch.js
+++ b/src/views/dashboard/components/threadSearch.js
@@ -37,6 +37,14 @@ class ThreadSearch extends React.Component<Props, State> {
     document.removeEventListener('keydown', this.handleKeyPress, false);
   }
 
+  componentWillReceiveProps({ queryString }) {
+    if (this.state.value !== queryString) {
+      this.setState({
+        value: queryString,
+      });
+    }
+  }
+
   handleKeyPress = (e: any) => {
     // escape
     if (e.keyCode === 27) {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- when user will switch between communities the search input will be cleared;

