### PR TITLE
Sort and preserve order of participant heads

### DIFF
--- a/src/views/dashboard/components/facepile.js
+++ b/src/views/dashboard/components/facepile.js
@@ -55,9 +55,9 @@ const Facepile = ({ participants, author, active }) => {
     );
   }
 
-  const participantList = participants.filter(
-    participant => participant.id !== author.id
-  );
+  const participantList = participants
+    .filter(participant => participant.id !== author.id)
+    .sort((a, b) => (a.username <= b.username ? -1 : 1));
   const participantCount = participants.length;
 
   const hasOverflow = participantCount > NUM_TO_DISPLAY;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Fixes a distracting bug that would reorder the participants of a conversation any time the thread was clicked

Closes #2814 

