### PR TITLE
🐛 Fix code block styling in quoted message

### DIFF
--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -355,8 +355,13 @@ export const QuotedParagraph = Paragraph.withComponent('div').extend`
   margin: 4px 0;
   color: ${props => props.theme.text.alt};
 
-  code,
+  code {
+    color: ${props => props.theme.text.alt};
+  }
   pre {
+    margin: 0;
+    width: 100%;
+    border: 1px solid ${props => hexa(props.theme.brand.border, 0.5)};
     color: ${props => props.theme.text.alt};
   }
 `;

--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -358,6 +358,7 @@ export const QuotedParagraph = Paragraph.withComponent('div').extend`
   code {
     color: ${props => props.theme.text.alt};
   }
+  /* overrides Bubble component styles to fix #3098 */
   pre {
     margin: 0;
     width: 100%;


### PR DESCRIPTION
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)


Before             |  After
:-------------------------:|:-------------------------:
![screen shot 2018-05-21 at 11 13 44 pm](https://user-images.githubusercontent.com/22687681/40321719-97e520d2-5d4d-11e8-8bac-de644538853b.png) | ![screen shot 2018-05-21 at 11 10 06 pm](https://user-images.githubusercontent.com/22687681/40321733-a4cfefc0-5d4d-11e8-8f90-ada6a3ba57ff.png)
![screen shot 2018-05-21 at 11 13 28 pm](https://user-images.githubusercontent.com/22687681/40321897-30365770-5d4e-11e8-8c76-3d58ea6c491d.png) | ![screen shot 2018-05-21 at 11 10 22 pm](https://user-images.githubusercontent.com/22687681/40321911-3a996f7c-5d4e-11e8-8931-60ed310d8580.png)
![screen shot 2018-05-21 at 11 13 17 pm](https://user-images.githubusercontent.com/22687681/40321960-678f9786-5d4e-11e8-94fc-f3038cf4ca53.png)| ![screen shot 2018-05-21 at 11 10 45 pm](https://user-images.githubusercontent.com/22687681/40321968-70938978-5d4e-11e8-838c-88538d30c1a1.png)
![screen shot 2018-05-21 at 11 36 19 pm](https://user-images.githubusercontent.com/22687681/40322468-1ae6c2a4-5d50-11e8-8fb8-f91bc866bac1.png)| ![screen shot 2018-05-21 at 11 35 41 pm](https://user-images.githubusercontent.com/22687681/40322476-22dabdbc-5d50-11e8-8834-227f451b7507.png)


Fixes #3098 

