### PR TITLE
Show photo size error on image added and neater error positioning

### DIFF
--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -21,6 +21,7 @@ import { addToastWithTimeout } from '../../actions/toasts';
 import { openModal } from '../../actions/modals';
 import {
   Form,
+  ChatInputContainer,
   ChatInputWrapper,
   SendButton,
   PhotoSizeError,
@@ -113,6 +114,7 @@ class ChatInput extends React.Component<Props, State> {
     if (currState.isSendingMediaMessage !== nextState.isSendingMediaMessage)
       return true;
     if (currState.mediaPreview !== nextState.mediaPreview) return true;
+    if (currState.photoSizeError !== nextState.photoSizeError) return true;
 
     return false;
   }
@@ -529,7 +531,7 @@ class ChatInput extends React.Component<Props, State> {
 
     return (
       <React.Fragment>
-        <ChatInputWrapper focus={isFocused} onClick={this.triggerFocus}>
+        <ChatInputContainer focus={isFocused} onClick={this.triggerFocus}>
           {photoSizeError && (
             <PhotoSizeError>
               <p
@@ -549,39 +551,41 @@ class ChatInput extends React.Component<Props, State> {
               />
             </PhotoSizeError>
           )}
-          {currentUser && (
-            <MediaUploader
-              isSendingMediaMessage={isSendingMediaMessage}
-              currentUser={currentUser}
-              onValidated={this.previewMedia}
-              onError={this.setMediaMessageError}
-              inputFocused={isFocused}
-            />
-          )}
-          <Form focus={isFocused}>
-            <Input
-              mediaPreview={mediaPreview}
-              onRemoveMedia={this.removeMediaPreview}
-              focus={isFocused}
-              placeholder={`Your message here...`}
-              editorState={state}
-              handleReturn={this.handleReturn}
-              onChange={this.onChange}
-              onFocus={this.onFocus}
-              onBlur={this.onBlur}
-              code={false}
-              editorRef={editor => (this.editor = editor)}
-              editorKey="chat-input"
-              decorators={[mentionsDecorator, linksDecorator]}
-              networkDisabled={networkDisabled}
-            />
-            <SendButton
-              data-cy="chat-input-send-button"
-              glyph="send-fill"
-              onClick={this.submit}
-            />
-          </Form>
-        </ChatInputWrapper>
+          <ChatInputWrapper>
+            {currentUser && (
+              <MediaUploader
+                isSendingMediaMessage={isSendingMediaMessage}
+                currentUser={currentUser}
+                onValidated={this.previewMedia}
+                onError={this.setMediaMessageError}
+                inputFocused={isFocused}
+              />
+            )}
+            <Form focus={isFocused}>
+              <Input
+                mediaPreview={mediaPreview}
+                onRemoveMedia={this.removeMediaPreview}
+                focus={isFocused}
+                placeholder={`Your message here...`}
+                editorState={state}
+                handleReturn={this.handleReturn}
+                onChange={this.onChange}
+                onFocus={this.onFocus}
+                onBlur={this.onBlur}
+                code={false}
+                editorRef={editor => (this.editor = editor)}
+                editorKey="chat-input"
+                decorators={[mentionsDecorator, linksDecorator]}
+                networkDisabled={networkDisabled}
+              />
+              <SendButton
+                data-cy="chat-input-send-button"
+                glyph="send-fill"
+                onClick={this.submit}
+              />
+            </Form>
+          </ChatInputWrapper>
+        </ChatInputContainer>
         <MarkdownHint showHint={markdownHint} data-cy="markdownHint">
           <b>**bold**</b>
           <i>*italics*</i>

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -18,13 +18,6 @@ export const ChatInputContainer = styled(FlexRow)`
   width: 100%;
   margin: 0;
 
-  @media (max-width: 768px) {
-    bottom: ${props => (props.focus ? '0' : 'auto')};
-    position: relative;
-    z-index: ${zIndex.mobileInput};
-    padding: 8px;
-  }
-
   a {
     text-decoration: underline;
   }
@@ -41,6 +34,13 @@ export const ChatInputWrapper = styled.div`
   border-top: 1px solid ${({ theme }) => theme.bg.border};
   box-shadow: -1px 0 0 ${props => props.theme.bg.border},
     1px 0 0 ${props => props.theme.bg.border};
+
+  @media (max-width: 768px) {
+    bottom: ${props => (props.focus ? '0' : 'auto')};
+    position: relative;
+    z-index: ${zIndex.mobileInput};
+    padding: 8px;
+  }
 `;
 
 export const Form = styled.form`

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -10,18 +10,13 @@ import {
 } from 'src/components/globals';
 import { Wrapper as EditorWrapper } from '../rich-text-editor/style';
 
-export const ChatInputWrapper = styled(FlexRow)`
-  flex: none;
-  align-items: center;
+export const ChatInputContainer = styled(FlexRow)`
+  display: flex;
+  flex-direction: column;
   z-index: inherit;
   position: relative;
   width: 100%;
   margin: 0;
-  padding: 16px 16px 0px;
-  background-color: ${props => props.theme.bg.default};
-  border-top: 1px solid ${({ theme }) => theme.bg.border};
-  box-shadow: -1px 0 0 ${props => props.theme.bg.border},
-    1px 0 0 ${props => props.theme.bg.border};
 
   @media (max-width: 768px) {
     bottom: ${props => (props.focus ? '0' : 'auto')};
@@ -33,6 +28,19 @@ export const ChatInputWrapper = styled(FlexRow)`
   a {
     text-decoration: underline;
   }
+`;
+
+export const ChatInputWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  margin: 0;
+  padding: 16px 16px 0px;
+  background-color: ${props => props.theme.bg.default};
+  border-top: 1px solid ${({ theme }) => theme.bg.border};
+  box-shadow: -1px 0 0 ${props => props.theme.bg.border},
+    1px 0 0 ${props => props.theme.bg.border};
 `;
 
 export const Form = styled.form`
@@ -176,6 +184,7 @@ export const PhotoSizeError = styled.div`
   align-items: center;
   align-content: center;
   padding: 8px 16px;
+  width: 100%;
   background: #fff1cc;
   border-top: 1px solid #ffd566;
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**

- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Previously render was only triggered once focus was lost from the input field;
- The error message when visible squashed the input field to the side
- This PR updates the ChatInput component to trigger a render when the MediaUploader onError event is hit. It also adds some styling to display the error message above the input field.

I've created a `ChatInputContainer` component to encapsulate the error and the input, and moved some of the styles out of `ChatInputWrapper`. Having two really similar names might be confusing though?

**Before**

<img width="703" alt="screen shot 2018-04-19 at 21 53 01" src="https://user-images.githubusercontent.com/4161106/39015174-d600951c-441c-11e8-96d1-082f7c5b22f8.png">

**After** 

<img width="653" alt="screen shot 2018-04-19 at 22 00 04" src="https://user-images.githubusercontent.com/4161106/39015248-133d78b4-441d-11e8-9243-c29a79a0561b.png">

