### PR TITLE
Resolve collapsing chat input for DMs

### DIFF
--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -11,6 +11,7 @@ import {
 import { Wrapper as EditorWrapper } from '../rich-text-editor/style';
 
 export const ChatInputContainer = styled(FlexRow)`
+  flex: none;
   display: flex;
   flex-direction: column;
   z-index: inherit;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Resolves a regression introduced when I restructured the photo size error message for DMs
- The chat input and error message collapses when the chat history extended passed the chat input

Thanks @uberbryn for spotting this :-)

**Before**

<img width="705" alt="screen shot 2018-04-24 at 21 06 25" src="https://user-images.githubusercontent.com/4161106/39208672-f99ccba4-4803-11e8-8c0d-ef1af19ea2a3.png">

**After**

<img width="708" alt="screen shot 2018-04-24 at 21 06 39" src="https://user-images.githubusercontent.com/4161106/39208682-feab4526-4803-11e8-9aa4-0231a2664a22.png">
