### PR TITLE
fix(message): always return false condition

### DIFF
--- a/src/components/message/view.js
+++ b/src/components/message/view.js
@@ -89,7 +89,9 @@ export class QuotedMessage extends React.Component<
       if (props.message.messageType === 'media') return false;
       const jsonBody = JSON.parse(props.message.content.body);
       return (
-        jsonBody.blocks.length < 1 ||
+        // Note (@ryota-murakami) i made a mistake on PR because i didn't invastigate DraftJS json schema some pattern of input.
+        // @see (@maxstbr)'s certainly comment and the conditions intent. https://github.com/withspectrum/spectrum/pull/3075#discussion_r187942991
+        jsonBody.blocks.length <= 1 ||
         toPlainText(toState(jsonBody)).length <= 170
       );
     };

--- a/src/components/message/view.js
+++ b/src/components/message/view.js
@@ -89,8 +89,7 @@ export class QuotedMessage extends React.Component<
       if (props.message.messageType === 'media') return false;
       const jsonBody = JSON.parse(props.message.content.body);
       return (
-        // Note (@ryota-murakami) i made a mistake on PR because i didn't invastigate DraftJS json schema some pattern of input.
-        // @see (@maxstbr)'s certainly comment and the conditions intent. https://github.com/withspectrum/spectrum/pull/3075#discussion_r187942991
+        // @see https://github.com/withspectrum/spectrum/pull/3075#discussion_r187942991
         jsonBody.blocks.length <= 1 ||
         toPlainText(toState(jsonBody)).length <= 170
       );

--- a/src/components/message/view.js
+++ b/src/components/message/view.js
@@ -89,7 +89,7 @@ export class QuotedMessage extends React.Component<
       if (props.message.messageType === 'media') return false;
       const jsonBody = JSON.parse(props.message.content.body);
       return (
-        !jsonBody.blocks.length > 1 ||
+        jsonBody.blocks.length < 1 ||
         toPlainText(toState(jsonBody)).length <= 170
       );
     };


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] Ready for review

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

this condition seems like always return false doesn't matter `jsonBody.blocks.length`.
eventually condition become `false > 1` or `true > 1`.

i fix the condition based on `isShort()` method intention(as far as I know)

thank you:pray: