### PR TITLE
Fix ServiceWorker caching issue

### DIFF
--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -3,6 +3,7 @@ const debug = require('debug')('hyperion');
 debug('Hyperion starting...');
 debug('logging with debug enabled');
 require('isomorphic-fetch'); // prevent https://github.com/withspectrum/spectrum/issues/3032
+import fs from 'fs';
 import express from 'express';
 import Loadable from 'react-loadable';
 import path from 'path';
@@ -105,9 +106,28 @@ import threadParamRedirect from 'shared/middlewares/thread-param';
 app.use(threadParamRedirect);
 
 // Static files
+// This route handles the case where our ServiceWorker requests main.asdf123.js, but
+// we've deployed a new version of the app so the filename changed to main.dfyt975.js
+let jsFiles;
+try {
+  jsFiles = fs.readdirSync(
+    path.resolve(__dirname, '..', 'build', 'static', 'js')
+  );
+} catch (err) {
+  // In development that folder might not exist, so ignore errors here
+  console.error(err);
+}
 app.use(
   express.static(path.resolve(__dirname, '..', 'build'), { index: false })
 );
+app.get('/static/js/:name', (req: express$Request, res, next) => {
+  if (!req.params.name) return next();
+  const match = req.params.name.match(/(\w+?)\.(\w+?\.)?js/i);
+  if (!match) return next();
+  const actualFilename = jsFiles.find(file => file.startsWith(match[1]));
+  if (!actualFilename) return next();
+  res.redirect(`/static/js/${actualFilename}`);
+});
 
 // In dev the static files from the root public folder aren't moved to the build folder by create-react-app
 // so we just tell Express to serve those too

--- a/hyperion/renderer/html-template.js
+++ b/hyperion/renderer/html-template.js
@@ -5,9 +5,7 @@ import { html } from 'common-tags';
 import serialize from 'serialize-javascript';
 
 // Match main.asdf123.js in production mode or bundle.js in dev mode
-const mainBundleRegex = new RegExp(
-  `${process.env.NODE_ENV === 'production' ? 'main' : 'bundle'}\.(?:.*\.)?js$`
-);
+const mainBundleRegex = /(main|bundle)\.(?:.*\.)?js$/;
 
 let bundles;
 try {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This patch introduces new routing behavior for static JS files being served from hyperion. No matter what the hash of the requested file is, the request will be redirected to the proper JS. E.g. if you request `/static/js/main.some-bullshit-thats-wrong.js` you will automatically be redirected to `/static/js/main.asdf123.js`. (where `asdf123` is the correct and up to date hash of the file on the disk)

This is necessary because of our client-side ServiceWorker caching. It seems to happen fairly often that it requests a new file, but due to a redeploy (and thusly the file hashes changing) the file isn't at that place anymore-so hyperion tries to SSR that path and returns HTML.

Closes #3034, closes #3011