### PR TITLE
Add continuous deployment for alpha

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,9 +210,9 @@ workflows:
             - checkout_environment
       - deploy_alpha:
           requires:
-            - test_web
             - test_static_js
           # TODO(@mxstbr): ENABLE BELOW LINES BEFORE MERGING
+            # - test_web
           # filters:
           #   branches:
           #     only: alpha

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,8 +211,7 @@ workflows:
       - deploy_alpha:
           requires:
             - test_static_js
-          # TODO(@mxstbr): ENABLE BELOW LINES BEFORE MERGING
-            # - test_web
-          # filters:
-          #   branches:
-          #     only: alpha
+            - test_web
+          filters:
+            branches:
+              only: alpha

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,12 +36,15 @@ aliases:
     background: true
 
   - &setup-and-build-web
-    name: Setup and build
+    name: Setup and build web
     command:
       |
         cp now-secrets.example.json now-secrets.json
         yarn run build:web
-        yarn run build:api
+
+  - &build-api
+    name: Build API
+    command: yarn run build:api
 
   - &start-api
     name: Start the API in the background
@@ -98,6 +101,7 @@ jobs:
           at: ~/spectrum
       - run: node -e "const setup = require('./shared/testing/setup.js')().then(() => process.exit())"
       - run: *setup-and-build-web
+      - run: *build-api
       - run: *start-api
       - run: *start-web
       # Wait for the API and webserver to start
@@ -112,6 +116,29 @@ jobs:
       - run:
           name: Run E2E Tests
           command: test $CYPRESS_RECORD_KEY && yarn run test:e2e -- --record || yarn run test:e2e
+
+  deploy_alpha:
+    <<: *js_defaults
+    docker:
+      - image: circleci/node:8-browsers
+    steps:
+      - attach_workspace:
+          at: ~/spectrum
+      - run:
+          name: Install now
+          command: sudo npm install --global --unsafe-perm now
+      - run: *build-api
+      - run:
+          name: Deploy and alias API
+          command: |
+            (cd build-api && now --token $ZEIT_TOKEN --team spaceprogram)
+            (cd build-api && now --token $ZEIT_TOKEN --team spaceprogram alias api.alpha.spectrum.chat)
+      - run:
+          name: Deploy and alias Hyperion
+          command: |
+            now --token $ZEIT_TOKEN --team spaceprogram
+            now --token $ZEIT_TOKEN --team spaceprogram alias hyperion.alpha.spectrum.chat
+
 
   # Run eslint, flow etc.
   test_static_js:
@@ -181,3 +208,11 @@ workflows:
       - test_static_js:
           requires:
             - checkout_environment
+      - deploy_alpha:
+          requires:
+            - test_web
+            - test_static_js
+          # TODO(@mxstbr): ENABLE BELOW LINES BEFORE MERGING
+          # filters:
+          #   branches:
+          #     only: alpha


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

~~Let's see if this works!~~

It works beautifully! This will now always deploy the latest changes to the API and the frontend to `alpha.spectrum.chat` once its merged to `alpha` and e2e tests pass. :100:

This is ready for a review & merge