### PR TITLE
Fix E2E memory shortage on CircleCI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,8 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/spectrum
-      - run: node -e "const setup = require('./shared/testing/setup.js')().then(() => process.exit())"
+      - run: yarn run db:migrate
+      - run: yarn run db:seed
       - run: *setup-and-build-web
       - run: *build-api
       - run: *start-api

--- a/package.json
+++ b/package.json
@@ -247,7 +247,7 @@
     "build:web": "cross-env NODE_PATH=./ react-app-rewired build",
     "jest": "cross-env NODE_PATH=./ jest",
     "test": "npm run jest -- --runInBand --watch",
-    "test:ci": "npm run jest -- --forceExit --outputFile test-results.json --json",
+    "test:ci": "npm run jest -- --forceExit --outputFile test-results.json --json --maxWorkers=2",
     "test:e2e": "cypress run",
     "prestart:api:test": "node -e \"require('./shared/testing/setup.js')().then(() => process.exit())\"",
     "start:api:test": "TEST_DB=true FORCE_DEV=true DEBUG=api*,shared* forever build-api/main.js",


### PR DESCRIPTION
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

## overview

fixed https://github.com/withspectrum/spectrum/issues/3096

currently, circle ci still faild by timeout [this build](https://circleci.com/gh/withspectrum/spectrum/6514?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link), but following is result of `channel profile as owner should render settings button` test, this is specific test spec issue.

```
  10) channel profile as owner should render settings button:
     CypressError: Timed out retrying: Expected to find element: '[data-cy="channel-settings-button"]', but never found it.
      at Object.cypressErr (http://localhost:3000/__cypress/runner/cypress_runner.js:66781:11)
      at Object.throwErr (http://localhost:3000/__cypress/runner/cypress_runner.js:66746:18)
      at Object.throwErrByPath (http://localhost:3000/__cypress/runner/cypress_runner.js:66773:17)
      at retry (http://localhost:3000/__cypress/runner/cypress_runner.js:60782:16)
      at http://localhost:3000/__cypress/runner/cypress_runner.js:53285:18
      at tryCatcher (http://localhost:3000/__cypress/runner/cypress_runner.js:6846:23)
      at Promise._settlePromiseFromHandler (http://localhost:3000/__cypress/runner/cypress_runner.js:4868:31)
      at Promise._settlePromise (http://localhost:3000/__cypress/runner/cypress_runner.js:4925:18)
      at Promise._settlePromise0 (http://localhost:3000/__cypress/runner/cypress_runner.js:4970:10)
      at Promise._settlePromises (http://localhost:3000/__cypress/runner/cypress_runner.js:5045:18)
      at Async._drainQueue (http://localhost:3000/__cypress/runner/cypress_runner.js:1778:16)
      at Async._drainQueues (http://localhost:3000/__cypress/runner/cypress_runner.js:1788:10)
      at Async.drainQueues (http://localhost:3000/__cypress/runner/cypress_runner.js:1662:14)
      at <anonymous>
```

one more thing, i runed `yarn test:2e2` for this PR investigation.
therefore cypress generated video capture.

I am glad if you can freely download from here if there is demand!
https://www.dropbox.com/s/wlj59yvi0t6admv/kctz2.mp4?dl=0

- my os environment
<img width="459" alt="screen shot 2018-05-20 at 1 01 43" src="https://user-images.githubusercontent.com/5501268/40270493-7a5cee1c-5bc9-11e8-919d-366c147d2529.png">

thanks🙏
