### PR TITLE
Fixes user profiles in top members component of analytics

### DIFF
--- a/api/queries/community/topMembers.js
+++ b/api/queries/community/topMembers.js
@@ -6,7 +6,7 @@ const { getTopMembersInCommunity } = require('../../models/reputationEvents');
 
 export default async (
   { id }: DBCommunity,
-  __: any,
+  _: any,
   { user, loaders }: GraphQLContext
 ) => {
   const currentUser = user;
@@ -26,8 +26,16 @@ export default async (
     );
   }
 
-  return getTopMembersInCommunity(id).then(users => {
-    if (!users) return [];
-    return loaders.user.loadMany(users);
+  // $FlowFixMe
+  const userIds = await getTopMembersInCommunity(id);
+
+  if (!userIds || userIds.length === 0) {
+    return [];
+  }
+
+  return getTopMembersInCommunity(id).then(usersIds => {
+    const permissionsArray = usersIds.map(userId => [userId, id]);
+    // $FlowIssue
+    return loaders.userPermissionsInCommunity.loadMany(permissionsArray);
   });
 };

--- a/api/types/Community.js
+++ b/api/types/Community.js
@@ -150,7 +150,7 @@ const Community = /* GraphQL */ `
     isPro: Boolean @cost(complexity: 1)
     memberGrowth: GrowthData @cost(complexity: 10)
     conversationGrowth: GrowthData @cost(complexity: 3)
-    topMembers: [User] @cost(complexity: 10)
+    topMembers: [CommunityMember] @cost(complexity: 10)
     topAndNewThreads: TopAndNewThreads @cost(complexity: 4)
 		watercooler: Thread
 		brandedLogin: BrandedLogin

--- a/shared/graphql/queries/community/getCommunityTopMembers.js
+++ b/shared/graphql/queries/community/getCommunityTopMembers.js
@@ -3,22 +3,13 @@ import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 import communityInfoFragment from 'shared/graphql/fragments/community/communityInfo';
 import type { CommunityInfoType } from '../../fragments/community/communityInfo';
-import userInfoFragment from 'shared/graphql/fragments/user/userInfo';
-import type { UserInfoType } from '../../fragments/user/userInfo';
-
-type User = {
-  ...$Exact<UserInfoType>,
-  isPro: boolean,
-  contextPermissions: {
-    reputation: number,
-    isOwner: boolean,
-    isModerator: boolean,
-  },
-};
+import communityMemberInfoFragment, {
+  type CommunityMemberInfoType,
+} from '../../fragments/communityMember/communityMemberInfo';
 
 export type GetCommunityTopMembersType = {
   ...$Exact<CommunityInfoType>,
-  topMembers: Array<?User>,
+  topMembers: Array<?CommunityMemberInfoType>,
 };
 
 export const getCommunityTopMembersQuery = gql`
@@ -26,18 +17,12 @@ export const getCommunityTopMembersQuery = gql`
     community(id: $id) {
       ...communityInfo
       topMembers {
-        ...userInfo
-        isPro
-        contextPermissions {
-          reputation
-          isOwner
-          isModerator
-        }
+        ...communityMemberInfo
       }
     }
   }
   ${communityInfoFragment}
-  ${userInfoFragment}
+  ${communityMemberInfoFragment}
 `;
 
 const getCommunityTopMembersOptions = {

--- a/src/views/communityAnalytics/style.js
+++ b/src/views/communityAnalytics/style.js
@@ -65,3 +65,20 @@ export const ThreadListItemSubtitle = styled.h5`
     color: ${props => props.theme.text.default};
   }
 `;
+
+export const MessageIconContainer = styled.div`
+  color: ${props => props.theme.text.alt};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  &:hover {
+    color: ${props => props.theme.brand.alt};
+  }
+`;
+
+export const UserListItemContainer = styled.div`
+  padding: 0 16px;
+  border-bottom: 1px solid ${props => props.theme.bg.wash};
+`;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Fixes a bug where reputation wouldn't appear in the 'Top members' component of community analytics

cc @mxstbr - I'm swapping the TopMembers component to return `CommunityMember` instead of `User` types - this may be breaking, but will just prompt for the component to refresh the page and get the new frontend bundle. I don't see this happening given volume of analytics users who would land directly on this view without navigating first to trigger a sw update.

