### PR TITLE
Update CSS transitions

### DIFF
--- a/admin/src/components/globals/index.js
+++ b/admin/src/components/globals/index.js
@@ -437,7 +437,7 @@ export const Tooltip = props => css`
   &:hover:after,
   &:hover:before {
     opacity: 1;
-    transition: all 0.1s ease-in 0.1s;
+    transition: opacity 0.1s ease-in 0.1s;
   }
 `;
 
@@ -487,7 +487,7 @@ export const Onboarding = props => css`
   &:after,
   &:before {
     opacity: 1;
-    transition: all 0.1s ease-in 0.1s;
+    transition: opacity 0.1s ease-in 0.1s;
   }
 `;
 

--- a/src/components/chatInput/components/style.js
+++ b/src/components/chatInput/components/style.js
@@ -16,7 +16,7 @@ export const MediaLabel = styled.label`
   outline: 0;
   display: inline-block;
   background: transparent;
-  transition: all 0.3s ease-out;
+  transition: color 0.3s ease-out;
   color: ${({ theme }) => theme.text.placeholder};
   height: 32px;
   width: 32px;

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -173,7 +173,7 @@ export const MediaLabel = styled.label`
   outline: 0;
   display: inline-block;
   background: transparent;
-  transition: all 0.3s ease-out;
+  transition: color 0.3s ease-out;
   border-radius: 4px;
   padding: 4px;
   position: relative;

--- a/src/components/gallery/style.js
+++ b/src/components/gallery/style.js
@@ -52,10 +52,10 @@ export const MiniImg = styled.img`
   border-radius: 2px;
   margin: 0.25rem;
   opacity: ${props => (props.active ? 1 : 0.5)};
-  transition: all 0.2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
 
   &:hover {
-    transition: all 0.2s ease-in-out;
+    transition: opacity 0.2s ease-in-out;
     cursor: pointer;
     opacity: ${props => (props.active ? 1 : 0.7)};
   }

--- a/src/components/globals/index.js
+++ b/src/components/globals/index.js
@@ -512,7 +512,7 @@ export const Tooltip = props => css`
   &:hover:after,
   &:hover:before {
     opacity: 1;
-    transition: all 0.1s ease-in 0.1s;
+    transition: opacity 0.1s ease-in 0.1s;
   }
 `;
 
@@ -562,7 +562,7 @@ export const Onboarding = props => css`
   &:after,
   &:before {
     opacity: 1;
-    transition: all 0.1s ease-in 0.1s;
+    transition: opacity 0.1s ease-in 0.1s;
   }
 `;
 

--- a/src/components/mediaInput/style.js
+++ b/src/components/mediaInput/style.js
@@ -15,7 +15,7 @@ export const MediaLabel = styled.label`
   outline: 0;
   display: inline-block;
   background: transparent;
-  transition: all 0.3s ease-out;
+  transition: color 0.3s ease-out;
   color: ${({ theme }) => theme.text.placeholder};
   height: 32px;
   width: 32px;

--- a/src/components/newActivityIndicator/index.js
+++ b/src/components/newActivityIndicator/index.js
@@ -25,17 +25,17 @@ const Pill = styled.div`
     props.active ? '80px' : '60px'});
   font-weight: 700;
   box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-  transition: all 0.2s ease-in-out;
+  transition: transform 0.2s ease-in-out;
   cursor: pointer;
 
   &:hover {
     transform: translateX(-50%) translateY(78px);
-    transition: all 0.2s ease-in-out;
+    transition: transform 0.2s ease-in-out;
   }
 
   &:active {
     transform: translateX(-50%) translateY(80px);
-    transition: all 0.1s ease-in-out;
+    transition: transform 0.1s ease-in-out;
   }
 
   @media (max-width: 768px) {
@@ -44,12 +44,12 @@ const Pill = styled.div`
 
     &:hover {
       transform: translateX(-50%) translateY(58px);
-      transition: all 0.2s ease-in-out;
+      transition: transform 0.2s ease-in-out;
     }
 
     &:active {
       transform: translateX(-50%) translateY(60px);
-      transition: all 0.1s ease-in-out;
+      transition: transform 0.1s ease-in-out;
     }
   }
 `;

--- a/src/components/rich-text-editor/Image.js
+++ b/src/components/rich-text-editor/Image.js
@@ -40,7 +40,7 @@ export const ActiveOverlay = styled.span`
   border-radius: 8px;
   border: 1px solid ${props => props.theme.brand.default};
   opacity: ${props => (props.active ? 1 : 0)};
-  transition: all 0.1s ease-in-out;
+  transition: opacity 0.1s ease-in-out;
 `;
 
 const Img = styled.img`

--- a/src/reset.css.js
+++ b/src/reset.css.js
@@ -138,14 +138,14 @@ injectGlobal`
     max-width: 100%;
     display: inline;
     border-radius: 4px;
-    transition: all 0.2s;
+    transition: box-shadow 0.2s;
     display: block;
     margin: 12px 0;
   }
 
   .markdown img:hover {
     cursor: pointer;
-    transition: all 0.2s;
+    transition: box-shadow 0.2s;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   }
 
@@ -206,7 +206,7 @@ injectGlobal`
 
   .markdown a:visited {
     opacity: 0.6;
-    transition: all 0.2s ease-in;
+    transition: opacity 0.2s ease-in;
   }
 
   .markdown code {

--- a/src/views/dashboard/style.js
+++ b/src/views/dashboard/style.js
@@ -770,7 +770,7 @@ export const ClearSearch = styled.span`
   font-weight: 500;
   pointer-events: ${props => (props.isOpen ? 'auto' : 'none')};
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background 0.2s;
 
   &:hover {
     background: ${props => props.theme.text.alt};

--- a/src/views/newUserOnboarding/style.js
+++ b/src/views/newUserOnboarding/style.js
@@ -115,6 +115,6 @@ export const StickyRow = styled.div`
   background: ${props => props.theme.bg.default};
   border-top: 2px solid ${props => props.theme.bg.border};
   z-index: ${zIndex.fullscreen + 1};
-  transition: all 0.3s ease-in-out;
+  transition: bottom 0.3s ease-in-out, opacity 0.3s ease-in-out;
   -webkit-transform: translate3d(0, 0, 0);
 `;

--- a/src/views/pages/features/style.js
+++ b/src/views/pages/features/style.js
@@ -67,7 +67,8 @@ export const Waterfall = styled.img`
   height: 100vh;
   max-height: 90vw;
   z-index: 0;
-  transition: all 0.2s ease-in-out;
+  transition: top 0.2s ease-in-out, height 0.2s ease-in-out,
+    left 0.2s ease-in-out;
 
   @media (max-width: 1480px) {
     top: -20vh;

--- a/src/views/pages/pricing/style.js
+++ b/src/views/pages/pricing/style.js
@@ -388,13 +388,13 @@ export const CommunityCardButton = styled.button`
   font-weight: 600;
   color: ${props => props.theme.text.alt};
   background: ${props => props.theme.bg.wash};
-  transition: all 0.2s cubic-bezier(0.77, 0, 0.175, 1);
+  transition: color 0.2s cubic-bezier(0.77, 0, 0.175, 1);
   width: 100%;
 
   &:hover {
     color: ${props => props.theme.text.default};
     cursor: pointer;
-    transition: all 0.2s cubic-bezier(0.77, 0, 0.175, 1);
+    transition: color 0.2s cubic-bezier(0.77, 0, 0.175, 1);
   }
 `;
 

--- a/src/views/pages/style.js
+++ b/src/views/pages/style.js
@@ -338,14 +338,14 @@ export const LinkSection = styled(FooterSection)`
       width: 0%;
       opacity: 0;
       background-color: ${props => props.theme.text.reverse};
-      transition: all 0.2s ease-in-out;
+      transition: opacity 0.2s ease-in-out, width 0.2s ease-in-out;
     }
 
     &:hover {
       &:after {
         width: 100%;
         opacity: 1;
-        transition: all 0.2s ease-in-out;
+        transition: opacity 0.2s ease-in-out, width 0.2s ease-in-out;
       }
     }
   }

--- a/src/views/search/style.js
+++ b/src/views/search/style.js
@@ -34,7 +34,7 @@ export const SearchInput = styled.input`
   font-size: 16px;
   display: flex;
   flex: 1;
-  transition: all 0.2s;
+  transition: color 0.2s;
   color: ${props => props.theme.text.alt};
   padding-right: 40px;
 
@@ -61,7 +61,7 @@ export const ClearSearch = styled.span`
   font-weight: 500;
   pointer-events: ${props => (props.isOpen ? 'auto' : 'none')};
   cursor: pointer;
-  transition: all 0.2s;
+  transition: background 0.2s, color 0.2s;
 
   &:hover {
     background: ${props => props.theme.text.alt};


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
I changed almost all of css transitions that were like `transition: all ...` for `transition: specific-property ...`. This will tell the browser "I want you to listen to only background-color and opacity, and animate those properties" instead of "Hey browser, listen for every single property that could change and then animate it"
