### PR TITLE
Disable pointer events for the new thread overlay

### DIFF
--- a/src/components/threadComposer/style.js
+++ b/src/components/threadComposer/style.js
@@ -1,3 +1,4 @@
+// @flow
 import styled, { keyframes } from 'styled-components';
 import { hexa, Transition, FlexRow, FlexCol, zIndex } from '../globals';
 

--- a/src/components/threadComposer/style.js
+++ b/src/components/threadComposer/style.js
@@ -53,7 +53,7 @@ export const Overlay = styled.div`
       height: 100%;
       z-index: ${props.isInbox ? '3000' : zIndex.composer - 1};
       background: #000;
-      pointer-events: auto;
+      pointer-events: none;
       opacity: 0.4;
     `
       : `


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] WIP
- [ ] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Resolve the bug pointed out here: https://spectrum.chat/?t=3a8e24ab-972f-496b-946a-2812ebd7c94b

The combination of `position: fixed` and `pointer-events: auto` prevents the user from scrolling over the overlay component. 

Setting `pointer-events: none` fixes that.

<!--

If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.

-->
