### PR TITLE
Sanitize filenames in image uploads

### DIFF
--- a/api/utils/s3.js
+++ b/api/utils/s3.js
@@ -4,6 +4,7 @@ import AWS from 'aws-sdk';
 import shortid from 'shortid';
 import _ from 'lodash';
 import Raven from 'shared/raven';
+import sanitize from 'sanitize-filename';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
 
@@ -45,7 +46,7 @@ export const uploadImage = async (
 ): Promise<string> => {
   const result = await file;
   const { filename, stream, mimetype } = result;
-
+  const sanitized = sanitize(filename);
   const validMediaTypes = ['image/gif', 'image/jpeg', 'image/png', 'video/mp4'];
 
   return new Promise(res => {
@@ -59,7 +60,7 @@ export const uploadImage = async (
     }
 
     const path = `spectrum-chat/${entity}/${id}`;
-    const fileKey = `${shortid.generate()}-${filename}`;
+    const fileKey = `${shortid.generate()}-${sanitized}`;
     return s3.upload(
       {
         Bucket: path,

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "rethinkdb-inspector": "^0.3.3",
     "rethinkdb-migrate": "^1.1.0",
     "rethinkdbdash": "^2.3.29",
+    "sanitize-filename": "^1.6.1",
     "serialize-javascript": "^1.4.0",
     "session-rethinkdb": "^2.0.0",
     "shortid": "^2.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9668,6 +9668,12 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
+sanitize-filename@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.1.tgz#612da1c96473fa02dccda92dcd5b4ab164a6772a"
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
+
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
@@ -10654,6 +10660,12 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  dependencies:
+    utf8-byte-length "^1.0.1"
+
 tryer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.0.tgz#027b69fa823225e551cace3ef03b11f6ab37c1d7"
@@ -10953,6 +10965,10 @@ use@^3.1.0:
 user-home@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
+
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

> sanitize-filename removes the following:

> Control characters (0x00–0x1f and 0x80–0x9f)
Reserved characters (/, ?, <, >, \, :, *, |, and ")
Unix reserved filenames (. and ..)
Trailing periods and spaces (for Windows)
Windows reserved filenames (CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9)

Closes #3000 