### PR TITLE
DMs force an entire refresh whenever I send a message in a thread #2965

### DIFF
--- a/src/views/directMessages/components/messages.js
+++ b/src/views/directMessages/components/messages.js
@@ -47,7 +47,6 @@ class MessagesWithData extends React.Component<Props, State> {
 
   componentDidUpdate(prev) {
     const { contextualScrollToBottom, data, setLastSeen } = this.props;
-
     if (this.props.data.loading) {
       this.unsubscribe();
     }
@@ -62,9 +61,21 @@ class MessagesWithData extends React.Component<Props, State> {
     }
     // force scroll to bottom when a message is sent in the same thread
     if (prev.data.messages !== data.messages && contextualScrollToBottom) {
+      setTimeout(() => this.props.forceScrollToBottom());
       // mark this thread as unread when new messages come in and i'm viewing it
       if (data.directMessageThread) setLastSeen(data.directMessageThread.id);
       contextualScrollToBottom();
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    if (
+      !!this.props.data.directMessageThread &&
+      !nextProps.data.directMessageThread
+    ) {
+      return false;
+    } else {
+      return true;
     }
   }
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
-

<!--

If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.

-->
This might be a very bad fix for bug  #2965. I guess i am not completely aware of the underlying problem. the reason is this commit 71a9080.
and somehow the `props.data.directMessageThread` is undefined for a short moment before it gets filled up again.

![kapture 2018-04-28 at 0 04 32](https://user-images.githubusercontent.com/815520/39387219-b6087556-4a78-11e8-9add-e6cb5b24b339.gif)
