### PR TITLE
Possibly fix broken chat input layout

### DIFF
--- a/src/views/thread/index.js
+++ b/src/views/thread/index.js
@@ -232,9 +232,10 @@ class ThreadContainer extends React.Component<Props, State> {
     const { channelPermissions } = thread.channel;
     const { communityPermissions } = thread.community;
 
-    const canSendMessages =
-      !channelPermissions.isBlocked && !communityPermissions.isBlocked;
-    if (!canSendMessages) return null;
+    const isBlockedInChannelOrCommunity =
+      channelPermissions.isBlocked || communityPermissions.isBlocked;
+
+    if (isBlockedInChannelOrCommunity) return null;
 
     const LS_KEY = 'last-chat-input-content';
     let storedContent;
@@ -264,23 +265,21 @@ class ThreadContainer extends React.Component<Props, State> {
       </Input>
     );
 
-    if (!currentUser) {
+    if (!currentUser || !currentUser.id) {
       return chatInputComponent;
     }
 
-    if (currentUser) {
-      if (storedContent) {
-        return chatInputComponent;
-      }
-
-      if (channelPermissions.isMember) {
-        return chatInputComponent;
-      }
-
-      return (
-        <JoinChannel channel={thread.channel} community={thread.community} />
-      );
+    if (storedContent) {
+      return chatInputComponent;
     }
+
+    if (channelPermissions.isMember) {
+      return chatInputComponent;
+    }
+
+    return (
+      <JoinChannel channel={thread.channel} community={thread.community} />
+    );
   };
 
   render() {

--- a/src/views/thread/index.js
+++ b/src/views/thread/index.js
@@ -265,7 +265,11 @@ class ThreadContainer extends React.Component<Props, State> {
       </Input>
     );
 
-    if (!currentUser || !currentUser.id) {
+    if (!currentUser) {
+      return chatInputComponent;
+    }
+
+    if (currentUser && !currentUser.id) {
       return chatInputComponent;
     }
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Fix a bug where the chat input would have broken formatting on first load

I'm not entirely sure if this fixes this bug, because the bug is super sporadic and I can't trace down a predictable repro flow. That being said, I *think* the issue was a condition where the `renderChatInputOrUpsell` function was returning two things, which broke the formatting of the chat, like this:
<img width="1680" alt="screenshot 2018-04-07 18 34 49" src="https://user-images.githubusercontent.com/1923260/38462065-9d25409e-3a94-11e8-97b1-4003f61e4714.png">

Let's ship this and keep an eye out for this error occurring again; I wish I'd taken more time when I hit the error state on web to inspect elements there.