### PR TITLE
Use a .prettierrc to allow editors to pick up Prettier config.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 flow-typed
+package.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
   },
   "lint-staged": {
     "*.js": [
-      "prettier --write --single-quote --trailing-comma es5",
+      "prettier --write",
       "eslint --fix",
       "git add"
     ]


### PR DESCRIPTION
This allows editors to pick up the Prettier config. Combined with a "format on save" option, this cleans up the output of `git diff` prior to committing since files get formatted with Prettier when a user saves a file.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**

**Release notes for users (delete if codebase-only change)**
- Introduce `.prettierrc`. This enables code editors to pick up Prettier settings and makes the local `git diff` output cleaner before prettier formats the code as part of the pre-commit hook.

<!--

If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.

-->
