### PR TITLE
Fix local mobile singin

### DIFF
--- a/api/utils/is-spectrum-url.js
+++ b/api/utils/is-spectrum-url.js
@@ -3,7 +3,7 @@ import { URL } from 'url';
 import { RELATIVE_URL } from 'shared/regexps';
 const IS_PROD = process.env.NODE_ENV === 'production';
 
-const EXPO_URL = /^https:\/\/auth\.expo\.io\/@(mxstbr|uberbryn|brianlovin)\//;
+const EXPO_URL = /^https:\/\/auth\.expo\.io\//;
 
 /**
  * Make a URL string is a spectrum.chat URL

--- a/now-secrets.example.json
+++ b/now-secrets.example.json
@@ -5,5 +5,6 @@
   "@google-oauth-client-secret-development": "i7H7ZLfntkIEp7kyyNsvyH3O",
   "@github-oauth-client-secret-development": "789f3a4b5772e978acd135fe7c86886e62f688c7",
   "@session-cookie-secret": "this-is-an-example-secret",
+  "@api-token-secret": "this-is-another-example-secret-string",
   "@stripe-token-development": "sk_test_EoC6py6fkeUHZJrEPffsGP0z"
 }


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

Previously any outside contributor except for the core Spectrum employees couldn't locally log into the mobile app.

This fixes it by adding an example api token secret to the example secrets file and fixing the EXPO_URL check.

/cc @juliankrispel