### PR TITLE
Fix community settings loader

### DIFF
--- a/api/loaders/channel.js
+++ b/api/loaders/channel.js
@@ -7,7 +7,6 @@ import {
 import { getChannelsSettings } from '../models/channelSettings';
 import createLoader from './create-loader';
 import { getPendingUsersInChannels } from '../models/usersChannels';
-import type { Loader } from './types';
 
 export const __createChannelLoader = createLoader(channels =>
   getChannels(channels)

--- a/api/loaders/user.js
+++ b/api/loaders/user.js
@@ -12,7 +12,6 @@ import {
 import { getUsersPermissionsInChannels } from '../models/usersChannels';
 import { getThreadsNotificationStatusForUsers } from '../models/usersThreads';
 import createLoader from './create-loader';
-import type { Loader } from './types';
 
 export const __createUserLoader = createLoader(users => getUsers(users), 'id');
 

--- a/api/models/communitySettings.js
+++ b/api/models/communitySettings.js
@@ -56,7 +56,7 @@ export const getCommunitiesSettings = (
           if (record) return record;
           return {
             ...defaultSettings,
-            communityId:,
+            communityId,
           };
         });
       }

--- a/api/models/communitySettings.js
+++ b/api/models/communitySettings.js
@@ -59,6 +59,17 @@ export const getCommunitiesSettings = (
           };
         });
       }
+
+      if (data.length > communityIds.length) {
+        return communityIds.map(community => {
+          const record = data.find(o => o.communityId === community);
+          if (record) return record;
+          return {
+            ...defaultSettings,
+            communityId: community,
+          };
+        });
+      }
     });
 };
 

--- a/api/models/communitySettings.js
+++ b/api/models/communitySettings.js
@@ -51,23 +51,23 @@ export const getCommunitiesSettings = (
       }
 
       if (data.length < communityIds.length) {
-        return communityIds.map(community => {
-          const record = data.find(o => o.communityId === community);
+        return communityIds.map(communityId => {
+          const record = data.find(o => o.communityId === communityId);
           if (record) return record;
           return {
             ...defaultSettings,
-            communityId: community,
+            communityId:,
           };
         });
       }
 
       if (data.length > communityIds.length) {
-        return communityIds.map(community => {
-          const record = data.find(o => o.communityId === community);
+        return communityIds.map(communityId => {
+          const record = data.find(o => o.communityId === communityId);
           if (record) return record;
           return {
             ...defaultSettings,
-            communityId: community,
+            communityId,
           };
         });
       }

--- a/api/models/communitySettings.js
+++ b/api/models/communitySettings.js
@@ -31,11 +31,12 @@ export const getCommunitiesSettings = (
     .getAll(...communityIds, { index: 'communityId' })
     .run()
     .then(data => {
-      if (!data || data.length === 0)
+      if (!data || data.length === 0) {
         return Array.from({ length: communityIds.length }, (_, index) => ({
           ...defaultSettings,
           communityId: communityIds[index],
         }));
+      }
 
       if (data.length === communityIds.length) {
         return data.map(

--- a/api/queries/community/brandedLogin.js
+++ b/api/queries/community/brandedLogin.js
@@ -1,6 +1,5 @@
 // @flow
 import type { DBCommunity } from 'shared/types';
-import { getCommunitySettings } from '../../models/communitySettings';
 import type { GraphQLContext } from '../../';
 
 export default async (


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

**Release notes for users (delete if codebase-only change)**
- Fixes a bug that would cause certain communities to fail to load

I discovered that `https://spectrum.chat/relay` throws an error and fails to load, but the community exists in the db. It turns out that it's a bug where more than one `communitySettings` record exists for a community - I found two communities affected by this. I am not sure how this is possible, except possibly by someone spam clicking the branded login settings controls...

Any how - this extra fallback solves the problem where a community may accidentally have more than one community settings record...