### PR TITLE
Fix Android fallback input styling

### DIFF
--- a/src/components/draft-js-plugins-editor/index.js
+++ b/src/components/draft-js-plugins-editor/index.js
@@ -7,6 +7,7 @@
 import React from 'react';
 import DraftEditor from 'draft-js-plugins-editor';
 import debounce from 'debounce';
+import Textarea from 'react-textarea-autosize';
 import { isAndroid, toPlainText, fromPlainText } from 'shared/draft-utils';
 import type DraftEditorProps from 'draft-js/lib/DraftEditorProps';
 
@@ -62,9 +63,8 @@ class AndroidFallbackInput extends React.Component<Props, FallbackState> {
     return (
       <div className="DraftEditor-root">
         <div className="DraftEditor-editorContainer">
-          <input
+          <Textarea
             {...this.props}
-            type="text"
             value={this.state.value}
             onChange={this.onChange}
             className={'DraftEditor-content ' + (this.props.className || '')}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This fixes the Android fallback input to be an autosizing textarea instead of a plain input. This fixes issue with long messages.

**Before**

<img width="789" alt="screen shot 2018-05-03 at 12 03 58" src="https://user-images.githubusercontent.com/7525670/39570977-4c7d9c50-4eca-11e8-8448-9e7ea42a4396.png">

**After**

<img width="789" alt="screen shot 2018-05-03 at 12 04 17" src="https://user-images.githubusercontent.com/7525670/39570975-4b76e898-4eca-11e8-9558-5c81eb452554.png">

@uberbryn @brianlovin total sidenote, but wdyt about moving the "send" button out of the input itself, similar to how e.g. WhatsApp does it? This is really awkward:

<img width="404" alt="screen shot 2018-05-03 at 12 06 49" src="https://user-images.githubusercontent.com/7525670/39571054-8f693092-4eca-11e8-96a3-fceb3a48a964.png">
