### PR TITLE
add cypress media to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ api/.env
 mobile/.expo
 test-results.json
 public/uploads
+cypress/screenshots/
+cypress/videos/


### PR DESCRIPTION
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

## overview
ignore cypress media log created when run `yarn test:e2e` on local.  

<img width="622" alt="screen shot 2018-05-20 at 17 10 05" src="https://user-images.githubusercontent.com/5501268/40276956-3d0ad776-5c51-11e8-9efd-dc1e2b11b488.png">

thanks🙏