### PR TITLE
Include SENTRY_DSN_CLIENT in webpack config - Closes #2908

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -167,5 +167,14 @@ module.exports = function override(config, env) {
       children: true,
     })
   );
+  if (process.env.NODE_ENV === 'production') {
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        'process.env': {
+          SENTRY_DSN_CLIENT: `"${process.env.SENTRY_DSN_CLIENT}"`,
+        },
+      })
+    );
+  }
   return rewireStyledComponents(config, env, { ssr: true });
 };


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Include `process.env.SENTRY_DSN_CLIENT` as @dev-drprasad suggested.

It can probably be tested by setting SENTRY_DSN_CLIENT locally

```
NODE_ENV=production SENTRY_DSN_CLIENT=<sentry dsn> yarn run dev:web
```

<!--

If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.

-->
