### PR TITLE
Truncate long quoted replies

### DIFF
--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -2,6 +2,7 @@
 import styled, { css } from 'styled-components';
 import { SvgWrapper } from '../icons';
 import { Gradient, zIndex, Transition, monoStack, hexa } from '../globals';
+import { Byline, Name, Username } from '../messageGroup/style';
 
 const Bubble = styled.div`
   display: inline-block;
@@ -391,5 +392,12 @@ export const QuoteWrapper = styled.div`
   ${SvgWrapper} {
     margin-left: -3px;
     margin-right: 2px;
+  }
+
+  /* Don't change the color of the name and username on hover since they aren't clickable in quotes */
+  ${Name}:hover,
+  ${Username}:hover,
+  ${Byline}:hover {
+    color: ${props => props.theme.text.alt};
   }
 `;

--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -360,6 +360,19 @@ export const QuotedParagraph = Paragraph.withComponent('div').extend`
   }
 `;
 
+export const QuoteWrapperGradient = styled.div`
+  background: linear-gradient(
+    to top,
+    rgba(255, 255, 255, 1),
+    rgba(255, 255, 255, 0)
+  );
+  height: 2em;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+`;
+
 export const QuoteWrapper = styled.div`
   background: ${props => props.theme.bg.default};
   border-radius: 12px;
@@ -370,6 +383,10 @@ export const QuoteWrapper = styled.div`
   margin-left: -12px;
   margin-top: -4px;
   margin-bottom: 8px;
+  max-height: ${props => (props.expanded ? 'none' : '7em')};
+  overflow-y: hidden;
+  cursor: pointer;
+  position: relative;
 
   ${SvgWrapper} {
     margin-left: -3px;

--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -372,6 +372,7 @@ export const QuoteWrapperGradient = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
+  border-radius: 0 0 12px 12px;
 `;
 
 export const QuoteWrapper = styled.div`

--- a/src/components/message/view.js
+++ b/src/components/message/view.js
@@ -74,6 +74,7 @@ type QuotedMessageProps = {
 };
 
 type QuotedMessageState = {
+  isShort: boolean,
   isExpanded: boolean,
 };
 
@@ -81,17 +82,35 @@ export class QuotedMessage extends React.Component<
   QuotedMessageProps,
   QuotedMessageState
 > {
-  state = {
-    isExpanded: false,
-  };
+  constructor(props: QuotedMessageProps) {
+    super(props);
+
+    const jsonBody = JSON.parse(props.message.content.body);
+    const isShort =
+      jsonBody.blocks.length === 1 ||
+      toPlainText(toState(jsonBody)).length <= 170;
+
+    this.state = {
+      isShort,
+      isExpanded: isShort,
+    };
+  }
+
+  shouldComponentUpdate(
+    nextProps: QuotedMessageProps,
+    nextState: QuotedMessageState
+  ) {
+    return nextState.isExpanded !== this.state.isExpanded;
+  }
 
   toggle = () => {
+    if (this.state.isShort) return;
     this.setState(prev => ({ isExpanded: !prev.isExpanded }));
   };
 
   render() {
     const { message, openGallery } = this.props;
-    const { isExpanded } = this.state;
+    const { isExpanded, isShort } = this.state;
     return (
       <QuoteWrapper
         expanded={isExpanded}

--- a/src/components/message/view.js
+++ b/src/components/message/view.js
@@ -12,6 +12,7 @@ import {
   ModActionWrapper,
   Time,
   QuoteWrapper,
+  QuoteWrapperGradient,
   QuotedParagraph,
 } from './style';
 import { messageRenderer } from 'shared/clients/draft-js/message/renderer.web';
@@ -67,28 +68,53 @@ export const Body = (props: {
   }
 };
 
-export const QuotedMessage = (props: {
+type QuotedMessageProps = {
   message: MessageInfoType,
   openGallery?: Function,
-}) => {
-  const { message, openGallery } = props;
-  return (
-    <QuoteWrapper data-cy="quoted-message">
-      <Byline>
-        <Icon glyph="reply" size={16} />
-        <Name>{message.author.user.name}</Name>
-        <Username>@{message.author.user.username}</Username>
-      </Byline>
-      <Body
-        message={message}
-        showParent={false}
-        me={false}
-        openGallery={openGallery ? openGallery : () => {}}
-        bubble={false}
-      />
-    </QuoteWrapper>
-  );
 };
+
+type QuotedMessageState = {
+  isExpanded: boolean,
+};
+
+export class QuotedMessage extends React.Component<
+  QuotedMessageProps,
+  QuotedMessageState
+> {
+  state = {
+    isExpanded: false,
+  };
+
+  toggle = () => {
+    this.setState(prev => ({ isExpanded: !prev.isExpanded }));
+  };
+
+  render() {
+    const { message, openGallery } = this.props;
+    const { isExpanded } = this.state;
+    return (
+      <QuoteWrapper
+        expanded={isExpanded}
+        onClick={this.toggle}
+        data-cy="quoted-message"
+      >
+        <Byline>
+          <Icon glyph="reply" size={16} />
+          <Name>{message.author.user.name}</Name>
+          <Username>@{message.author.user.username}</Username>
+        </Byline>
+        <Body
+          message={message}
+          showParent={false}
+          me={false}
+          openGallery={openGallery ? openGallery : () => {}}
+          bubble={false}
+        />
+        {!isExpanded && <QuoteWrapperGradient />}
+      </QuoteWrapper>
+    );
+  }
+}
 
 type ActionProps = {
   me: boolean,


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This truncates long quoted replies and expands them on click. Closed state:

<img width="480" alt="screen shot 2018-05-04 at 14 03 36" src="https://user-images.githubusercontent.com/7525670/39626913-30a6bc70-4fa4-11e8-8eb0-5a782cc31fab.png">

When clicked and expanded it looks just like it does now:

<img width="485" alt="screen shot 2018-05-04 at 14 03 50" src="https://user-images.githubusercontent.com/7525670/39626927-3b9d8b86-4fa4-11e8-92f9-d7fd33a4e20c.png">

Ref #2969