### PR TITLE
Verify DraftJS inputs

### DIFF
--- a/api/types/Thread.js
+++ b/api/types/Thread.js
@@ -13,7 +13,7 @@ const Thread = /* GraphQL */ `
 	# The contents of a thread
 	type ThreadContent {
 		title: String
-		body: String
+		body: RawDraftContentState
 		media: String
 	}
 
@@ -78,7 +78,7 @@ const Thread = /* GraphQL */ `
 
 	input ThreadContentInput {
 		title: String
-		body: String
+		body: RawDraftContentState
 	}
 
 	input EditThreadInput {

--- a/api/types/custom-scalars/RawDraftContentState.js
+++ b/api/types/custom-scalars/RawDraftContentState.js
@@ -1,8 +1,23 @@
 // @flow
+const debug = require('debug')('api:types:custom-scalars');
 import { GraphQLScalarType, Kind } from 'graphql';
 import UserError from '../../utils/UserError';
 
-const isRawDraftContentState = (contentState: mixed) => true;
+// Pretty dumb manual check to make sure a value is actual raw draft content state
+const isRawDraftContentState = (contentState: string) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(contentState);
+  } catch (err) {
+    debug('error parsing raw draft content state');
+    return false;
+  }
+  if (!parsed.blocks || !Array.isArray(parsed.blocks) || !parsed.entityMap) {
+    debug('invalid raw draft content state');
+    return false;
+  }
+  return true;
+};
 
 const RawDraftContentState = new GraphQLScalarType({
   name: 'RawDraftContentState',
@@ -10,7 +25,7 @@ const RawDraftContentState = new GraphQLScalarType({
 
   // Input validation
   parseValue(value) {
-    if (isRawDraftContentState(value)) return JSON.parse(value);
+    if (isRawDraftContentState(value)) return value;
     throw new UserError('Please provide raw DraftJS ContentState as input.');
   },
   parseLiteral(ast) {

--- a/api/types/custom-scalars/RawDraftContentState.js
+++ b/api/types/custom-scalars/RawDraftContentState.js
@@ -1,0 +1,31 @@
+// @flow
+import { GraphQLScalarType, Kind } from 'graphql';
+import UserError from '../../utils/UserError';
+
+const isRawDraftContentState = (contentState: mixed) => true;
+
+const RawDraftContentState = new GraphQLScalarType({
+  name: 'RawDraftContentState',
+  description: 'Returns all strings in lower case',
+
+  // Input validation
+  parseValue(value) {
+    if (isRawDraftContentState(value)) return JSON.parse(value);
+    throw new UserError('Please provide raw DraftJS ContentState as input.');
+  },
+  parseLiteral(ast) {
+    // Extract the value from the AST
+    if (ast.kind === Kind.STRING && isRawDraftContentState(ast.value)) {
+      return ast.value;
+    }
+    throw new UserError('Please provide raw DraftJS ContentState as input.');
+  },
+
+  // Output conversion
+  serialize(value) {
+    if (typeof value === 'string') return value;
+    return JSON.stringify(value);
+  },
+});
+
+export default RawDraftContentState;

--- a/api/types/scalars.js
+++ b/api/types/scalars.js
@@ -3,23 +3,21 @@
  * Custom scalars (data types, like Int, String,...) live in this file,
  * both their type definitions and their resolvers
  */
-const GraphQLDate = require('graphql-date');
+import GraphQLDate from 'graphql-date';
 import { GraphQLUpload } from 'apollo-upload-server';
 import LowercaseString from './custom-scalars/LowercaseString';
+import RawDraftContentState from './custom-scalars/RawDraftContentState';
 
-const typeDefs = /* GraphQL */ `
+export const typeDefs = /* GraphQL */ `
 	scalar Date
   scalar Upload
   scalar LowercaseString
+  scalar RawDraftContentState
 `;
 
-const resolvers = {
+export const resolvers = {
   Date: GraphQLDate,
   Upload: GraphQLUpload,
-  LowercaseString: LowercaseString,
-};
-
-module.exports = {
-  typeDefs,
-  resolvers,
+  LowercaseString,
+  RawDraftContentState,
 };


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

This verifies that input marked as being raw DraftJS content state is actual raw DraftJS content state. /cc @flarnie is there any chance DraftJS will expose a `isRawDraftContentState(value)` API itself sometime?