### PR TITLE
[Mobile v1] Overlay thread participant heads

### DIFF
--- a/mobile/components/Avatar/index.js
+++ b/mobile/components/Avatar/index.js
@@ -6,13 +6,16 @@ type AvatarProps = {
   src: string,
   size: number,
   radius: number,
+  style?: Object,
 };
 
 export default class Avatar extends Component<AvatarProps> {
   render() {
-    const { src, size, radius } = this.props;
+    const { src, size, radius, style } = this.props;
     let source = src ? { uri: src } : {};
 
-    return <AvatarImage source={source} size={size} radius={radius} />;
+    return (
+      <AvatarImage source={source} size={size} radius={radius} style={style} />
+    );
   }
 }

--- a/mobile/components/Avatar/style.js
+++ b/mobile/components/Avatar/style.js
@@ -5,5 +5,4 @@ export const AvatarImage = styled.Image`
   width: ${props => (props.size ? `${props.size}px` : '30px')};
   height: ${props => (props.size ? `${props.size}px` : '30px')};
   border-radius: ${props => (props.radius ? `${props.radius}px` : '15px')};
-  margin-right: 5px;
 `;

--- a/mobile/components/ThreadItem/Facepile.js
+++ b/mobile/components/ThreadItem/Facepile.js
@@ -2,7 +2,11 @@
 import * as React from 'react';
 import Avatar from '../Avatar';
 import type { UserInfoType } from '../../../shared/graphql/fragments/user/userInfo';
-import { FacepileContainer, EmptyParticipantHead } from './style';
+import {
+  FacepileContainer,
+  StackedEmptyParticipantHead,
+  StackedAvatar,
+} from './style';
 const NUM_TO_DISPLAY = 5;
 
 const messageAvatars = list => {
@@ -13,7 +17,7 @@ const messageAvatars = list => {
       return null;
     }
     return (
-      <Avatar
+      <StackedAvatar
         key={participant.id}
         src={participant.profilePhoto}
         size={30}
@@ -50,12 +54,12 @@ const Facepile = ({ participants, creator }: FacepileProps) => {
 
   return (
     <FacepileContainer>
-      <Avatar src={creator.profilePhoto} size={30} radius={15} />
+      <StackedAvatar src={creator.profilePhoto} size={30} radius={15} />
       {messageAvatars(participantList)}
       {hasOverflow && (
-        <EmptyParticipantHead adjustsFontSizeToFit>
+        <StackedEmptyParticipantHead size={30} adjustsFontSizeToFit>
           {overflowAmount}
-        </EmptyParticipantHead>
+        </StackedEmptyParticipantHead>
       )}
     </FacepileContainer>
   );

--- a/mobile/components/ThreadItem/style.js
+++ b/mobile/components/ThreadItem/style.js
@@ -1,6 +1,7 @@
 // @flow
 import styled from 'styled-components/native';
 import { Stylesheet } from 'react-native';
+import Avatar from '../Avatar';
 
 export const InboxThreadItem = styled.View`
   display: flex;
@@ -53,11 +54,24 @@ export const FacepileContainer = styled.View`
 export const EmptyParticipantHead = styled.Text`
   color: ${props => props.theme.text.alt};
   background: ${props => props.theme.bg.wash};
-  border-radius: 15px;
+  border-radius: ${props => (props.radius ? `${props.radius}px` : '15px')};
   text-align: center;
   text-align-vertical: center;
   font-size: 12px;
   font-weight: 600;
-  width: 30px;
+  height: ${props => (props.size ? `${props.size}px` : '30px')};
+  width: ${props => (props.size ? `${props.size}px` : '30px')};
   overflow: hidden;
 `;
+
+const stackizeHeads = (
+  component,
+  { marginRight = '-10px', borderWidth = '2px', borderColor = '#FFFFFF' } = {}
+) => styled(component)`
+  margin-right: ${marginRight};
+  border-width: ${borderWidth};
+  border-color: ${borderColor};
+`;
+
+export const StackedEmptyParticipantHead = stackizeHeads(EmptyParticipantHead);
+export const StackedAvatar = stackizeHeads(Avatar);

--- a/mobile/components/ThreadItem/style.js
+++ b/mobile/components/ThreadItem/style.js
@@ -1,5 +1,5 @@
 // @flow
-import styled from 'styled-components/native';
+import styled, { css } from 'styled-components/native';
 import { Stylesheet } from 'react-native';
 import Avatar from '../Avatar';
 
@@ -64,14 +64,16 @@ export const EmptyParticipantHead = styled.Text`
   overflow: hidden;
 `;
 
-const stackizeHeads = (
-  component,
-  { marginRight = '-10px', borderWidth = '2px', borderColor = '#FFFFFF' } = {}
-) => styled(component)`
-  margin-right: ${marginRight};
-  border-width: ${borderWidth};
-  border-color: ${borderColor};
+const stackingStyles = css`
+  margin-right: -10px;
+  border-width: 2px;
+  border-color: #ffffff;
 `;
 
-export const StackedEmptyParticipantHead = stackizeHeads(EmptyParticipantHead);
-export const StackedAvatar = stackizeHeads(Avatar);
+export const StackedEmptyParticipantHead = styled(EmptyParticipantHead)`
+  ${stackingStyles};
+`;
+
+export const StackedAvatar = styled(Avatar)`
+  ${stackingStyles};
+`;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- mobile

**Release notes for users (delete if codebase-only change)**
_Tired of seeing those heads so spaced out? Well no more, now they stack in a sexy way!_ 

Before:
![participants_before](https://user-images.githubusercontent.com/11748696/39948771-1f166aa2-553d-11e8-8adf-2d1211db975b.png)

After:
![participants_after](https://user-images.githubusercontent.com/11748696/39948773-2394fcf6-553d-11e8-96cc-34c493ffb9af.png)

<!--

If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.

-->

Parent Isue: #2330 
