### PR TITLE
chore(src): replace tab-charactor to whitespace

### DIFF
--- a/src/components/globals/index.js
+++ b/src/components/globals/index.js
@@ -343,8 +343,8 @@ const returnTooltip = props => {
             bottom: 100%;
             right: 0;
             transform: translateX(-100%);
-      	    border-bottom-width: 0;
-      	    border-top-color: ${
+            border-bottom-width: 0;
+            border-top-color: ${
               props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
             };
           }
@@ -359,8 +359,8 @@ const returnTooltip = props => {
             bottom: 100%;
             left: 0;
             transform: translateX(100%);
-      	    border-bottom-width: 0;
-      	    border-top-color: ${
+            border-bottom-width: 0;
+            border-top-color: ${
               props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
             };
           }
@@ -409,8 +409,8 @@ const returnTooltip = props => {
             top: 100%;
             right: 0;
             transform: translateX(-100%);
-      	    border-top-width: 0;
-      	    border-bottom-color: ${
+            border-top-width: 0;
+            border-bottom-color: ${
               props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
             };
           }
@@ -425,8 +425,8 @@ const returnTooltip = props => {
             top: 100%;
             left: 0;
             transform: translateX(100%);
-      	    border-top-width: 0;
-      	    border-bottom-color: ${
+            border-top-width: 0;
+            border-bottom-color: ${
               props.onboarding ? props.theme.brand.alt : props.theme.bg.reverse
             };
           }

--- a/src/components/linkPreview/style.js
+++ b/src/components/linkPreview/style.js
@@ -99,12 +99,12 @@ export const LinkPreviewSkeleton = styled.div`
 `;
 
 const placeHolderShimmer = keyframes`
-	0%{
-			background-position: -600px 0
-	}
-	100%{
-			background-position: 600px 0
-	}
+  0%{
+      background-position: -600px 0
+  }
+  100%{
+      background-position: 600px 0
+  }
 `;
 
 export const AnimatedBackground = styled.div`

--- a/src/components/loginButtonSet/style.js
+++ b/src/components/loginButtonSet/style.js
@@ -38,19 +38,19 @@ export const SigninButton = styled.div`
   ${props =>
     props.showAfter &&
     `
-			&:after {
-				content: 'Previously signed in with';
-				position: absolute;
-				top: -32px;
-				font-size: 14px;
-				font-weight: 600;
-				left: 50%;
-				transform: translateX(-50%);
-				width: 100%;
-				text-align: center;
-				color: ${props.theme.text.alt};
-			}
-		`} svg {
+    &:after {
+        content: 'Previously signed in with';
+        position: absolute;
+        top: -32px;
+        font-size: 14px;
+        font-weight: 600;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 100%;
+        text-align: center;
+        color: ${props.theme.text.alt};
+      }
+    `} svg {
     fill: currentColor !important;
   }
 `;

--- a/src/components/reaction/style.js
+++ b/src/components/reaction/style.js
@@ -19,14 +19,14 @@ export const ReactionWrapper = styled.b`
       ? `background-color: ${
           props.active ? props.theme.warn.default : props.theme.text.alt
         };
-		background-image: ${
+    background-image: ${
       props.active
         ? Gradient(props.theme.warn.alt, props.theme.warn.default)
         : 'none'
     }
-			`
+      `
       : `background-color: ${props.theme.bg.border};
-		background-image: none;`};
+    background-image: none;`};
 
   padding: ${props => (props.hasCount ? '0 10px 0 6px' : '0')};
   display: flex;

--- a/src/components/scrollRow/style.js
+++ b/src/components/scrollRow/style.js
@@ -2,14 +2,14 @@ import styled from 'styled-components';
 import { FlexRow } from '../globals';
 
 export const ScrollableFlexRow = styled(FlexRow)`
-	overflow-x: scroll;
-	flex-wrap: nowrap;
-	background: transparent;
-	cursor: pointer;
-	cursor: hand;
-	cursor: grab;
+  overflow-x: scroll;
+  flex-wrap: nowrap;
+  background: transparent;
+  cursor: pointer;
+  cursor: hand;
+  cursor: grab;
 
-	&:active {
-		cursor: grabbing;
-	}
+  &:active {
+    cursor: grabbing;
+  }
 `;

--- a/src/components/toasts/style.js
+++ b/src/components/toasts/style.js
@@ -18,18 +18,18 @@ export const Container = styled.div`
 `;
 
 const toastFade = keyframes`
-	0% {
-		opacity: 0;
+  0% {
+    opacity: 0;
     top: 8px;
-	}
-	5% {
-		opacity: 1;
+  }
+  5% {
+    opacity: 1;
     top: 0;
-	}
+  }
   95% {
-		opacity: 1;
+    opacity: 1;
     top: 0;
-	}
+  }
   100% {
     opacity: 0;
     top: -4px;

--- a/src/components/upsell/style.js
+++ b/src/components/upsell/style.js
@@ -304,19 +304,19 @@ export const SigninButton = styled.a`
   ${props =>
     props.after &&
     `
-			&:after {
-				content: 'Previously signed in with';
-				position: absolute;
-				top: -32px;
-				font-size: 14px;
-				font-weight: 600;
-				left: 50%;
-				transform: translateX(-50%);
-				width: 100%;
-				text-align: center;
-				color: ${props.theme.text.alt};
-			}
-		`} span {
+      &:after {
+        content: 'Previously signed in with';
+        position: absolute;
+        top: -32px;
+        font-size: 14px;
+        font-weight: 600;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 100%;
+        text-align: center;
+        color: ${props.theme.text.alt};
+      }
+    `} span {
     display: inline-block;
     flex: 0 0 auto;
     margin-top: -1px;

--- a/src/views/pages/style.js
+++ b/src/views/pages/style.js
@@ -189,7 +189,7 @@ export const SignInButton = styled.a`
   ${props =>
     props.after &&
     `
-			margin: 24px 0;
+  		margin: 24px 0;
 
 			&:after {
 				content: 'Previously signed in with';


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] Ready for review

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

while doing https://github.com/withspectrum/spectrum/pull/2958, I noticed that tab-charactor is not replaced whitespace by prettier.

the project's prettier settings surely use whitespace instead tab-character(prettier default), a little bit strange:thinking: