### PR TITLE
Changes to make direct messages deletable

### DIFF
--- a/shared/graphql/mutations/message/deleteMessage.js
+++ b/shared/graphql/mutations/message/deleteMessage.js
@@ -2,8 +2,7 @@
 import gql from 'graphql-tag';
 import { graphql } from 'react-apollo';
 import { getThreadMessageConnectionQuery } from '../../queries/thread/getThreadMessageConnection';
-import { getDirectMessageThreadQuery } from '../../queries/directMessageThread/getDirectMessageThread';
-
+import { getDMThreadMessageConnectionQuery } from '../../queries/directMessageThread/getDirectMessageThreadMessageConnection';
 export type DeleteMessageType = {
   data: {
     deleteMessage: boolean,
@@ -52,18 +51,18 @@ const deleteMessageOptions = {
           } else if (ownProps.threadType === 'directMessageThread') {
             // Read the data from our cache for this query.
             const data = store.readQuery({
-              query: getDirectMessageThreadQuery,
+              query: getDMThreadMessageConnectionQuery,
               variables: {
                 id: ownProps.threadId,
               },
             });
 
             data.directMessageThread.messageConnection.edges = data.directMessageThread.messageConnection.edges.filter(
-              message => message.id !== id
+              ({ node }) => node.id !== id
             );
             // Write our data back to the cache.
             store.writeQuery({
-              query: getDirectMessageThreadQuery,
+              query: getDMThreadMessageConnectionQuery,
               data,
               variables: {
                 id: ownProps.threadId,

--- a/src/components/messageGroup/index.js
+++ b/src/components/messageGroup/index.js
@@ -178,8 +178,7 @@ class Messages extends Component<MessageGroupProps, State> {
           const me = currentUser
             ? author.user && author.user.id === currentUser.id
             : false;
-          const canModerate =
-            threadType !== 'directMessageThread' && (me || isModerator);
+          const canModerate = threadType !== (me || isModerator);
 
           if (roboText) {
             if (initialMessage.message.type === 'timestamp') {

--- a/src/components/messageGroup/index.js
+++ b/src/components/messageGroup/index.js
@@ -178,7 +178,7 @@ class Messages extends Component<MessageGroupProps, State> {
           const me = currentUser
             ? author.user && author.user.id === currentUser.id
             : false;
-          const canModerate = threadType !== (me || isModerator);
+          const canModerate = me || isModerator;
 
           if (roboText) {
             if (initialMessage.message.type === 'timestamp') {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)
- athena
- vulcan
- mercury
- hermes
- chronos
- pluto
- mobile

**Run database migrations (delete if no migration was added)**
YES

**Release notes for users (delete if codebase-only change)**
-

<!--

If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.

-->
Hi.
I have resolved the problem of making the direct messages deletable. The first was to allow users to delete the direct messages.
Second was that removing the message from UI once they are deleted.

For the second one I found a bug inside _shared/graphql/mutations/message/deleteMessage.js_.
The problem was that we were reading and updating the cache using getDirectMessageThreadQuery query. Now, this retrieved the direct message without the edges.  Hence we were getting no edges found error while executing `data.directMessageThread.messageConnection.edges = data.directMessageThread.messageConnection.edges.filter(`. So the cache was not getting updated. Moreover, we need to delete particular node for the message from the edges of direct message thread.

Hence we basically needed to use getDMThreadMessageConnectionQuery instead to retrieve direct message thread along with its edges. See below screenshot for more details:-

![image](https://user-images.githubusercontent.com/31564466/39415492-a54e1636-4c61-11e8-9b00-744c61c5a858.png)

After completing all the changes I am able to delete the direct messages.