### PR TITLE
Force watercoolers to always fetch the last 50 messages

### DIFF
--- a/shared/graphql/queries/thread/getThreadMessageConnection.js
+++ b/shared/graphql/queries/thread/getThreadMessageConnection.js
@@ -69,6 +69,13 @@ export const getThreadMessageConnectionOptions = {
       }
     }
 
+    if (props.isWatercooler) {
+      variables.before = null;
+      variables.after = null;
+      //$FlowFixMe
+      variables.last = 50;
+    }
+
     return {
       variables,
       fetchPolicy: 'cache-and-network',

--- a/shared/graphql/queries/thread/getThreadMessageConnection.js
+++ b/shared/graphql/queries/thread/getThreadMessageConnection.js
@@ -41,7 +41,7 @@ export const getThreadMessageConnectionOptions = {
         msgsbefore = params.msgsbefore;
       } catch (err) {
         // Ignore errors in query string parsing, who cares
-        console.log(err);
+        console.error(err);
       }
     }
     let variables = {

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -434,6 +434,7 @@ class ThreadContainer extends React.Component<Props, State> {
                       shouldForceScrollToTopOnMessageLoad={false}
                       hasMessagesToLoad={thread.messageCount > 0}
                       isModerator={isModerator}
+                      isWatercooler={true}
                     />
                   )}
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Watercoolers can have a frustrating behavior where it won't just automatically put you at the end of the latest chat. We try to be clever about where to put the user based on their last seen time, the number of messages in the thread, etc.

But since watercoolers are our most "ephemeral" chat area, this clever-ness is mostly just annoying and ends up with people having to do extra scrolling or paginating to get to the last set of messages to see what people are talking about *right now*. This change makes it so that watercoolers *only* fetch the latest 50 messages, and users have the ability to paginate back in time if they want.

Closes #3013 