### PR TITLE
Add local file storage for dev environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ api/.env
 .expo
 mobile/.expo
 test-results.json
+public/uploads

--- a/README.md
+++ b/README.md
@@ -228,18 +228,6 @@ No matter what you're trying to do though, you'll want to have the API running, 
 yarn run dev:api
 ```
 
-##### Using file system storage for image uploads
-
-By default images are uploaded to an AWS S3 bucket which requires an AWS key and secret. For contributors without AWS credentials, images can be uploaded to your file system by setting the `FILE_STORAGE` environment variable to `local`.
-
-```
-FILE_STORAGE=local yarn run dev:api
-```
-
-File storage options:
-- local
-- s3
-
 #### Develop the web UI
 
 To develop the frontend and web UI run

--- a/README.md
+++ b/README.md
@@ -228,6 +228,18 @@ No matter what you're trying to do though, you'll want to have the API running, 
 yarn run dev:api
 ```
 
+##### Using file system storage for image uploads
+
+By default images are uploaded to an AWS S3 bucket which requires an AWS key and secret. For contributors without AWS credentials, images can be uploaded to your file system by setting the `FILE_STORAGE` environment variable to `local`.
+
+```
+FILE_STORAGE=local yarn run dev:api
+```
+
+File storage options:
+- local
+- s3
+
 #### Develop the web UI
 
 To develop the frontend and web UI run

--- a/api/models/community.js
+++ b/api/models/community.js
@@ -1,7 +1,7 @@
 // @flow
 const { db } = require('./db');
 import { parseRange } from './utils';
-import { uploadImage } from '../utils/s3';
+import { uploadImage } from '../utils/file-storage';
 import getRandomDefaultPhoto from '../utils/get-random-default-photo';
 import {
   sendNewCommunityWelcomeEmailQueue,

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -1,6 +1,6 @@
 // @flow
 const { db } = require('./db');
-import { uploadImage } from '../utils/s3';
+import { uploadImage } from '../utils/file-storage';
 import { createNewUsersSettings } from './usersSettings';
 import { sendNewUserWelcomeEmailQueue } from 'shared/bull/queues';
 import type { PaginationOptions } from '../utils/paginate-arrays';

--- a/api/mutations/directMessageThread/createDirectMessageThread.js
+++ b/api/mutations/directMessageThread/createDirectMessageThread.js
@@ -6,7 +6,7 @@ import {
   getDirectMessageThread,
   createDirectMessageThread,
 } from '../../models/directMessageThread';
-import { uploadImage } from '../../utils/s3';
+import { uploadImage } from '../../utils/file-storage';
 import { storeMessage } from '../../models/message';
 import {
   setUserLastSeenInDirectMessageThread,

--- a/api/mutations/message/addMessage.js
+++ b/api/mutations/message/addMessage.js
@@ -3,7 +3,7 @@ import { stateFromMarkdown } from 'draft-js-import-markdown';
 import { EditorState } from 'draft-js';
 import type { GraphQLContext } from '../../';
 import UserError from '../../utils/UserError';
-import { uploadImage } from '../../utils/s3';
+import { uploadImage } from '../../utils/file-storage';
 import { storeMessage } from '../../models/message';
 import { setDirectMessageThreadLastActive } from '../../models/directMessageThread';
 import { setUserLastSeenInDirectMessageThread } from '../../models/usersDirectMessageThreads';

--- a/api/mutations/thread/editThread.js
+++ b/api/mutations/thread/editThread.js
@@ -2,7 +2,7 @@
 import type { GraphQLContext } from '../../';
 import type { EditThreadInput } from '../../models/thread';
 import UserError from '../../utils/UserError';
-import { uploadImage } from '../../utils/s3';
+import { uploadImage } from '../../utils/file-storage';
 import { getThreads, editThread } from '../../models/thread';
 import { getUserPermissionsInCommunity } from '../../models/usersCommunities';
 import { getUserPermissionsInChannel } from '../../models/usersChannels';

--- a/api/mutations/thread/publishThread.js
+++ b/api/mutations/thread/publishThread.js
@@ -3,7 +3,7 @@ const debug = require('debug')('api:mutations:thread:publish-thread');
 import stringSimilarity from 'string-similarity';
 import type { GraphQLContext } from '../../';
 import UserError from '../../utils/UserError';
-import { uploadImage } from '../../utils/s3';
+import { uploadImage } from '../../utils/file-storage';
 import {
   publishThread,
   editThread,

--- a/api/utils/file-storage.js
+++ b/api/utils/file-storage.js
@@ -1,6 +1,8 @@
 // @flow
 require('now-env');
 
+import type { FileUpload, EntityTypes } from 'shared/types';
+
 const { FILE_STORAGE } = process.env;
 
 const getUploadImageFn = () => {

--- a/api/utils/file-storage.js
+++ b/api/utils/file-storage.js
@@ -1,0 +1,25 @@
+// @flow
+require('now-env');
+
+const { FILE_STORAGE } = process.env;
+
+const getUploadImageFn = () => {
+  switch (FILE_STORAGE) {
+    case 'local':
+      return require('./file-system').uploadImage;
+    case 's3':
+    default:
+      return require('./s3').uploadImage;
+  }
+};
+
+const uploadImageFn = getUploadImageFn();
+
+export const uploadImage = (
+  file: FileUpload,
+  entity: EntityTypes,
+  id: string
+): Promise<string> =>
+  uploadImageFn(file, entity, id).catch(err => {
+    throw new Error(err);
+  });

--- a/api/utils/file-system.js
+++ b/api/utils/file-system.js
@@ -1,0 +1,37 @@
+// @flow
+import shortid from 'shortid';
+import fs from 'fs';
+
+const STORAGE_DIR = 'public/uploads';
+
+const dirExists = (path: string): Promise<boolean> =>
+  new Promise(res => fs.access(path, err => res(!!!err)));
+
+const createUploadsDir = (path: string): Promise<void> =>
+  new Promise(res =>
+    fs.mkdir(path, err => {
+      if (err) throw new Error(err);
+      res();
+    })
+  );
+
+export const uploadImage = async (
+  file: FileUpload,
+  entity: EntityTypes,
+  id: string
+): Promise<string> => {
+  const result = await file;
+
+  if (!await dirExists(STORAGE_DIR)) {
+    await createUploadsDir(STORAGE_DIR);
+  }
+
+  return new Promise(res => {
+    const filePath = `${shortid.generate()}-${entity}-${id}`;
+    const { stream } = result;
+    stream.pipe(fs.createWriteStream(`${STORAGE_DIR}/${filePath}`));
+    stream.on('end', () => {
+      res(encodeURI(`/uploads/${filePath}`));
+    });
+  });
+};

--- a/api/utils/file-system.js
+++ b/api/utils/file-system.js
@@ -2,14 +2,17 @@
 import shortid from 'shortid';
 import fs from 'fs';
 
+import type { FileUpload, EntityTypes } from 'shared/types';
+
 const STORAGE_DIR = 'public/uploads';
+const READ_WRITE_MODE = 0o777;
 
 const dirExists = (path: string): Promise<boolean> =>
-  new Promise(res => fs.access(path, err => res(!!!err)));
+  new Promise(res => fs.access(path, fs.constants.F_OK, err => res(!!!err)));
 
 const createUploadsDir = (path: string): Promise<void> =>
   new Promise(res =>
-    fs.mkdir(path, err => {
+    fs.mkdir(path, READ_WRITE_MODE, err => {
       if (err) throw new Error(err);
       res();
     })

--- a/api/utils/s3.js
+++ b/api/utils/s3.js
@@ -36,7 +36,7 @@ const generateImageUrl = path => {
   return imgixBase + '/' + newPath;
 };
 
-const upload = async (
+export const uploadImage = async (
   file: FileUpload,
   entity: EntityTypes,
   id: string
@@ -60,15 +60,5 @@ const upload = async (
         res(encodeURI(url));
       }
     );
-  });
-};
-
-export const uploadImage = async (
-  file: FileUpload,
-  entity: EntityTypes,
-  id: string
-): Promise<string> => {
-  return await upload(file, entity, id).catch(err => {
-    throw new Error(err);
   });
 };

--- a/api/utils/s3.js
+++ b/api/utils/s3.js
@@ -4,8 +4,7 @@ import AWS from 'aws-sdk';
 import shortid from 'shortid';
 const IS_PROD = process.env.NODE_ENV === 'production';
 
-import type { FileUpload } from 'shared/types';
-type EntityTypes = 'communities' | 'channels' | 'users' | 'threads';
+import type { FileUpload, EntityTypes } from 'shared/types';
 
 let S3_TOKEN = process.env.S3_TOKEN;
 let S3_SECRET = process.env.S3_SECRET;

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "start:pluto": "cross-env NODE_ENV=production node build-pluto/main.js",
     "start:api": "cross-env NODE_ENV=production node build-api/main.js",
     "dev:web": "cross-env NODE_PATH=./ react-app-rewired start",
-    "dev:api": "cross-env NODE_PATH=./ cross-env NODE_ENV=development cross-env DEBUG=build*,api*,shared:middlewares*,-api:resolvers cross-env DIR=api backpack",
+    "dev:api": "cross-env FILE_STORAGE=local cross-env NODE_PATH=./ cross-env NODE_ENV=development cross-env DEBUG=build*,api*,shared:middlewares*,-api:resolvers cross-env DIR=api backpack",
     "dev:athena": "cross-env NODE_PATH=./ cross-env NODE_ENV=development cross-env DEBUG=build*,athena*,shared:middlewares*,-athena:resolvers cross-env DIR=athena backpack",
     "dev:hermes": "cross-env NODE_PATH=./ cross-env NODE_ENV=development cross-env DEBUG=build*,hermes*,shared:middlewares*,-hermes:resolvers cross-env DIR=hermes backpack",
     "dev:chronos": "cross-env NODE_PATH=./ cross-env NODE_ENV=development cross-env DEBUG=build*,chronos*,shared:middlewares*,-chronos:resolvers cross-env DIR=chronos backpack",

--- a/shared/types.js
+++ b/shared/types.js
@@ -387,3 +387,5 @@ export type FileUpload = {
   encoding: string,
   stream: any,
 };
+
+export type EntityTypes = 'communities' | 'channels' | 'users' | 'threads';


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [x] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

**Release notes for users (delete if codebase-only change)**
- This adds an option to allow local storage of uploaded images instead of storing to S3.
- The change is purely opt-in, so without using the `FILE_STORAGE` env variable, it'll default to original S3 logic.
- Local storage points to the `public/uploads` dir, which will be created if it doesn't exist
- `public/uploads` has been added to .gitignore

This PR will allow contributors to work with image uploads without requiring AWS keys/secrets. It should also be easier to add new implementations in the future.

If this is something that y'all would like to have, it would be good to test with and without AWS keys.

