### PR TITLE
GraphQL rate limiting

### DIFF
--- a/api/mutations/message/addMessage.js
+++ b/api/mutations/message/addMessage.js
@@ -125,8 +125,8 @@ export default async (
   // at this point we are only dealing with thread messages
   const thread = await loaders.thread.load(message.threadId);
 
-  if (thread.isDeleted) {
-    return new UserError("Can't reply in a deleted thread.");
+  if (!thread || thread.isDeleted) {
+    return new UserError("Can't post message in non-existant thread.");
   }
 
   if (thread.isLocked) {

--- a/api/routes/api/graphql.js
+++ b/api/routes/api/graphql.js
@@ -2,6 +2,7 @@
 import { graphqlExpress } from 'graphql-server-express';
 import depthLimit from 'graphql-depth-limit';
 import costAnalysis from 'graphql-cost-analysis';
+import rateLimiter from '../../utils/graphql-rate-limiter';
 import Raven from 'shared/raven';
 import UserError from '../../utils/UserError';
 import createLoaders from '../../loaders/';
@@ -18,6 +19,7 @@ export default graphqlExpress(req => ({
   },
   validationRules: [
     depthLimit(10),
+    rateLimiter(),
     costAnalysis({
       variables: req.body.variables,
       maximumCost: 750,

--- a/api/routes/api/graphql.js
+++ b/api/routes/api/graphql.js
@@ -10,26 +10,42 @@ import createLoaders from '../../loaders/';
 import createErrorFormatter from '../../utils/create-graphql-error-formatter';
 import schema from '../../schema';
 
-export default graphqlExpress(req => ({
-  schema,
-  formatError: createErrorFormatter(req),
-  context: {
-    user: req.user ? (req.user.bannedAt ? null : req.user) : null,
-    loaders: createLoaders(),
-  },
-  validationRules: [
-    depthLimit(10),
-    rateLimiter(),
-    costAnalysis({
-      variables: req.body.variables,
-      maximumCost: 750,
-      defaultCost: 1,
-      createError: (max, actual) => {
-        const err = new UserError(
-          `GraphQL query exceeds maximum complexity, please remove some nesting or fields and try again. (max: ${max}, actual: ${actual})`
-        );
-        return err;
-      },
-    }),
-  ],
-}));
+import { parse } from 'graphql';
+
+export default graphqlExpress(async req => {
+  if (!req.body.query) throw new Error('No query provided.');
+  let doc;
+  try {
+    doc = parse(req.body.query);
+    // Ignore any errors that happen while parsing and let graphql-express handle them
+  } catch (err) {}
+  if (doc) {
+    await rateLimiter({
+      doc,
+      schema,
+      id: (req.user && req.user.id) || 'anonymous',
+    });
+  }
+  return {
+    schema,
+    formatError: createErrorFormatter(req),
+    context: {
+      user: req.user ? (req.user.bannedAt ? null : req.user) : null,
+      loaders: createLoaders(),
+    },
+    validationRules: [
+      depthLimit(10),
+      costAnalysis({
+        variables: req.body.variables,
+        maximumCost: 750,
+        defaultCost: 1,
+        createError: (max, actual) => {
+          const err = new UserError(
+            `GraphQL query exceeds maximum complexity, please remove some nesting or fields and try again. (max: ${max}, actual: ${actual})`
+          );
+          return err;
+        },
+      }),
+    ],
+  };
+});

--- a/api/types/Message.js
+++ b/api/types/Message.js
@@ -51,7 +51,7 @@ const Message = /* GraphQL */ `
 
 
 	extend type Mutation {
-    addMessage(message: MessageInput!): Message @rateLimit(limit: 20, window: 60000)
+    addMessage(message: MessageInput!): Message @rateLimit(limit: 2, window: 60000)
 		deleteMessage(id: ID!): Boolean
 	}
 

--- a/api/types/Message.js
+++ b/api/types/Message.js
@@ -51,7 +51,7 @@ const Message = /* GraphQL */ `
 
 
 	extend type Mutation {
-		addMessage(message: MessageInput!): Message
+    addMessage(message: MessageInput!): Message @rateLimit(limit: 20, window: 60000)
 		deleteMessage(id: ID!): Boolean
 	}
 

--- a/api/utils/graphql-rate-limiter.js
+++ b/api/utils/graphql-rate-limiter.js
@@ -37,11 +37,16 @@ export default (options?: {}) => (context: ValidationContext) => {
         const type = fields[field.name.value];
         if (!type) return;
 
-        const rateLimitingDirective = type.astNode.directives.find(
+        const directive = type.astNode.directives.find(
           ({ name }) => name.value === 'rateLimit'
         );
-        if (!rateLimitingDirective) return;
-        console.log(rateLimitingDirective);
+        if (!directive) return;
+        const { limit, window } = directive.arguments.reduce((obj, arg) => {
+          if (arg.name.value === 'limit') obj.limit = arg.value.value;
+          if (arg.name.value === 'window') obj.window = arg.value.value;
+          return obj;
+        }, {});
+        if (!limit || !window) return;
       },
     },
   };

--- a/api/utils/graphql-rate-limiter.js
+++ b/api/utils/graphql-rate-limiter.js
@@ -1,0 +1,48 @@
+/* @flow
+ *
+ * GraphQL rate limiting validation rule
+ *
+ */
+import type {
+  OperationDefinitionNode,
+  ValidationContext,
+  Schema,
+} from 'graphql';
+
+const getFields = (schema: Schema, operation: OperationDefinitionNode) => {
+  switch (operation.operation) {
+    case 'query': {
+      return schema.getQueryType().getFields();
+    }
+    case 'mutation': {
+      return schema.getMutationType().getFields();
+    }
+    default: {
+      return;
+    }
+  }
+};
+
+export default (options?: {}) => (context: ValidationContext) => {
+  return {
+    OperationDefinition: {
+      enter: (operation: OperationDefinitionNode) => {
+        const schema = context.getSchema();
+        const fields = getFields(schema, operation);
+        const field = operation.selectionSet.selections.find(
+          ({ kind }) => kind === 'Field'
+        );
+        if (!fields || !field) return;
+
+        const type = fields[field.name.value];
+        if (!type) return;
+
+        const rateLimitingDirective = type.astNode.directives.find(
+          ({ name }) => name.value === 'rateLimit'
+        );
+        if (!rateLimitingDirective) return;
+        console.log(rateLimitingDirective);
+      },
+    },
+  };
+};


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] WIP
- [ ] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

**Todo**

- [x] Figure out whether validation rules can be async (if not, I need to rethink the entire approach)
- [x] Enforce maximum requests per limit
- [ ] Store request count in Redis

The first point is the most important one: I tried doing something async in the validation rule visitor but the resolver would execute immediately, not waiting for it. Obviously if I can't do anything async in validation rules, I can't go to Redis to fetch request counts, so that would be a blocker.

I couldn't find any information on this so I've reached out to @leebyron, until he responds I'll pause work on this since it might just not be possible this way.

Closes #2777, /cc @fubhy