### PR TITLE
Swap spectrum api keys in alpha to keep in sync with prod hotfix

### DIFF
--- a/athena/queues/moderationEvents/message.js
+++ b/athena/queues/moderationEvents/message.js
@@ -1,10 +1,9 @@
 // @flow
-const debug = require('debug')('athena:queue:channel-notification');
+const debug = require('debug')('athena:queue:moderation-events:message');
 import { getUserById } from '../../models/user';
 import { getThreadById } from '../../models/thread';
 import { getCommunityById } from '../../models/community';
 import { getChannelById } from '../../models/channel';
-import type { DBMessage } from 'shared/types';
 import { toState, toPlainText } from 'shared/draft-utils';
 import getSpectrumScore from './spectrum';
 import getPerspectiveScore from './perspective';

--- a/athena/queues/moderationEvents/perspective.js
+++ b/athena/queues/moderationEvents/perspective.js
@@ -1,5 +1,5 @@
 // @flow
-const debug = require('debug')('athena:queue:moderation:perspective');
+const debug = require('debug')('athena:queue:moderation-events:perspective');
 require('now-env');
 import axios from 'axios';
 const PERSPECTIVE_API_KEY = process.env.PERSPECTIVE_API_KEY;

--- a/athena/queues/moderationEvents/spectrum.js
+++ b/athena/queues/moderationEvents/spectrum.js
@@ -1,12 +1,20 @@
 // @flow
+const debug = require('debug')('athena:queue:moderation-events:spectrum');
+require('now-env');
 import axios from 'axios';
+const SPECTRUM_MODERATION_API_KEY = process.env.SPECTRUM_MODERATION_API_KEY;
+
+if (!SPECTRUM_MODERATION_API_KEY) {
+  debug('No API key for Spectrum provided, not sending moderation events.');
+}
 
 export default async (text: string, contextId: string, userId: string) => {
+  if (!SPECTRUM_MODERATION_API_KEY) return;
   const request = await axios({
     method: 'post',
     url: 'https://api.prod.getspectrum.io/api/v1/classification',
     headers: {
-      Authorization: 'Apikey 205276812f89fcec2856d48c9192b2588',
+      Authorization: `Apikey ${SPECTRUM_MODERATION_API_KEY}`,
       'Content-Type': 'application/json',
     },
     data: {

--- a/athena/queues/moderationEvents/thread.js
+++ b/athena/queues/moderationEvents/thread.js
@@ -1,9 +1,8 @@
 // @flow
-const debug = require('debug')('athena:queue:channel-notification');
+const debug = require('debug')('athena:queue:moderation-events:thread');
 import { getUserById } from '../../models/user';
 import { getCommunityById } from '../../models/community';
 import { getChannelById } from '../../models/channel';
-import type { DBThread } from 'shared/types';
 import { toState, toPlainText } from 'shared/draft-utils';
 import getSpectrumScore from './spectrum';
 import getPerspectiveScore from './perspective';

--- a/now.json
+++ b/now.json
@@ -38,6 +38,7 @@
 		"ALGOLIA_APP_ID": "@algolia-app-id",
 		"ALGOLIA_API_SECRET": "@algolia-api-secret",
 		"APOLLO_ENGINE_API_KEY": "@apollo-engine-api-key",
-    "API_TOKEN_SECRET": "@api-token-secret"
+		"API_TOKEN_SECRET": "@api-token-secret",
+		"SPECTRUM_MODERATION_API_KEY": "@spectrum-moderation-api-key"
 	}
 }


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

This has already been hotfix deployed to production athena. Next place we'll need it on alpha api.