### PR TITLE
remove linter warnings

### DIFF
--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -4,11 +4,9 @@ import compose from 'recompose/compose';
 import withState from 'recompose/withState';
 import withHandlers from 'recompose/withHandlers';
 import { connect } from 'react-redux';
-import changeCurrentBlockType from 'draft-js-markdown-plugin/lib/modifiers/changeCurrentBlockType';
 import { KeyBindingUtil } from 'draft-js';
 import debounce from 'debounce';
 import Icon from '../../components/icons';
-import { IconButton } from '../../components/buttons';
 import { track } from '../../helpers/events';
 import {
   toJSON,

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -18,13 +18,7 @@ import 'prismjs/components/prism-perl';
 import 'prismjs/components/prism-ruby';
 import 'prismjs/components/prism-swift';
 import createPrismPlugin from 'draft-js-prism-plugin';
-import {
-  toPlainText,
-  toState,
-  fromPlainText,
-  toJSON,
-  isAndroid,
-} from 'shared/draft-utils';
+import { toPlainText, fromPlainText, isAndroid } from 'shared/draft-utils';
 import { customStyleMap } from 'src/components/draftjs-editor/style';
 import type { DraftEditorState } from 'draft-js/lib/EditorState';
 

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -1,5 +1,5 @@
 // @flow
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { IconButton } from '../buttons';
 import {
   FlexRow,

--- a/src/components/message/view.js
+++ b/src/components/message/view.js
@@ -11,7 +11,6 @@ import {
   ActionWrapper,
   ModActionWrapper,
   Time,
-  Code,
 } from './style';
 import { messageRenderer } from 'shared/clients/draft-js/message/renderer.web';
 import type { Node } from 'react';


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] Ready for review

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Removed some linter ~errors~ warnings I found when I first run the project before working on https://github.com/withspectrum/spectrum/issues/2682

```shell
./src/components/message/view.js
  Line 14:  'Code' is defined but never used  no-unused-vars

./src/components/chatInput/input.js
  Line 23:  'toState' is defined but never used  no-unused-vars
  Line 25:  'toJSON' is defined but never used   no-unused-vars

./src/components/chatInput/style.js
  Line 2:  'css' is defined but never used  no-unused-vars

./src/components/message/style.js
  Line 3:  'Gradient' is defined but never used  no-unused-vars

./src/components/chatInput/index.js
  Line 7:   'changeCurrentBlockType' is defined but never used  no-unused-vars
  Line 11:  'IconButton' is defined but never used              no-unused-vars
```
