### PR TITLE
Cache homescreen icons from the ServiceWorker

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -103,7 +103,6 @@ module.exports = function override(config, env) {
       return;
     externals.push(file.replace(/public/, ''));
   });
-  console.log(externals);
   config.plugins.push(
     new OfflinePlugin({
       // Don't cache anything in dev

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -99,9 +99,11 @@ module.exports = function override(config, env) {
   let externals = [];
   walkFolder('./public/', file => {
     // HOTFIX: Don't cache images
-    if (file.indexOf('img') > -1) return;
+    if (file.indexOf('img') > -1 && file.indexOf('homescreen-icon') === -1)
+      return;
     externals.push(file.replace(/public/, ''));
   });
+  console.log(externals);
   config.plugins.push(
     new OfflinePlugin({
       // Don't cache anything in dev


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

We had to disable caching for all images as Zeit was rate-limiting us
due to too many requests being sent from a single browser in a short
period of time.

Unfortunately, that broke adding-to-homescreen as the icons wouldn't be
sent properly. This patch fixes it by caching homescreen icons in the
ServiceWorker. Closes #2822