### PR TITLE
hovercard changes for thread author avatar

### DIFF
--- a/src/views/dashboard/components/facepile.js
+++ b/src/views/dashboard/components/facepile.js
@@ -25,6 +25,7 @@ const messageAvatars = (list, active) => {
         link={participant.username ? `/users/${participant.username}` : null}
         src={`${participant.profilePhoto}`}
         role="presentation"
+        showProfile={true}
       />
     </ParticipantHead>
   ));
@@ -49,6 +50,7 @@ const Facepile = ({ participants, author, active }) => {
             link={author.username ? `/users/${author.username}` : null}
             src={author.profilePhoto}
             role="presentation"
+            showProfile={true}
           />
         </ParticipantHead>
       </FacepileContainer>
@@ -83,6 +85,7 @@ const Facepile = ({ participants, author, active }) => {
           link={author.username ? `/users/${author.username}` : null}
           src={author.profilePhoto}
           role="presentation"
+          showProfile={true}
         />
       </ParticipantHead>
       {messageAvatars(participantList, active)}

--- a/src/views/thread/components/threadByline.js
+++ b/src/views/thread/components/threadByline.js
@@ -33,6 +33,7 @@ class ThreadByline extends React.Component<Props> {
           isOnline={user.isOnline}
           src={user.profilePhoto}
           link={user.username ? `/users/${user.username}` : false}
+          showProfile={true}
         />
         <BylineMeta>
           {user.username ? (


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] WIP
- [ ] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)
- athena
- vulcan
- mercury
- hermes
- chronos
- pluto
- mobile

**Run database migrations (delete if no migration was added)**
YES

**Release notes for users (delete if codebase-only change)**
-

<!--

If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.

-->
Before:- 
There was no avatar while hovering over thread author avatar

After:-
![image](https://user-images.githubusercontent.com/31564466/39081826-ccece184-4565-11e8-8ff0-d53a0fcddee1.png)

Facing issues while trying to put hovercard over username.
@brianlovin 