### PR TITLE
fix(shared/graphql): not flow typechecked file

### DIFF
--- a/shared/graphql/apollo-client-options.js
+++ b/shared/graphql/apollo-client-options.js
@@ -1,7 +1,8 @@
+// @flow
 var apollo = require('apollo-utilities'),
   toIdValue = apollo.toIdValue;
 
-function dataIdFromObject(result) {
+function dataIdFromObject(result: any) {
   if (result.__typename) {
     // Custom Community cache key based on slug
     if (result.__typename === 'Community' && !!result.slug) {
@@ -35,17 +36,17 @@ var getSharedApolloClientOptions = function getSharedApolloClientOptions() {
     dataIdFromObject: dataIdFromObject,
     cacheRedirects: {
       Query: {
-        thread: function thread(_, _ref) {
+        thread: function thread(_: any, _ref: any) {
           var id = _ref.id;
           return toIdValue(dataIdFromObject({ __typename: 'Thread', id: id }));
         },
-        community: function community(_, _ref2) {
+        community: function community(_: any, _ref2: any) {
           var slug = _ref2.slug;
           return toIdValue(
             dataIdFromObject({ __typename: 'Community', slug: slug })
           );
         },
-        channel: function channel(_, _ref3) {
+        channel: function channel(_: any, _ref3: any) {
           var channelSlug = _ref3.channelSlug,
             communitySlug = _ref3.communitySlug;
           return toIdValue(


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] Ready for review

**Deploy after merge (delete what needn't be deployed)**
- shared

i figure outed not flow typechecked file.
so i enable flow typeckeck at `shared/graphql/apollo-client-options.js` & add some any type.

this file syntax seems like before es2015, so strange for me:hushed:

<!--

If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.

-->
