### PR TITLE
Fix null results from crashing user profiles

### DIFF
--- a/api/queries/community/brandedLogin.js
+++ b/api/queries/community/brandedLogin.js
@@ -8,6 +8,7 @@ export default async (
   { loaders }: GraphQLContext
 ) => {
   return await loaders.communitySettings.load(id).then(settings => {
+    if (!settings) return null;
     return settings.brandedLogin;
   });
 };

--- a/api/queries/community/brandedLogin.js
+++ b/api/queries/community/brandedLogin.js
@@ -8,7 +8,7 @@ export default async (
   { loaders }: GraphQLContext
 ) => {
   return await loaders.communitySettings.load(id).then(settings => {
-    if (!settings) return null;
+    if (!settings) return { isEnabled: null, message: null };
     return settings.brandedLogin;
   });
 };


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

I honestly have no clue what is going on here - basically the loader would return null immediately before returning the proper results for `communitySettings` - so weird. If we ignore the null result first things are fixed. This bug was breaking this user profile:

spectrum.chat/users/frankast

Fixes https://sentry.io/space-program/spectrum/issues/529296144/?query=is:unresolved