### PR TITLE
Disabeling CI Danger run for forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - run:
           name: Danger
           when: always
-          command: yarn run danger ci
+          command: test -z $DANGER_GITHUB_API_TOKEN && yarn run danger ci || echo "forks are not allowed to run danger"
       - run:
           name: Run E2E Tests
           command: yarn run test:e2e


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

This should fix CircleCi fail when a forked repo tries to run `danger` without credentials.

/cc @mxstbr 