### PR TITLE
Add TRACK_DB_PERF environment variable to API

### DIFF
--- a/api/models/db.js
+++ b/api/models/db.js
@@ -38,7 +38,7 @@ if (process.env.TEST_DB) {
   });
 }
 
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'development' && process.env.TRACK_DB_PERF) {
   const fs = require('fs');
   const inspect = require('rethinkdb-inspector');
   const queries = [];


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

Previously in development mode we would automatically track db query perf and output the stats to two files in the root of the project automatically. (`queries-by-time.json` & `queries-by-response-size.json`)

As @ryota-murakami figured out, those files changing causes the mobile app to live reload (since it sensed files changed), but since those files change on every API request the mobile client would infinitely reboot.  This change makes the perf analysis opt-in, which means mobile no longer infinitely reboots!

Closes #2894