### PR TITLE
Mentions and links are no longer clickable in code blocks

### DIFF
--- a/shared/clients/draft-js/links-decorator/core.js
+++ b/shared/clients/draft-js/links-decorator/core.js
@@ -19,7 +19,14 @@ let i = 0;
 const createLinksDecorator = (
   Component: ComponentType<LinksDecoratorComponentProps>
 ) => ({
-  strategy: linkStrategy,
+  strategy: (
+    contentBlock: ContentBlock,
+    callback: (...args?: Array<any>) => any
+  ) => {
+    if (contentBlock.type === 'code-block') return;
+
+    linkStrategy(contentBlock, callback);
+  },
   component: ({ decoratedText, children }: DecoratorComponentProps) => (
     <Component
       href={normalizeUrl(decoratedText)}

--- a/shared/clients/draft-js/mentions-decorator/core.js
+++ b/shared/clients/draft-js/mentions-decorator/core.js
@@ -17,6 +17,9 @@ const createMentionsDecorator = (
     contentBlock: ContentBlock,
     callback: (...args?: Array<any>) => any
   ) => {
+    // This prevents the search for mentions when we're inside of a code-block
+    if (contentBlock.type === 'code-block') return;
+
     // -> "@brian_lovin, what's up with @mxstbr?"
     const text = contentBlock.getText();
     // -> ["@brian_lovin", " @mxstbr"];


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Changes**
* Mentions and links are no longer clickable in code blocks.
* Closes #2945 

### Before
<img width="461" alt="before" src="https://user-images.githubusercontent.com/464978/39336081-50293d86-497b-11e8-85dc-394ea0c0a464.png">

### After
<img width="424" alt="after" src="https://user-images.githubusercontent.com/464978/39335976-ebcb8740-497a-11e8-88d3-812fa1b17009.png">

