### PR TITLE
Fix/GitHub theme

### DIFF
--- a/src/components/loginButtonSet/style.js
+++ b/src/components/loginButtonSet/style.js
@@ -101,8 +101,10 @@ export const GoogleButton = styled(SigninButton)`
 `;
 
 export const GithubButton = styled(SigninButton)`
-  background: ${props => (props.preferred ? props.theme.text.default : 'none')};
-  color: ${props => (props.preferred ? '#fff' : props.theme.text.default)};
+  background: ${props =>
+    props.preferred ? props.theme.social.github.default : 'none'};
+  color: ${props =>
+    props.preferred ? '#fff' : props.theme.social.github.default};
 
   &:after {
     color: ${props => props.theme.text.default};

--- a/src/components/theme/index.js
+++ b/src/components/theme/index.js
@@ -37,8 +37,8 @@ export const theme = {
       alt: '#ea4335',
     },
     github: {
-      default: '#1475DA',
-      alt: '#1475DA',
+      default: '#16171A',
+      alt: '#16171A',
     },
     ph: {
       default: '#D85537',


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] Ready for review

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

## Overview
i figure out this while doing https://github.com/withspectrum/spectrum/pull/2880.

in Login Page,  Github Button recived `props.theme.text.default` as a color.
i thought should use `props.theme.social.github.default` instead.
but prev `props.theme.social.github.default` assinged bluecolor('#1475DA').

so first, I confirmed that the github theme is not used elsewhere by `find src/ -type f -name "*.js" | xargs grep 'theme.social.github'`,
then i replace `theme.social.github.default` to blackcolor('#16171A')

it seems work fine on my local:computer:

## Image
<img width="686" alt="screen shot 2018-04-27 at 3 00 37" src="https://user-images.githubusercontent.com/5501268/39324239-fde843d8-49c9-11e8-9de5-f1439a36b618.png">

thanks:smile:
