### PR TITLE
fix focus of the chatinput after a user composes a new DM #2493

### DIFF
--- a/src/views/directMessages/containers/existingThread.js
+++ b/src/views/directMessages/containers/existingThread.js
@@ -53,6 +53,14 @@ class ExistingThread extends React.Component<Props> {
     ) {
       this.chatInput.triggerFocus();
     }
+    // as soon as the direct message thread is loaded, refocus the chat input
+    if (
+      this.props.data.directMessageThread &&
+      !prevProps.data.directMessageThread &&
+      this.chatInput
+    ) {
+      this.chatInput.triggerFocus();
+    }
     if (prevProps.match.params.threadId !== this.props.match.params.threadId) {
       const threadId = this.props.match.params.threadId;
       this.props.setActiveThread(threadId);


### PR DESCRIPTION
fixes #2493 

**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Fix**
loading the `directMessageThread` part of the props triggers the render of the chat input. So we need to wait for that before we can even call `this.chatInput.triggerFocus()`

**before:**
![before-fix](https://user-images.githubusercontent.com/815520/38962660-99d3badc-436e-11e8-8e2d-f1238e84d95c.gif)

**after:**
![after-fix](https://user-images.githubusercontent.com/815520/38962536-1851e33a-436e-11e8-9312-7edc934096a9.gif)
