### PR TITLE
Implement close modal handler for create/restore channel modals 

### DIFF
--- a/src/components/modals/CreateChannelModal/index.js
+++ b/src/components/modals/CreateChannelModal/index.js
@@ -354,7 +354,9 @@ class CreateChannelModal extends React.Component<Props, State> {
             </UpsellDescription>
 
             <Actions>
-              <TextButton color={'warn.alt'}>Cancel</TextButton>
+              <TextButton onClick={this.close} color={'warn.alt'}>
+                Cancel
+              </TextButton>
               <Button
                 disabled={
                   !name ||

--- a/src/components/modals/RestoreChannelModal/index.js
+++ b/src/components/modals/RestoreChannelModal/index.js
@@ -91,7 +91,9 @@ class RestoreChannelModal extends React.Component<Props, State> {
             )}
 
             <Actions>
-              <TextButton color={'warn.alt'}>Cancel</TextButton>
+              <TextButton onClick={this.close} color={'warn.alt'}>
+                Cancel
+              </TextButton>
               <Button
                 disabled={channel.isPrivate && !hasChargeableSource}
                 loading={isLoading}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Minor bug affecting the create and restore channel modals where the cancel button reloads the app instead of using the `close` handler to hide the modal.

