### PR TITLE
[WIP] Idleness Manager

### DIFF
--- a/admin/src/api/fragments/user/userInfo.js
+++ b/admin/src/api/fragments/user/userInfo.js
@@ -13,6 +13,7 @@ export const userInfoFragment = gql`
     isAdmin
     isPro
     isOnline
+    status
     totalReputation
   }
 `;

--- a/api/migrations/20180512123308-user-status-to-offline.js
+++ b/api/migrations/20180512123308-user-status-to-offline.js
@@ -1,0 +1,21 @@
+exports.up = async (r, conn) => {
+  return Promise.all([
+    r
+      .table('users')
+      .update({
+        status: 'offline',
+      })
+      .run(conn),
+  ]).catch(err => console.error(err));
+};
+
+exports.down = async (r, conn) => {
+  return Promise.all([
+    r
+      .table('users')
+      .update({
+        status: r.literal(),
+      })
+      .run(conn),
+  ]).catch(err => console.error(err));
+};

--- a/api/migrations/seed/generate.js
+++ b/api/migrations/seed/generate.js
@@ -34,6 +34,7 @@ const generateUser = () => {
     createdAt,
     // Make sure lastSeen is > createdAt
     lastSeen: faker.date.between(createdAt, new Date()),
+    status: 'offline',
   };
 };
 

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -423,7 +423,7 @@ const setUserOnline = (id: string, isOnline: boolean): DBUser => {
     });
 };
 
-const updateUserStatus = (id: string, status: string): DBUser => {
+const updateUserStatus = (id: string, status: string): Promise<DBUser> => {
   const data = { status };
 
   return db

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -406,11 +406,26 @@ const setUserOnline = (id: string, isOnline: boolean): DBUser => {
   let data = {};
 
   data.isOnline = isOnline;
+  data.status = isOnline ? 'online' : 'offline';
 
   // If a user is going offline, store their lastSeen
   if (isOnline === false) {
     data.lastSeen = new Date();
   }
+  return db
+    .table('users')
+    .get(id)
+    .update(data, { returnChanges: 'always' })
+    .run()
+    .then(result => {
+      if (result.changes[0].new_val) return result.changes[0].new_val;
+      return result.changes[0].old_val;
+    });
+};
+
+const updateUserStatus = (id: string, status: string): DBUser => {
+  const data = { status };
+
   return db
     .table('users')
     .get(id)
@@ -489,6 +504,7 @@ module.exports = {
   editUser,
   getEverything,
   setUserOnline,
+  updateUserStatus,
   setUserPendingEmail,
   updateUserEmail,
   deleteUser,

--- a/api/mutations/user/index.js
+++ b/api/mutations/user/index.js
@@ -12,6 +12,7 @@ import toggleNotificationSettings from './toggleNotificationSettings';
 import subscribeWebPush from './subscribeWebPush';
 import unsubscribeWebPush from './unsubscribeWebPush';
 import updateUserEmail from './updateUserEmail';
+import updateUserStatus from './updateUserStatus';
 import deleteCurrentUser from './deleteCurrentUser';
 
 module.exports = {
@@ -21,6 +22,7 @@ module.exports = {
     subscribeWebPush,
     unsubscribeWebPush,
     updateUserEmail,
+    updateUserStatus,
     deleteCurrentUser,
   },
 };

--- a/api/mutations/user/updateUserStatus.js
+++ b/api/mutations/user/updateUserStatus.js
@@ -4,7 +4,7 @@ import UserError from '../../utils/UserError';
 import { updateUserStatus } from '../../models/user';
 import Raven from 'shared/raven';
 
-import { UserStatus } from 'shared/graphql/fragments/user/userInfo';
+import type { UserStatus } from 'shared/graphql/fragments/user/userInfo';
 
 export default async (
   _: any,

--- a/api/mutations/user/updateUserStatus.js
+++ b/api/mutations/user/updateUserStatus.js
@@ -1,0 +1,20 @@
+// @flow
+import type { GraphQLContext } from '../../';
+import UserError from '../../utils/UserError';
+import { updateUserStatus } from '../../models/user';
+import Raven from 'shared/raven';
+
+import { UserStatus } from 'shared/graphql/fragments/user/userInfo';
+
+export default async (
+  _: any,
+  { status }: { status: UserStatus },
+  { user }: GraphQLContext
+) => {
+  const currentUser = user;
+
+  return updateUserStatus(user.id, status).catch(err => {
+    console.error(err);
+    Raven.captureException(err);
+  });
+};

--- a/api/types/User.js
+++ b/api/types/User.js
@@ -79,6 +79,12 @@ const User = /* GraphQL */ `
 		username: String
 	}
 
+	enum StatusType {
+		offline
+		online
+		idle
+	}
+
 	type User {
 		id: ID!
 		name: String
@@ -93,6 +99,7 @@ const User = /* GraphQL */ `
 		createdAt: Date!
 		lastSeen: Date!
 		isOnline: Boolean
+		status: StatusType
 		timezone: Int
 		totalReputation: Int
 		pendingEmail: LowercaseString
@@ -160,6 +167,7 @@ const User = /* GraphQL */ `
     subscribeExpoPush(token: String!): Boolean
 		deleteCurrentUser: Boolean
 		updateUserEmail(email: LowercaseString!): User
+		updateUserStatus(status: LowercaseString!): User
 	}
 `;
 

--- a/athena/utils/get-email-status.js
+++ b/athena/utils/get-email-status.js
@@ -19,8 +19,8 @@ const getEmailStatus = (
         return false;
       }
 
-      if (user.isOnline) {
-        debug(`user#${userId} is online, not sending email`);
+      if (user.status && user.status !== 'offline') {
+        debug(`user#${userId} is not offline, not sending email`);
         return false;
       }
 

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "react-error-boundary": "^1.2.1",
     "react-flip-move": "^2.10.1",
     "react-helmet-async": "^0.0.4",
+    "react-idle": "^3.0.0",
     "react-infinite-scroller-with-scroll-element": "2.0.2",
     "react-loadable": "5.3.1",
     "react-modal": "3.x",

--- a/shared/graphql/fragments/user/userInfo.js
+++ b/shared/graphql/fragments/user/userInfo.js
@@ -1,6 +1,8 @@
 // @flow
 import gql from 'graphql-tag';
 
+export type UserStatus = 'online' | 'offline' | 'idle';
+
 export type UserInfoType = {
   id: string,
   profilePhoto: string,

--- a/shared/graphql/mutations/user/updateUserStatus.js
+++ b/shared/graphql/mutations/user/updateUserStatus.js
@@ -1,0 +1,27 @@
+// @flow
+import { graphql } from 'react-apollo';
+import gql from 'graphql-tag';
+import userInfoFragment from '../../fragments/user/userInfo';
+import type { UserInfoType } from '../../fragments/user/userInfo';
+
+export const updateUserStatusMutation = gql`
+  mutation updateUserStatus($status: LowercaseString!) {
+    updateUserStatus(status: $status) {
+      ...userInfo
+    }
+  }
+  ${userInfoFragment}
+`;
+
+const userStatusOptions = {
+  props: ({ mutate }) => ({
+    updateStatus: status =>
+      mutate({
+        variables: {
+          status,
+        },
+      }),
+  }),
+};
+
+export default graphql(updateUserStatusMutation, userStatusOptions);

--- a/shared/types.js
+++ b/shared/types.js
@@ -265,6 +265,7 @@ export type DBUser = {
   username: ?string,
   timezone?: ?number,
   isOnline?: boolean,
+  status: 'online' | 'offline' | 'idle',
   lastSeen?: ?Date,
   description?: ?string,
   website?: ?string,

--- a/src/helpers/idleManager.js
+++ b/src/helpers/idleManager.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { withRouter } from 'react-router';
+import { withApollo } from 'react-apollo';
+import { connect } from 'react-redux';
+import compose from 'recompose/compose';
+import Idle from 'react-idle';
+
+import updateUserStatusMutation from 'shared/graphql/mutations/user/updateUserStatus';
+
+const IDLE_TIMEOUT_MINUTES = 3;
+const BLURRED_TIMEOUT_MINUTES = 0.5;
+
+type Props = {
+  currentUser?: Object,
+};
+
+type State = {
+  isBlurred: boolean,
+  isIdle: boolean,
+};
+
+class IdleManagerWithData extends React.Component<Props, State> {
+  state = {
+    isBlurred: false,
+    isIdle: false,
+  };
+
+  updateStatus = isIdle => {
+    if (this.state.isIdle === isIdle) return;
+
+    this.setState({ isIdle }, () => {
+      if (this.props.currentUser)
+        this.props.updateStatus(isIdle ? 'idle' : 'online');
+    });
+  };
+
+  handleWindowBlur = () => {
+    this.setState({ isBlurred: true });
+  };
+
+  handleWindowFocus = () => {
+    this.setState({ isBlurred: false });
+  };
+
+  componentDidMount() {
+    window.addEventListener('blur', this.handleWindowBlur);
+    window.addEventListener('focus', this.handleWindowFocus);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('blur', this.handleWindowBlur);
+    window.removeEventListener('focus', this.handleWindowFocus);
+  }
+
+  render() {
+    return (
+      <Idle
+        timeout={
+          this.state.isBlurred
+            ? BLURRED_TIMEOUT_MINUTES * 60000
+            : IDLE_TIMEOUT_MINUTES * 60000
+        }
+        onChange={({ idle }) => this.updateStatus(idle)}
+      />
+    );
+  }
+}
+
+const map = state => ({
+  currentUser: state.users.currentUser,
+});
+
+const IdleManager = compose(
+  updateUserStatusMutation,
+  withRouter,
+  withApollo,
+  // $FlowIssue
+  connect(map)
+)(IdleManagerWithData);
+
+export default IdleManager;

--- a/src/helpers/idleManager.js
+++ b/src/helpers/idleManager.js
@@ -8,8 +8,8 @@ import Idle from 'react-idle';
 
 import updateUserStatusMutation from 'shared/graphql/mutations/user/updateUserStatus';
 
-const IDLE_TIMEOUT_MINUTES = 3;
-const BLURRED_TIMEOUT_MINUTES = 0.5;
+const IDLE_TIMEOUT_MINUTES = 0.2;
+const BLURRED_TIMEOUT_MINUTES = 0.2;
 
 type Props = {
   currentUser?: Object,
@@ -42,6 +42,7 @@ class IdleManagerWithData extends React.Component<Props, State> {
 
   handleWindowFocus = () => {
     this.setState({ isBlurred: false });
+    this.updateStatus(false);
   };
 
   componentDidMount() {
@@ -55,6 +56,7 @@ class IdleManagerWithData extends React.Component<Props, State> {
   }
 
   render() {
+    console.log('rendering the idle manager');
     return (
       <Idle
         timeout={

--- a/src/helpers/idleManager.js
+++ b/src/helpers/idleManager.js
@@ -8,8 +8,8 @@ import Idle from 'react-idle';
 
 import updateUserStatusMutation from 'shared/graphql/mutations/user/updateUserStatus';
 
-const IDLE_TIMEOUT_MINUTES = 0.2;
-const BLURRED_TIMEOUT_MINUTES = 0.2;
+const IDLE_TIMEOUT_MINUTES = 3;
+const BLURRED_TIMEOUT_MINUTES = 0.5;
 
 type Props = {
   currentUser?: Object,
@@ -56,7 +56,6 @@ class IdleManagerWithData extends React.Component<Props, State> {
   }
 
   render() {
-    console.log('rendering the idle manager');
     return (
       <Idle
         timeout={

--- a/src/helpers/idleManager.js
+++ b/src/helpers/idleManager.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import { withRouter } from 'react-router';
 import { withApollo } from 'react-apollo';
@@ -12,6 +13,7 @@ const BLURRED_TIMEOUT_MINUTES = 0.5;
 
 type Props = {
   currentUser?: Object,
+  updateStatus: Function,
 };
 
 type State = {
@@ -25,7 +27,7 @@ class IdleManagerWithData extends React.Component<Props, State> {
     isIdle: false,
   };
 
-  updateStatus = isIdle => {
+  updateStatus = (isIdle: boolean) => {
     if (this.state.isIdle === isIdle) return;
 
     this.setState({ isIdle }, () => {

--- a/src/routes.js
+++ b/src/routes.js
@@ -28,6 +28,7 @@ import Login from './views/login';
 
 import DirectMessages from './views/directMessages';
 import Thread from './views/thread';
+import IdleManager from './helpers/idleManager';
 
 /* prettier-ignore */
 const Explore = Loadable({
@@ -168,6 +169,7 @@ class Routes extends React.Component<{}> {
     return (
       <ThemeProvider theme={theme}>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
+          <IdleManager />
           <ScrollManager>
             <Body>
               {/* Default meta tags, get overriden by anything further down the tree */}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8938,6 +8938,10 @@ react-helmet-async@^0.0.4:
     prop-types "^15.6.0"
     shallowequal "^1.0.2"
 
+react-idle@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-idle/-/react-idle-3.0.0.tgz#d0e25abcc7192e64b49c21749920c6feae61dab2"
+
 react-infinite-scroller-with-scroll-element@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/react-infinite-scroller-with-scroll-element/-/react-infinite-scroller-with-scroll-element-2.0.2.tgz#1a59ee022cd798260593c1322794ed809cd5e2a5"


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] WIP
- [ ] Ready for review
- [x] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)
- athena

**Run database migrations (delete if no migration was added)**
YES


-------
for #1941

- introduces a new `status = 'offline' | 'online' | 'idle'` field to the user documents.
- modifies email notification logic to only send when offline (not when online or idle).
- atm user goes idle when on focused tab in 3 minutes, 30 seconds when blurred tab.

As discussed in DMs, there's one issue here (that seems to be in current production as well with `user.isOnline`) in that tabs will compete with each other to set this state, so a backgrounded tab will possibly set the status to idle even if a foreground tab is active.

I'm looking for input on how to solve this, options that come to mind but haven't thought out too much yet:

1. Some kind of service worker implementation to have registered tabs coordinating on maintaining the idle state?
2. Naively polling the server on some interval to set as "active". Still going to be a case where some background tab goes idle, and there is time in between the active tab polling back to online.
3. Maybe use LocalStorage and StorageEvent to coordinate the value across tabs?

Any of these seem more reasonable than others? Any other suggestions?

Also need input on the timing related to idleness