### PR TITLE
GraphQL error logging improvement

### DIFF
--- a/api/test/utils/__mocks__/debug.js
+++ b/api/test/utils/__mocks__/debug.js
@@ -1,0 +1,15 @@
+// @flow
+
+const loggers = {};
+
+function makeLogger() {
+  function logger(...args: any[]) {
+    logger.log.push(args.join(' '));
+  }
+  logger.log = [];
+  return logger;
+}
+
+module.exports = (namespace: string) => {
+  return (loggers[namespace] = loggers[namespace] || makeLogger());
+};

--- a/api/test/utils/__snapshots__/create-graphql-error-formatter.test.js.snap
+++ b/api/test/utils/__snapshots__/create-graphql-error-formatter.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createGraphQLErrorFormatter logs error path 1`] = `
+Array [
+  "---GraphQL Error---",
+  "GraphQLError: Cannot return null for non-nullable field Thread.channel.",
+  "path community.threadConnection.edges[0].node.channel",
+  "-------------------
+",
+]
+`;
+
+exports[`createGraphQLErrorFormatter logs query and variables 1`] = `
+Array [
+  "---GraphQL Error---",
+  "GraphQLError: Cannot return null for non-nullable field Thread.channel.",
+  "query getCommunityThreadConnection( $id: ID )",
+  "variables [object Object]",
+  "path community.threadConnection.edges[0].node.channel",
+  "-------------------
+",
+]
+`;

--- a/api/test/utils/__snapshots__/create-graphql-error-formatter.test.js.snap
+++ b/api/test/utils/__snapshots__/create-graphql-error-formatter.test.js.snap
@@ -15,7 +15,7 @@ Array [
   "---GraphQL Error---",
   "GraphQLError: Cannot return null for non-nullable field Thread.channel.",
   "query getCommunityThreadConnection( $id: ID )",
-  "variables [object Object]",
+  "variables {\\"id\\":1}",
   "path community.threadConnection.edges[0].node.channel",
   "-------------------
 ",

--- a/api/test/utils/create-graphql-error-formatter.test.js
+++ b/api/test/utils/create-graphql-error-formatter.test.js
@@ -1,0 +1,106 @@
+// @flow
+
+const debug = require('debug')('api:utils:error-formatter');
+
+import { graphql, print } from 'graphql';
+import { makeExecutableSchema } from 'graphql-tools';
+
+import createErrorFormatter from '../../utils/create-graphql-error-formatter';
+
+const typeDefs = `
+	type Community {
+		id: ID!
+    threadConnection(first: Int = 10, after: String): CommunityThreadsConnection!
+	}
+
+	type CommunityThreadsConnection {
+		edges: [CommunityThreadEdge!]
+	}
+
+	type CommunityThreadEdge {
+		node: Thread!
+	}
+
+	type Thread {
+		id: ID!
+		channel: Channel!
+	}
+
+	type Channel {
+		id: ID!
+	}
+
+	type Query {
+		community(id: ID): Community
+	}
+`;
+
+const resolvers = {
+  Query: {
+    community: () => ({ id: 1 }),
+  },
+  Community: {
+    threadConnection: () => ({}),
+  },
+  CommunityThreadsConnection: {
+    edges: () => [6],
+  },
+  CommunityThreadEdge: {
+    node: id => ({ id }),
+  },
+  Thread: {
+    channel: () => null,
+  },
+};
+
+const schema = makeExecutableSchema({ typeDefs, resolvers });
+
+const query = `
+    query getCommunityThreadConnection( $id: ID ){
+      community( id: $id ) {
+        id
+        threadConnection {
+          edges {
+            node {
+              id
+              channel {
+                id
+              }
+            }
+          }
+        }
+      }
+    }
+    `;
+
+const variables = { id: 1 };
+
+describe('createGraphQLErrorFormatter', () => {
+  const stderrWrite = process.stderr.write;
+
+  afterEach(() => {
+    process.stderr.write = stderrWrite;
+  });
+
+  it('returns function', () => {
+    expect(createErrorFormatter()).toBeInstanceOf(Function);
+  });
+
+  it('logs error path', async () => {
+    debug.log = [];
+
+    const result = await graphql(schema, query, null, null, variables);
+    const formatter = createErrorFormatter();
+    (result.errors || []).forEach(formatter);
+    expect(debug.log).toMatchSnapshot();
+  });
+
+  it('logs query and variables', async () => {
+    debug.log = [];
+
+    const result = await graphql(schema, query, null, null, variables);
+    const formatter = createErrorFormatter({ body: { query, variables } });
+    (result.errors || []).forEach(formatter);
+    expect(debug.log).toMatchSnapshot();
+  });
+});

--- a/api/utils/create-graphql-error-formatter.js
+++ b/api/utils/create-graphql-error-formatter.js
@@ -33,7 +33,7 @@ const logGraphQLError = (req, error) => {
   debug(error);
   if (req) {
     debug(collectQueries(req.body.query));
-    debug('variables', req.body.variables);
+    debug('variables', JSON.stringify(req.body.variables || {}));
   }
   const path = errorPath(error);
   path && debug('path', path);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

Added GraphQL query name, variables and path where the error occurred,
if any. See test snapshots for an example.

Closes #2962, cc @brianlovin
