### PR TITLE
[GDPR] Allow users to download their personal data

### DIFF
--- a/api/routes/api/export-user-data.js
+++ b/api/routes/api/export-user-data.js
@@ -1,0 +1,17 @@
+// @flow
+import { Router } from 'express';
+const userDataRouter = Router();
+import { getUserById } from '../../models/user';
+import type { DBUser } from 'shared/types';
+
+userDataRouter.get('/', async (req: express$Request, res: express$Response) => {
+  if (!req.user) return res.send('No logged-in user');
+  // $FlowIssue
+  const user = await getUserById(req.user.id);
+  if (!user) return res.send('User not found.');
+  // This forces the browser to download a .json file instead of rendering it
+  res.setHeader('Content-Type', 'application/octet-stream');
+  return res.send(user);
+});
+
+export default userDataRouter;

--- a/api/routes/api/index.js
+++ b/api/routes/api/index.js
@@ -18,6 +18,9 @@ apiRouter.use('/stripe', stripe);
 import email from './email';
 apiRouter.use('/email', email);
 
+import userExportRouter from './export-user-data';
+apiRouter.use('/user.json', userExportRouter);
+
 import graphql from './graphql';
 apiRouter.use('/', graphql);
 

--- a/src/views/userSettings/components/downloadDataForm.js
+++ b/src/views/userSettings/components/downloadDataForm.js
@@ -1,0 +1,62 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import styled from 'styled-components';
+import { addToastWithTimeout } from 'src/actions/toasts';
+import {
+  SectionCard,
+  SectionTitle,
+  SectionSubtitle,
+  SectionCardFooter,
+} from 'src/components/settingsViews/style';
+import { Notice } from 'src/components/listItems/style';
+import { Button, TextButton, OutlineButton } from 'src/components/buttons';
+
+const Link = styled.a`
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  color: ${props => props.theme.brand.default};
+  padding: 12px 16px;
+
+  &:hover {
+    color: ${props => props.theme.brand.alt};
+  }
+`;
+
+type Props = {
+  user: Object,
+};
+
+class DownloadDataForm extends React.Component<Props> {
+  render() {
+    const { user } = this.props;
+
+    if (!user) return null;
+
+    return (
+      <SectionCard data-cy="download-data-container">
+        <SectionTitle>Download my data</SectionTitle>
+        <SectionSubtitle>
+          You can download your personal data at any time.
+        </SectionSubtitle>
+
+        <SectionCardFooter>
+          <Link
+            href={
+              process.env.NODE_ENV === 'production'
+                ? '/api/user.json'
+                : 'http://localhost:3001/api/user.json'
+            }
+            download
+          >
+            Download my data
+          </Link>
+        </SectionCardFooter>
+      </SectionCard>
+    );
+  }
+}
+
+export default DownloadDataForm;

--- a/src/views/userSettings/components/overview.js
+++ b/src/views/userSettings/components/overview.js
@@ -6,6 +6,7 @@ import EmailSettings from './emailSettings';
 import NotificationSettings from './notificationSettings';
 import Invoices from './invoices';
 import DeleteAccountForm from './deleteAccountForm';
+import DownloadDataForm from './downloadDataForm';
 import RecurringPaymentsList from './recurringPaymentsList';
 import { SectionsContainer, Column } from 'src/components/settingsViews/style';
 
@@ -22,6 +23,7 @@ class Overview extends React.Component<Props> {
         <Column>
           <UserEditForm user={user} />
           <DeleteAccountForm id={user.id} />
+          <DownloadDataForm user={user} />
         </Column>
         <Column>
           <RecurringPaymentsList user={user} />


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

This adds a new route, `api/user.json`, which sends a JSON file to the requester with the current users' data. Also adds a button to the user settings which does exactly that.

<img width="606" alt="screen shot 2018-05-03 at 10 23 56" src="https://user-images.githubusercontent.com/7525670/39566517-2061fa02-4ebc-11e8-8b7b-142072faef8d.png">

Note that I am totally not sure how much or little data we should send the user—right now it literally just sends the user record?

Ref #2817