### PR TITLE
Error boundaries

### DIFF
--- a/email-templates/privateCommunityRequestApproved.html
+++ b/email-templates/privateCommunityRequestApproved.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>{{subject}}</title>
+    <!--
+    The style block is collapsed on page load to save you some scrolling.
+    Postmark automatically inlines all CSS properties for maximum email client
+    compatibility. You can just update styles here, and Postmark does the rest.
+    -->
+    <style type="text/css" rel="stylesheet" media="all">
+    *:not(br):not(tr):not(html) {
+      font-family: -apple-system, BlinkMacSystemFont, Helvetica, "Segoe", Arial, Helvetica, sans-serif;
+      box-sizing: border-box;
+    }
+    
+    body {
+      width: 100% !important;
+      height: 100%;
+      margin: 0;
+      line-height: 1.4;
+      background-color: #F5F8FC;
+      color: #16171A;
+      -webkit-text-size-adjust: none;
+    }
+    
+    p,
+    ul,
+    ol,
+    blockquote {
+      line-height: 1.4;
+      text-align: left;
+      margin: 0;
+      padding: 0;
+    }
+    
+    a {
+      color: #7B16FF;
+      text-decoration: none;
+    }
+
+    a.black {
+      color: #16171A;
+    }
+
+    a.block {
+      display: block;
+      width: 100%;
+    }
+    
+    a img {
+      border: none;
+    }
+    
+    td {
+      word-break: break-word;
+    }
+    /* Layout ------------------------------ */
+    
+    .email-wrapper {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      background-color: #F5F8FC;
+    }
+    
+    .email-content {
+      width: 100%;
+      margin: 0;
+      padding: 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      background-color: #FFFFFF;
+      border-bottom: 1px solid #DAE4F2;
+    }
+    
+    /* Body ------------------------------ */
+    
+    .email-body {
+      width: 100%;
+      margin: 0;
+      padding: 32px 0;
+      -premailer-width: 100%;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+    }
+    
+    .email-body_inner {
+      width: 570px;
+      margin: 0 auto;
+      padding: 16px;
+      -premailer-width: 570px;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      background-color: #FFFFFF;
+    }
+    
+    .email-footer {
+      width: 570px;
+      margin: 0 auto;
+      padding: 16px 16px 32px;
+      -premailer-width: 570px;
+      -premailer-cellpadding: 0;
+      -premailer-cellspacing: 0;
+      text-align: center;
+    }
+    
+    .email-footer p {
+      color: #828C99;
+      font-size: 14px;
+    }
+    
+    .email-footer a {
+      color: #1D2129;
+    }
+
+    .email-footer ul {
+      list-style-type: none;
+      margin: 24px 0;
+    }
+
+    .email-footer li {
+      margin: 8px 0;
+      font-size: 14px;
+    }
+    
+    .preheader {
+      display: none !important;
+      visibility: hidden;
+      font-size: 1px;
+      line-height: 1px;
+      max-height: 0;
+      max-width: 0;
+      opacity: 0;
+      overflow: hidden;
+    }
+
+    .signoff {
+      padding-top: 32px;
+    }
+    /* Utilities ------------------------------ */
+    
+    .align-right {
+      text-align: right;
+    }
+    
+    .align-left {
+      text-align: left;
+    }
+    
+    .align-center {
+      text-align: center;
+    }
+
+    .divider {
+      height: 1px;
+      background-color: #DAE4F2;
+      display: block;
+      width: 100%;
+      margin: 16px 0;
+    }
+
+    /*Media Queries ------------------------------ */
+    
+    @media only screen and (max-width: 600px) {
+      .email-body_inner,
+      .email-footer {
+        width: 100% !important;
+      }
+
+      .thread-actions.multi {
+        background: transparent;
+      }
+
+      .thread-actions.multi a {
+        width: auto;
+        display: inline-block;
+      }
+
+      .thread-actions.multi td {
+        padding-right: 0!important;
+        display: block;
+        width: 100%;
+        margin: 0!important;
+        padding: 8px 0!important;
+        background: transparent;
+      }
+
+      .thread-actions.multi td:not(:first-of-type) {
+        margin-top: 12px!important;
+        clear: both;
+        z-index: 1000;
+      }
+    }
+    
+    @media only screen and (max-width: 500px) {
+      .button {
+        width: 100% !important;
+      }
+    }
+    /* Buttons ------------------------------ */
+    
+    .button-row {
+      display: block;
+      margin: 16px 0;
+    }
+
+    .button {
+      background-color: #7B16FF;
+      display: inline-block;
+      color: #FFF;
+      padding: 12px 16px;
+      text-decoration: none;
+      border-radius: 8px;
+      font-size: 16px;
+      font-weight: 600;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+      -webkit-text-size-adjust: none;
+      word-break: keep-all;
+      white-space: nowrap;
+      text-align: center;
+    }
+    
+    .button.outline {
+      background-color: #FFFFFF;
+      color: #828C99;
+      border: 1px solid #828C99;
+      box-shadow: none;
+    }
+    
+    .button.textonly {
+      background-color: #FFFFFF;
+      color: #828C99;
+      border: 0;
+      box-shadow: none;
+    }
+    
+    .button:hover {
+      text-decoration: none;
+      box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+    }
+    
+    .button.black {
+      background-color: #16171A;
+    }
+    
+    .button.twitter {
+     background-color: #00ACED; 
+    }
+    
+    .button.facebook {
+      background-color: #3B5998;
+    }
+    
+    .button.success {
+      background-color: #00B88B;
+    }
+    /* Type ------------------------------ */
+    
+    h1 {
+      margin-top: 0;
+      color: #16171A;
+      font-size: 24px;
+      font-weight: bold;
+      text-align: left;
+    }
+    
+    h2 {
+      margin-top: 0;
+      color: #16171A;
+      font-size: 20px;
+      font-weight: bold;
+      text-align: left;
+    }
+    
+    h3 {
+      margin-top: 0;
+      color: #16171A;
+      font-size: 16px;
+      font-weight: bold;
+      text-align: left;
+    }
+    
+    p {
+      margin-top: 12px;
+      color: #828C99;
+      font-size: 16px;
+      line-height: 1.4;
+      text-align: left;
+    }
+    
+    p.center {
+      text-align: center;
+    }
+
+    p.emoji, span.emoji {
+      font-size: 32px;
+      vertical-align: middle;
+      line-height: 1.6;
+    }
+
+    /*Custom for this email ------------------------------ */
+    .thread-actions {
+      padding: 32px 0px;
+    }
+
+    .thread-actions.multi a {
+      display: block;
+      width: 100%;
+    }
+
+    .thread-actions.multi td {
+      padding-right: 16px;
+    }
+
+    .thread-actions.multi td:last-of-type {
+      padding-right: 0;
+    }
+    </style>
+  </head>
+  <body>
+    <div class="preheader">
+      {{preheader}}
+    </div>
+
+    <!-- Insert &zwnj;&nbsp; hack after hidden preview text -->
+    <div style="display: none; max-height: 0px; overflow: hidden;">
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+      &nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;
+    </div>
+
+    <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
+      <tr>
+        <td align="center">
+          <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+            <!-- Email Body -->
+            <tr>
+              <td class="email-body" width="100%" cellpadding="0" cellspacing="0">
+                <table class="email-body_inner" align="center" cellpadding="0" cellspacing="0">
+                  <!-- Body content -->
+                  <tr>
+                    <td class="content-cell">
+                      <p>Your request to join the <a href="https://spectrum.chat/{{data.community.slug}}">{{data.community.name}} community</a> was approved! You can now join any conversations happening in this community.</p>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td>
+                      <table width="100%" cellpadding="0" cellspacing="0" class="thread-actions multi">
+                        <tr width="100%" cellpadding="0" cellspacing="0">
+                          <td valign="middle">
+                            <a href="https://spectrum.chat/{{data.community.slug}}" class="button">
+                              View Community
+                            </a>
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+
+                  <tr>
+                    <td class="signoff">
+                      <p class="emoji">✌️</p>
+                      <p>- The Spectrum team</p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+
+          <table class="email-footer" align="center" width="560" cellpadding="0" cellspacing="0">
+            <tr>
+              <td>
+                <p>
+                  You are receiving this email because you joined <a href="https://spectrum.chat">Spectrum</a>.
+                </p>
+
+                <ul>
+                  <li>
+                    <a href="https://twitter.com/withspectrum">Follow @withspectrum on Twitter</a>
+                  </li>
+
+                  <li>
+                    <a href="https://spectrum.chat/spectrum/hugs-n-bugs">Report bugs</a> · <a href="https://spectrum.chat/spectrum/feature-requests">Request a feature</a>
+                  </li>
+                </ul>
+
+                <p>Spectrum is made by Space Program, Inc.<br/>542 Brannan St. 409, San Francisco, CA 94107</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "react-app-rewired": "^1.0.5",
     "react-clipboard.js": "^1.1.3",
     "react-dom": "16.2.0",
-    "react-error-boundary": "^1.2.1",
     "react-flip-move": "^2.10.1",
     "react-helmet-async": "^0.0.4",
     "react-infinite-scroller-with-scroll-element": "2.0.2",

--- a/src/components/emailInvitationForm/index.js
+++ b/src/components/emailInvitationForm/index.js
@@ -11,7 +11,6 @@ import sendCommunityEmailInvitations from 'shared/graphql/mutations/community/se
 import { Button } from '../buttons';
 import { Error } from '../formElements';
 import { SectionCardFooter } from '../settingsViews/style';
-import type { Dispatch } from 'redux';
 import {
   EmailInviteForm,
   EmailInviteInput,

--- a/src/components/error/ErrorBoundary.js
+++ b/src/components/error/ErrorBoundary.js
@@ -12,7 +12,7 @@ type Props = {
   fallbackComponent?: ?any,
 };
 
-class SentryErrorBoundary extends React.Component<Props, State> {
+class ErrorBoundary extends React.Component<Props, State> {
   state = { error: null };
 
   componentDidCatch = (error: any, errorInfo: any) => {
@@ -41,4 +41,4 @@ class SentryErrorBoundary extends React.Component<Props, State> {
   }
 }
 
-export default SentryErrorBoundary;
+export default ErrorBoundary;

--- a/src/components/error/SentryErrorBoundary.js
+++ b/src/components/error/SentryErrorBoundary.js
@@ -1,0 +1,44 @@
+// @flow
+import * as React from 'react';
+import Raven from 'raven-js';
+import BlueScreen from '.';
+
+type State = {
+  error: ?any,
+};
+
+type Props = {
+  children: any,
+  fallbackComponent?: ?any,
+};
+
+class SentryErrorBoundary extends React.Component<Props, State> {
+  state = { error: null };
+
+  componentDidCatch = (error: any, errorInfo: any) => {
+    this.setState({ error });
+    Raven.captureException(error, { extra: errorInfo });
+  };
+
+  render() {
+    const { error } = this.state;
+    const { fallbackComponent: FallbackComponent, children } = this.props;
+
+    if (error) {
+      if (this.props.fallbackComponent) {
+        // $FlowFixMe
+        return <FallbackComponent />;
+      }
+
+      if (this.props.fallbackComponent === null) {
+        return null;
+      }
+
+      return <BlueScreen />;
+    }
+
+    return children;
+  }
+}
+
+export default SentryErrorBoundary;

--- a/src/components/error/SettingsFallback.js
+++ b/src/components/error/SettingsFallback.js
@@ -1,0 +1,44 @@
+// @flow
+import * as React from 'react';
+import {
+  SectionCard,
+  SectionTitle,
+  SectionSubtitle,
+  SectionCardFooter,
+} from 'src/components/settingsViews/style';
+import { Button } from 'src/components/buttons';
+
+class SettingsFallback extends React.Component<{}> {
+  render() {
+    return (
+      <SectionCard>
+        <SectionTitle>
+          <span
+            role="img"
+            aria-label="sad emoji"
+            style={{ marginRight: '8px' }}
+          >
+            😔
+          </span>{' '}
+          Something has gone wrong
+        </SectionTitle>
+        <SectionSubtitle>
+          There was an error loading this information. Our team has been alerted
+          and will fix this as soon as possible.
+        </SectionSubtitle>
+
+        <SectionCardFooter>
+          <Button
+            large={false}
+            icon="view-reload"
+            onClick={() => window.location.reload(true)}
+          >
+            Refresh the page
+          </Button>
+        </SectionCardFooter>
+      </SectionCard>
+    );
+  }
+}
+
+export default SettingsFallback;

--- a/src/components/error/index.js
+++ b/src/components/error/index.js
@@ -2,11 +2,13 @@
 // This component is shown as a full replacement for the entire app in production whenever an error happens that would otherwise crash the app
 import React from 'react';
 import ViewError from '../viewError';
+import SentryErrorBoundary from './SentryErrorBoundary';
+import SettingsFallback from './SettingsFallback';
 
 const BlueScreen = () => {
   return (
     <ViewError
-      heading={'Something went wrong 😢'}
+      heading={'Something went wrong'}
       subheading={
         'Sorry about the technical issues. Brian, Bryn and Max have been notified of the problem and should resolve it soon.'
       }
@@ -15,4 +17,5 @@ const BlueScreen = () => {
   );
 };
 
+export { SentryErrorBoundary, SettingsFallback };
 export default BlueScreen;

--- a/src/components/error/index.js
+++ b/src/components/error/index.js
@@ -2,7 +2,7 @@
 // This component is shown as a full replacement for the entire app in production whenever an error happens that would otherwise crash the app
 import React from 'react';
 import ViewError from '../viewError';
-import SentryErrorBoundary from './SentryErrorBoundary';
+import ErrorBoundary from './ErrorBoundary';
 import SettingsFallback from './SettingsFallback';
 
 const BlueScreen = () => {
@@ -17,5 +17,5 @@ const BlueScreen = () => {
   );
 };
 
-export { SentryErrorBoundary, SettingsFallback };
+export { ErrorBoundary, SettingsFallback };
 export default BlueScreen;

--- a/src/components/message/messageErrorFallback.js
+++ b/src/components/message/messageErrorFallback.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react';
+import { Text } from './style';
+
+type Props = {
+  me: boolean,
+};
+
+class MessageErrorFallback extends React.Component<Props> {
+  render() {
+    const { me } = this.props;
+
+    return (
+      <Text me={me} error>
+        We encountered an error loading this message - the Spectrum team has
+        been alerted.
+      </Text>
+    );
+  }
+}
+
+export default MessageErrorFallback;

--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -255,7 +255,16 @@ export const Text = styled(Bubble)`
     props.me ? props.theme.text.reverse : props.theme.text.default};
   font-weight: ${props => (props.me ? `500` : `400`)};
 
-  & + & {
+  ${props =>
+    props.error &&
+    css`
+      background-color: ${props.theme.warn.default} !important;
+      background-image: ${Gradient(
+        props.theme.warn.alt,
+        props.theme.warn.default
+      )} !important;
+      color: ${props => props.theme.text.reverse} !important;
+    `} & + & {
     margin-top: 2px;
   }
 

--- a/src/components/messageGroup/index.js
+++ b/src/components/messageGroup/index.js
@@ -7,6 +7,8 @@ import Badge from '../badges';
 import Avatar from '../avatar';
 import Message from '../message';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary } from 'src/components/error';
+import MessageErrorFallback from '../message/messageErrorFallback';
 
 import {
   Byline,
@@ -239,20 +241,26 @@ class Messages extends Component<MessageGroupProps, State> {
                   />
                   {group.map(message => {
                     return (
-                      <Message
+                      <SentryErrorBoundary
+                        fallbackComponent={() => (
+                          <MessageErrorFallback me={me} />
+                        )}
                         key={message.id}
-                        message={message}
-                        reaction={'like'}
-                        me={me}
-                        canModerate={canModerate}
-                        pending={message.id < 0}
-                        currentUser={currentUser}
-                        threadType={threadType}
-                        threadId={threadId}
-                        toggleReaction={toggleReaction}
-                        selectedId={this.state.selectedMessage}
-                        changeSelection={this.toggleSelectedMessage}
-                      />
+                      >
+                        <Message
+                          message={message}
+                          reaction={'like'}
+                          me={me}
+                          canModerate={canModerate}
+                          pending={message.id < 0}
+                          currentUser={currentUser}
+                          threadType={threadType}
+                          threadId={threadId}
+                          toggleReaction={toggleReaction}
+                          selectedId={this.state.selectedMessage}
+                          changeSelection={this.toggleSelectedMessage}
+                        />
+                      </SentryErrorBoundary>
                     );
                   })}
                 </MessageGroup>

--- a/src/components/messageGroup/index.js
+++ b/src/components/messageGroup/index.js
@@ -7,7 +7,7 @@ import Badge from '../badges';
 import Avatar from '../avatar';
 import Message from '../message';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 import MessageErrorFallback from '../message/messageErrorFallback';
 
 import {
@@ -241,7 +241,7 @@ class Messages extends Component<MessageGroupProps, State> {
                   />
                   {group.map(message => {
                     return (
-                      <SentryErrorBoundary
+                      <ErrorBoundary
                         fallbackComponent={() => (
                           <MessageErrorFallback me={me} />
                         )}
@@ -260,7 +260,7 @@ class Messages extends Component<MessageGroupProps, State> {
                           selectedId={this.state.selectedMessage}
                           changeSelection={this.toggleSelectedMessage}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   })}
                 </MessageGroup>

--- a/src/components/threadFeed/index.js
+++ b/src/components/threadFeed/index.js
@@ -17,7 +17,7 @@ import ViewError from '../viewError';
 import { Upsell, UpsellHeader, UpsellFooter } from './style';
 import type { GetCommunityType } from 'shared/graphql/queries/community/getCommunity';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 const NullState = ({ viewContext, search }) => {
   let hd;
@@ -268,7 +268,7 @@ class ThreadFeedPure extends React.Component<Props, State> {
           {this.props.data.community &&
             this.props.data.community.pinnedThread &&
             this.props.data.community.pinnedThread.id && (
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <InboxThread
                   data={this.props.data.community.pinnedThread}
                   viewContext={viewContext}
@@ -277,13 +277,13 @@ class ThreadFeedPure extends React.Component<Props, State> {
                     viewContext === 'community' && this.props.data.community
                   }
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             )}
 
           {this.props.data.community &&
             this.props.data.community.watercooler &&
             this.props.data.community.watercooler.id && (
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <InboxThread
                   data={this.props.data.community.watercooler}
                   viewContext={viewContext}
@@ -291,7 +291,7 @@ class ThreadFeedPure extends React.Component<Props, State> {
                     viewContext === 'community' && this.props.data.community
                   }
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             )}
 
           <InfiniteList
@@ -308,7 +308,7 @@ class ThreadFeedPure extends React.Component<Props, State> {
           >
             {uniqueThreads.map(thread => {
               return (
-                <SentryErrorBoundary fallbackComponent={null} key={thread.id}>
+                <ErrorBoundary fallbackComponent={null} key={thread.id}>
                   <InboxThread
                     data={thread}
                     viewContext={viewContext}
@@ -319,7 +319,7 @@ class ThreadFeedPure extends React.Component<Props, State> {
                       viewContext === 'channel' && this.props.data.channel
                     }
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             })}
           </InfiniteList>

--- a/src/components/threadFeed/index.js
+++ b/src/components/threadFeed/index.js
@@ -308,9 +308,8 @@ class ThreadFeedPure extends React.Component<Props, State> {
           >
             {uniqueThreads.map(thread => {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <SentryErrorBoundary fallbackComponent={null} key={thread.id}>
                   <InboxThread
-                    key={thread.id}
                     data={thread}
                     viewContext={viewContext}
                     hasActiveCommunity={

--- a/src/components/threadFeed/index.js
+++ b/src/components/threadFeed/index.js
@@ -17,6 +17,7 @@ import ViewError from '../viewError';
 import { Upsell, UpsellHeader, UpsellFooter } from './style';
 import type { GetCommunityType } from 'shared/graphql/queries/community/getCommunity';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary } from 'src/components/error';
 
 const NullState = ({ viewContext, search }) => {
   let hd;
@@ -267,26 +268,30 @@ class ThreadFeedPure extends React.Component<Props, State> {
           {this.props.data.community &&
             this.props.data.community.pinnedThread &&
             this.props.data.community.pinnedThread.id && (
-              <InboxThread
-                data={this.props.data.community.pinnedThread}
-                viewContext={viewContext}
-                pinnedThreadId={this.props.data.community.pinnedThread.id}
-                hasActiveCommunity={
-                  viewContext === 'community' && this.props.data.community
-                }
-              />
+              <SentryErrorBoundary fallbackComponent={null}>
+                <InboxThread
+                  data={this.props.data.community.pinnedThread}
+                  viewContext={viewContext}
+                  pinnedThreadId={this.props.data.community.pinnedThread.id}
+                  hasActiveCommunity={
+                    viewContext === 'community' && this.props.data.community
+                  }
+                />
+              </SentryErrorBoundary>
             )}
 
           {this.props.data.community &&
             this.props.data.community.watercooler &&
             this.props.data.community.watercooler.id && (
-              <InboxThread
-                data={this.props.data.community.watercooler}
-                viewContext={viewContext}
-                hasActiveCommunity={
-                  viewContext === 'community' && this.props.data.community
-                }
-              />
+              <SentryErrorBoundary fallbackComponent={null}>
+                <InboxThread
+                  data={this.props.data.community.watercooler}
+                  viewContext={viewContext}
+                  hasActiveCommunity={
+                    viewContext === 'community' && this.props.data.community
+                  }
+                />
+              </SentryErrorBoundary>
             )}
 
           <InfiniteList
@@ -303,17 +308,19 @@ class ThreadFeedPure extends React.Component<Props, State> {
           >
             {uniqueThreads.map(thread => {
               return (
-                <InboxThread
-                  key={thread.id}
-                  data={thread}
-                  viewContext={viewContext}
-                  hasActiveCommunity={
-                    viewContext === 'community' && this.props.data.community
-                  }
-                  hasActiveChannel={
-                    viewContext === 'channel' && this.props.data.channel
-                  }
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <InboxThread
+                    key={thread.id}
+                    data={thread}
+                    viewContext={viewContext}
+                    hasActiveCommunity={
+                      viewContext === 'community' && this.props.data.community
+                    }
+                    hasActiveChannel={
+                      viewContext === 'channel' && this.props.data.channel
+                    }
+                  />
+                </SentryErrorBoundary>
               );
             })}
           </InfiniteList>

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Route, Switch, Redirect } from 'react-router';
 import styled, { ThemeProvider } from 'styled-components';
 import Loadable from 'react-loadable';
-import ErrorBoundary from 'react-error-boundary';
+import { ErrorBoundary } from 'src/components/error';
 import { CLIENT_URL } from './api/constants';
 import generateMetaInfo from 'shared/generate-meta-info';
 import './reset.css.js';
@@ -188,7 +188,7 @@ class Routes extends React.Component<Props> {
 
     return (
       <ThemeProvider theme={theme}>
-        <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <ErrorBoundary fallbackComponent={ErrorFallback}>
           <ScrollManager>
             <Body>
               {/* Default meta tags, get overriden by anything further down the tree */}

--- a/src/views/channel/index.js
+++ b/src/views/channel/index.js
@@ -39,6 +39,7 @@ import { LoginButton, ColumnHeading, MidSegment } from '../community/style';
 import ToggleChannelMembership from '../../components/toggleChannelMembership';
 import { track, events, transformations } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary } from 'src/components/error';
 
 const ThreadFeedWithData = compose(connect(), getChannelThreadConnection)(
   ThreadFeed
@@ -339,23 +340,32 @@ class ChannelView extends React.Component<Props, State> {
           <Grid id="main">
             <CoverPhoto src={channel.community.coverPhoto} />
             <Meta>
-              <ChannelProfile data={{ channel }} profileSize="full" />
+              <SentryErrorBoundary fallbackComponent={null}>
+                <ChannelProfile data={{ channel }} profileSize="full" />
+              </SentryErrorBoundary>
 
               {actionButton}
 
               {isLoggedIn &&
                 userHasPermissions &&
                 !channel.isArchived && (
-                  <NotificationsToggle
-                    value={channel.channelPermissions.receiveNotifications}
-                    channel={channel}
-                  />
+                  <SentryErrorBoundary fallbackComponent={null}>
+                    <NotificationsToggle
+                      value={channel.channelPermissions.receiveNotifications}
+                      channel={channel}
+                    />
+                  </SentryErrorBoundary>
                 )}
 
               {/* user is signed in and has permissions to view pending users */}
               {isLoggedIn &&
                 (isOwner || isGlobalOwner) && (
-                  <PendingUsersNotification channel={channel} id={channel.id} />
+                  <SentryErrorBoundary fallbackComponent={null}>
+                    <PendingUsersNotification
+                      channel={channel}
+                      id={channel.id}
+                    />
+                  </SentryErrorBoundary>
                 )}
             </Meta>
             <Content>
@@ -408,10 +418,12 @@ class ChannelView extends React.Component<Props, State> {
                 userHasPermissions &&
                 ((channel.isPrivate && !channel.isArchived) ||
                   !channel.isPrivate) && (
-                  <ThreadComposer
-                    activeCommunity={communitySlug}
-                    activeChannel={channelSlug}
-                  />
+                  <SentryErrorBoundary fallbackComponent={null}>
+                    <ThreadComposer
+                      activeCommunity={communitySlug}
+                      activeChannel={channelSlug}
+                    />
+                  </SentryErrorBoundary>
                 )}
 
               {// thread list
@@ -425,16 +437,24 @@ class ChannelView extends React.Component<Props, State> {
               )}
 
               {//search
-              selectedView === 'search' && <Search channel={channel} />}
+              selectedView === 'search' && (
+                <SentryErrorBoundary>
+                  <Search channel={channel} />
+                </SentryErrorBoundary>
+              )}
 
               {// members grid
               selectedView === 'members' && (
-                <ChannelMemberGrid id={channel.id} />
+                <SentryErrorBoundary>
+                  <ChannelMemberGrid id={channel.id} />
+                </SentryErrorBoundary>
               )}
             </Content>
             <Extras>
-              <ColumnHeading>Members</ColumnHeading>
-              <ChannelMemberGrid first={5} id={channel.id} />
+              <SentryErrorBoundary fallbackComponent={null}>
+                <ColumnHeading>Members</ColumnHeading>
+                <ChannelMemberGrid first={5} id={channel.id} />
+              </SentryErrorBoundary>
             </Extras>
           </Grid>
         </AppViewWrapper>

--- a/src/views/channel/index.js
+++ b/src/views/channel/index.js
@@ -39,7 +39,7 @@ import { LoginButton, ColumnHeading, MidSegment } from '../community/style';
 import ToggleChannelMembership from '../../components/toggleChannelMembership';
 import { track, events, transformations } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 const ThreadFeedWithData = compose(connect(), getChannelThreadConnection)(
   ThreadFeed
@@ -340,32 +340,32 @@ class ChannelView extends React.Component<Props, State> {
           <Grid id="main">
             <CoverPhoto src={channel.community.coverPhoto} />
             <Meta>
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <ChannelProfile data={{ channel }} profileSize="full" />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
 
               {actionButton}
 
               {isLoggedIn &&
                 userHasPermissions &&
                 !channel.isArchived && (
-                  <SentryErrorBoundary fallbackComponent={null}>
+                  <ErrorBoundary fallbackComponent={null}>
                     <NotificationsToggle
                       value={channel.channelPermissions.receiveNotifications}
                       channel={channel}
                     />
-                  </SentryErrorBoundary>
+                  </ErrorBoundary>
                 )}
 
               {/* user is signed in and has permissions to view pending users */}
               {isLoggedIn &&
                 (isOwner || isGlobalOwner) && (
-                  <SentryErrorBoundary fallbackComponent={null}>
+                  <ErrorBoundary fallbackComponent={null}>
                     <PendingUsersNotification
                       channel={channel}
                       id={channel.id}
                     />
-                  </SentryErrorBoundary>
+                  </ErrorBoundary>
                 )}
             </Meta>
             <Content>
@@ -418,12 +418,12 @@ class ChannelView extends React.Component<Props, State> {
                 userHasPermissions &&
                 ((channel.isPrivate && !channel.isArchived) ||
                   !channel.isPrivate) && (
-                  <SentryErrorBoundary fallbackComponent={null}>
+                  <ErrorBoundary fallbackComponent={null}>
                     <ThreadComposer
                       activeCommunity={communitySlug}
                       activeChannel={channelSlug}
                     />
-                  </SentryErrorBoundary>
+                  </ErrorBoundary>
                 )}
 
               {// thread list
@@ -438,23 +438,23 @@ class ChannelView extends React.Component<Props, State> {
 
               {//search
               selectedView === 'search' && (
-                <SentryErrorBoundary>
+                <ErrorBoundary>
                   <Search channel={channel} />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               )}
 
               {// members grid
               selectedView === 'members' && (
-                <SentryErrorBoundary>
+                <ErrorBoundary>
                   <ChannelMemberGrid id={channel.id} />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               )}
             </Content>
             <Extras>
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <ColumnHeading>Members</ColumnHeading>
                 <ChannelMemberGrid first={5} id={channel.id} />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             </Extras>
           </Grid>
         </AppViewWrapper>

--- a/src/views/channelSettings/components/overview.js
+++ b/src/views/channelSettings/components/overview.js
@@ -11,6 +11,7 @@ import ChannelMembers from './channelMembers';
 import ArchiveForm from './archiveForm';
 import LoginTokenSettings from './loginTokenSettings';
 import SlackConnection from '../../communitySettings/components/slack';
+import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   community: Object,
@@ -27,41 +28,63 @@ class Overview extends React.Component<Props> {
     return (
       <SectionsContainer data-cy="channel-overview">
         <Column>
-          <EditForm channel={channel} />
-          <SlackConnection
-            type={'bot-only'}
-            id={community.id}
-            channelFilter={channel.id}
-          />
-          {channel.slug !== 'general' && <ArchiveForm channel={channel} />}
-          {channel.isPrivate && (
-            <LoginTokenSettings id={channel.id} channel={channel} />
-          )}
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <EditForm channel={channel} />
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <SlackConnection
+              type={'bot-only'}
+              id={community.id}
+              channelFilter={channel.id}
+            />
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            {channel.slug !== 'general' && <ArchiveForm channel={channel} />}
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            {channel.isPrivate && (
+              <LoginTokenSettings id={channel.id} channel={channel} />
+            )}
+          </SentryErrorBoundary>
         </Column>
 
         <Column>
           {channel.isPrivate && (
             <span>
-              <ChannelMembers
-                channel={channel}
-                id={channel.id}
-                initMessage={initMessage}
-              />
-              <PendingUsers
-                togglePending={this.props.togglePending}
-                channel={channel}
-                id={channel.id}
-                initMessage={initMessage}
-              />
-              <BlockedUsers
-                unblock={this.props.unblock}
-                channel={channel}
-                id={channel.id}
-                initMessage={initMessage}
-              />
+              <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+                <ChannelMembers
+                  channel={channel}
+                  id={channel.id}
+                  initMessage={initMessage}
+                />
+              </SentryErrorBoundary>
+
+              <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+                <PendingUsers
+                  togglePending={this.props.togglePending}
+                  channel={channel}
+                  id={channel.id}
+                  initMessage={initMessage}
+                />
+              </SentryErrorBoundary>
+
+              <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+                <BlockedUsers
+                  unblock={this.props.unblock}
+                  channel={channel}
+                  id={channel.id}
+                  initMessage={initMessage}
+                />
+              </SentryErrorBoundary>
             </span>
           )}
-          {!channel.isPrivate && <ChannelMembers id={channel.id} />}
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            {!channel.isPrivate && <ChannelMembers id={channel.id} />}
+          </SentryErrorBoundary>
         </Column>
       </SectionsContainer>
     );

--- a/src/views/channelSettings/components/overview.js
+++ b/src/views/channelSettings/components/overview.js
@@ -11,7 +11,7 @@ import ChannelMembers from './channelMembers';
 import ArchiveForm from './archiveForm';
 import LoginTokenSettings from './loginTokenSettings';
 import SlackConnection from '../../communitySettings/components/slack';
-import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
+import { ErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   community: Object,
@@ -28,63 +28,63 @@ class Overview extends React.Component<Props> {
     return (
       <SectionsContainer data-cy="channel-overview">
         <Column>
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <EditForm channel={channel} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <SlackConnection
               type={'bot-only'}
               id={community.id}
               channelFilter={channel.id}
             />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             {channel.slug !== 'general' && <ArchiveForm channel={channel} />}
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             {channel.isPrivate && (
               <LoginTokenSettings id={channel.id} channel={channel} />
             )}
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         </Column>
 
         <Column>
           {channel.isPrivate && (
             <span>
-              <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <ErrorBoundary fallbackComponent={SettingsFallback}>
                 <ChannelMembers
                   channel={channel}
                   id={channel.id}
                   initMessage={initMessage}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
 
-              <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <ErrorBoundary fallbackComponent={SettingsFallback}>
                 <PendingUsers
                   togglePending={this.props.togglePending}
                   channel={channel}
                   id={channel.id}
                   initMessage={initMessage}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
 
-              <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <ErrorBoundary fallbackComponent={SettingsFallback}>
                 <BlockedUsers
                   unblock={this.props.unblock}
                   channel={channel}
                   id={channel.id}
                   initMessage={initMessage}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             </span>
           )}
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             {!channel.isPrivate && <ChannelMembers id={channel.id} />}
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         </Column>
       </SectionsContainer>
     );

--- a/src/views/community/index.js
+++ b/src/views/community/index.js
@@ -45,6 +45,7 @@ import {
 import ChannelList from './components/channelList';
 import ModeratorList from './components/moderatorList';
 import { track, events, transformations } from 'src/helpers/analytics';
+import { SentryErrorBoundary } from 'src/components/error';
 
 const CommunityThreadFeed = compose(connect(), getCommunityThreads)(ThreadFeed);
 
@@ -217,7 +218,9 @@ class CommunityView extends React.Component<Props, State> {
           <Grid id="main">
             <CoverPhoto src={community.coverPhoto} />
             <Meta>
-              <CommunityProfile data={{ community }} profileSize="full" />
+              <SentryErrorBoundary fallbackComponent={null}>
+                <CommunityProfile data={{ community }} profileSize="full" />
+              </SentryErrorBoundary>
 
               {!isLoggedIn ? (
                 <Link to={loginUrl}>
@@ -303,10 +306,12 @@ class CommunityView extends React.Component<Props, State> {
               isLoggedIn &&
                 selectedView === 'threads' &&
                 userHasPermissions && (
-                  <ThreadComposer
-                    activeCommunity={communitySlug}
-                    showComposerUpsell={showComposerUpsell}
-                  />
+                  <SentryErrorBoundary fallbackComponent={null}>
+                    <ThreadComposer
+                      activeCommunity={communitySlug}
+                      showComposerUpsell={showComposerUpsell}
+                    />
+                  </SentryErrorBoundary>
                 )}
 
               {// thread list
@@ -327,27 +332,38 @@ class CommunityView extends React.Component<Props, State> {
 
               {// members grid
               selectedView === 'members' && (
-                <CommunityMemberGrid
-                  id={community.id}
-                  filter={{ isMember: true, isBlocked: false }}
-                />
+                <SentryErrorBoundary>
+                  <CommunityMemberGrid
+                    id={community.id}
+                    filter={{ isMember: true, isBlocked: false }}
+                  />
+                </SentryErrorBoundary>
               )}
 
               {//search
-              selectedView === 'search' && <Search community={community} />}
+              selectedView === 'search' && (
+                <SentryErrorBoundary>
+                  <Search community={community} />
+                </SentryErrorBoundary>
+              )}
             </Content>
             <Extras>
-              <ColumnHeading>Channels</ColumnHeading>
-              <ChannelList
-                id={community.id}
-                communitySlug={communitySlug.toLowerCase()}
-              />
-              <ColumnHeading>Team</ColumnHeading>
-              <ModeratorList
-                id={community.id}
-                first={20}
-                filter={{ isModerator: true, isOwner: true }}
-              />
+              <SentryErrorBoundary fallbackComponent={null}>
+                <ColumnHeading>Channels</ColumnHeading>
+                <ChannelList
+                  id={community.id}
+                  communitySlug={communitySlug.toLowerCase()}
+                />
+              </SentryErrorBoundary>
+
+              <SentryErrorBoundary fallbackComponent={null}>
+                <ColumnHeading>Team</ColumnHeading>
+                <ModeratorList
+                  id={community.id}
+                  first={20}
+                  filter={{ isModerator: true, isOwner: true }}
+                />
+              </SentryErrorBoundary>
             </Extras>
           </Grid>
         </AppViewWrapper>

--- a/src/views/community/index.js
+++ b/src/views/community/index.js
@@ -45,7 +45,7 @@ import {
 import ChannelList from './components/channelList';
 import ModeratorList from './components/moderatorList';
 import { track, events, transformations } from 'src/helpers/analytics';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 const CommunityThreadFeed = compose(connect(), getCommunityThreads)(ThreadFeed);
 
@@ -218,9 +218,9 @@ class CommunityView extends React.Component<Props, State> {
           <Grid id="main">
             <CoverPhoto src={community.coverPhoto} />
             <Meta>
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <CommunityProfile data={{ community }} profileSize="full" />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
 
               {!isLoggedIn ? (
                 <Link to={loginUrl}>
@@ -306,12 +306,12 @@ class CommunityView extends React.Component<Props, State> {
               isLoggedIn &&
                 selectedView === 'threads' &&
                 userHasPermissions && (
-                  <SentryErrorBoundary fallbackComponent={null}>
+                  <ErrorBoundary fallbackComponent={null}>
                     <ThreadComposer
                       activeCommunity={communitySlug}
                       showComposerUpsell={showComposerUpsell}
                     />
-                  </SentryErrorBoundary>
+                  </ErrorBoundary>
                 )}
 
               {// thread list
@@ -332,38 +332,38 @@ class CommunityView extends React.Component<Props, State> {
 
               {// members grid
               selectedView === 'members' && (
-                <SentryErrorBoundary>
+                <ErrorBoundary>
                   <CommunityMemberGrid
                     id={community.id}
                     filter={{ isMember: true, isBlocked: false }}
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               )}
 
               {//search
               selectedView === 'search' && (
-                <SentryErrorBoundary>
+                <ErrorBoundary>
                   <Search community={community} />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               )}
             </Content>
             <Extras>
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <ColumnHeading>Channels</ColumnHeading>
                 <ChannelList
                   id={community.id}
                   communitySlug={communitySlug.toLowerCase()}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
 
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <ColumnHeading>Team</ColumnHeading>
                 <ModeratorList
                   id={community.id}
                   first={20}
                   filter={{ isModerator: true, isOwner: true }}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             </Extras>
           </Grid>
         </AppViewWrapper>

--- a/src/views/communityAnalytics/index.js
+++ b/src/views/communityAnalytics/index.js
@@ -17,7 +17,7 @@ import {
 } from '../../components/settingsViews/style';
 import { track, events, transformations } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
+import { ErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   currentUser: Object,
@@ -56,31 +56,31 @@ class CommunityAnalytics extends React.Component<Props, State> {
     if (community && community.id) {
       if (!community.hasFeatures || !community.hasFeatures.analytics) {
         return (
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <AnalyticsUpsell community={community} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         );
       }
 
       return (
         <SectionsContainer>
           <Column>
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <MemberGrowth id={community.id} />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
 
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <TopMembers id={community.id} />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           </Column>
           <Column>
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <ConversationGrowth id={community.id} />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
 
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <TopAndNewThreads id={community.id} />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           </Column>
         </SectionsContainer>
       );

--- a/src/views/communityAnalytics/index.js
+++ b/src/views/communityAnalytics/index.js
@@ -17,6 +17,7 @@ import {
 } from '../../components/settingsViews/style';
 import { track, events, transformations } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   currentUser: Object,
@@ -54,18 +55,32 @@ class CommunityAnalytics extends React.Component<Props, State> {
 
     if (community && community.id) {
       if (!community.hasFeatures || !community.hasFeatures.analytics) {
-        return <AnalyticsUpsell community={community} />;
+        return (
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <AnalyticsUpsell community={community} />
+          </SentryErrorBoundary>
+        );
       }
 
       return (
         <SectionsContainer>
           <Column>
-            <MemberGrowth id={community.id} />
-            <TopMembers id={community.id} />
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <MemberGrowth id={community.id} />
+            </SentryErrorBoundary>
+
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <TopMembers id={community.id} />
+            </SentryErrorBoundary>
           </Column>
           <Column>
-            <ConversationGrowth id={community.id} />
-            <TopAndNewThreads id={community.id} />
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <ConversationGrowth id={community.id} />
+            </SentryErrorBoundary>
+
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <TopAndNewThreads id={community.id} />
+            </SentryErrorBoundary>
           </Column>
         </SectionsContainer>
       );

--- a/src/views/communityBilling/index.js
+++ b/src/views/communityBilling/index.js
@@ -22,7 +22,7 @@ import AdministratorEmailForm from './components/administratorEmailForm';
 import Source from './components/source';
 import Invoice from './components/invoice';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
+import { ErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   currentUser: Object,
@@ -58,13 +58,13 @@ class CommunityMembersSettings extends React.Component<Props> {
         return (
           <SectionsContainer data-cy="community-settings-billing-admin-email-form">
             <Column>
-              <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <ErrorBoundary fallbackComponent={SettingsFallback}>
                 <AdministratorEmailForm
                   community={community}
                   id={community.id}
                   data
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             </Column>
           </SectionsContainer>
         );
@@ -73,7 +73,7 @@ class CommunityMembersSettings extends React.Component<Props> {
       return (
         <SectionsContainer data-cy="community-settings-billing">
           <Column>
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <SectionCard>
                 <SectionTitle>Your subscription</SectionTitle>
                 {(community.billingSettings.subscriptions.length === 0 ||
@@ -105,11 +105,11 @@ class CommunityMembersSettings extends React.Component<Props> {
                     )
                 )}
               </SectionCard>
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           </Column>
 
           <Column>
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <SectionCard>
                 <SectionTitle>Payment methods</SectionTitle>
                 <SectionSubtitle>
@@ -141,9 +141,9 @@ class CommunityMembersSettings extends React.Component<Props> {
                   />
                 </AddCardSection>
               </SectionCard>
-            </SentryErrorBoundary>
+            </ErrorBoundary>
 
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <SectionCard>
                 <SectionTitle>Payment history</SectionTitle>
                 {community.billingSettings.invoices.length === 0 && (
@@ -156,9 +156,9 @@ class CommunityMembersSettings extends React.Component<Props> {
                     invoice && <Invoice key={invoice.id} invoice={invoice} />
                 )}
               </SectionCard>
-            </SentryErrorBoundary>
+            </ErrorBoundary>
 
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               {community.billingSettings.subscriptions.length > 0 &&
                 community.billingSettings.subscriptions[0].items.length > 0 && (
                   <SectionCard>
@@ -178,7 +178,7 @@ class CommunityMembersSettings extends React.Component<Props> {
                     </SectionCardFooter>
                   </SectionCard>
                 )}
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           </Column>
         </SectionsContainer>
       );

--- a/src/views/communityBilling/index.js
+++ b/src/views/communityBilling/index.js
@@ -22,6 +22,7 @@ import AdministratorEmailForm from './components/administratorEmailForm';
 import Source from './components/source';
 import Invoice from './components/invoice';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   currentUser: Object,
@@ -57,11 +58,13 @@ class CommunityMembersSettings extends React.Component<Props> {
         return (
           <SectionsContainer data-cy="community-settings-billing-admin-email-form">
             <Column>
-              <AdministratorEmailForm
-                community={community}
-                id={community.id}
-                data
-              />
+              <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+                <AdministratorEmailForm
+                  community={community}
+                  id={community.id}
+                  data
+                />
+              </SentryErrorBoundary>
             </Column>
           </SectionsContainer>
         );
@@ -70,101 +73,112 @@ class CommunityMembersSettings extends React.Component<Props> {
       return (
         <SectionsContainer data-cy="community-settings-billing">
           <Column>
-            <SectionCard>
-              <SectionTitle>Your subscription</SectionTitle>
-              {(community.billingSettings.subscriptions.length === 0 ||
-                (community.billingSettings.subscriptions.length > 0 &&
-                  community.billingSettings.subscriptions[0].items.length ===
-                    0)) && (
-                <React.Fragment>
-                  <SectionSubtitle>
-                    You have no active subscriptions. As soon as you add
-                    moderators, private channels, or analytics to this
-                    community, your subscription information will appear here.
-                  </SectionSubtitle>
-                  <SectionSubtitle>
-                    <Link to={'/pricing'}>
-                      Learn more about Spectrum features
-                    </Link>
-                  </SectionSubtitle>
-                </React.Fragment>
-              )}
-              {community.billingSettings.subscriptions.map(
-                subscription =>
-                  subscription &&
-                  subscription.items.length > 0 && (
-                    <Subscription
-                      key={subscription.id}
-                      subscription={subscription}
-                      community={community}
-                    />
-                  )
-              )}
-            </SectionCard>
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <SectionCard>
+                <SectionTitle>Your subscription</SectionTitle>
+                {(community.billingSettings.subscriptions.length === 0 ||
+                  (community.billingSettings.subscriptions.length > 0 &&
+                    community.billingSettings.subscriptions[0].items.length ===
+                      0)) && (
+                  <React.Fragment>
+                    <SectionSubtitle>
+                      You have no active subscriptions. As soon as you add
+                      moderators, private channels, or analytics to this
+                      community, your subscription information will appear here.
+                    </SectionSubtitle>
+                    <SectionSubtitle>
+                      <Link to={'/pricing'}>
+                        Learn more about Spectrum features
+                      </Link>
+                    </SectionSubtitle>
+                  </React.Fragment>
+                )}
+                {community.billingSettings.subscriptions.map(
+                  subscription =>
+                    subscription &&
+                    subscription.items.length > 0 && (
+                      <Subscription
+                        key={subscription.id}
+                        subscription={subscription}
+                        community={community}
+                      />
+                    )
+                )}
+              </SectionCard>
+            </SentryErrorBoundary>
           </Column>
 
           <Column>
-            <SectionCard>
-              <SectionTitle>Payment methods</SectionTitle>
-              <SectionSubtitle>
-                {community.billingSettings.sources.length === 0
-                  ? 'Saved payment methods will appear here'
-                  : `You can manage your payment information here or change your
-                  default card. To remove your default payment method, you'll need to first cancel any active subscriptions.`}
-              </SectionSubtitle>
-              {community.billingSettings.sources.map(
-                source =>
-                  source && (
-                    <Source
-                      key={source.id}
-                      source={source}
-                      community={community}
-                      canRemoveDefault={
-                        community.billingSettings.subscriptions.length === 0
-                      }
-                    />
-                  )
-              )}
-              <AddCardSection>
-                <SectionTitle>Add new card</SectionTitle>
-                <StripeCardForm
-                  community={community}
-                  render={({ isLoading }) => (
-                    <Button loading={isLoading}>Save</Button>
-                  )}
-                />
-              </AddCardSection>
-            </SectionCard>
-
-            <SectionCard>
-              <SectionTitle>Payment history</SectionTitle>
-              {community.billingSettings.invoices.length === 0 && (
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <SectionCard>
+                <SectionTitle>Payment methods</SectionTitle>
                 <SectionSubtitle>
-                  Receipts will appear here each time a payment occurs.
+                  {community.billingSettings.sources.length === 0
+                    ? 'Saved payment methods will appear here'
+                    : `You can manage your payment information here or change your
+                    default card. To remove your default payment method, you'll need to first cancel any active subscriptions.`}
                 </SectionSubtitle>
-              )}
-              {community.billingSettings.invoices.map(
-                invoice =>
-                  invoice && <Invoice key={invoice.id} invoice={invoice} />
-              )}
-            </SectionCard>
+                {community.billingSettings.sources.map(
+                  source =>
+                    source && (
+                      <Source
+                        key={source.id}
+                        source={source}
+                        community={community}
+                        canRemoveDefault={
+                          community.billingSettings.subscriptions.length === 0
+                        }
+                      />
+                    )
+                )}
+                <AddCardSection>
+                  <SectionTitle>Add new card</SectionTitle>
+                  <StripeCardForm
+                    community={community}
+                    render={({ isLoading }) => (
+                      <Button loading={isLoading}>Save</Button>
+                    )}
+                  />
+                </AddCardSection>
+              </SectionCard>
+            </SentryErrorBoundary>
 
-            {community.billingSettings.subscriptions.length > 0 &&
-              community.billingSettings.subscriptions[0].items.length > 0 && (
-                <SectionCard>
-                  <SectionTitle>Cancel your subscription</SectionTitle>
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <SectionCard>
+                <SectionTitle>Payment history</SectionTitle>
+                {community.billingSettings.invoices.length === 0 && (
                   <SectionSubtitle>
-                    Canceling your subscription will immediately remove access
-                    to all paid features, including private channels and
-                    moderator seats.
+                    Receipts will appear here each time a payment occurs.
                   </SectionSubtitle>
-                  <SectionCardFooter>
-                    <Button gradientTheme={'warn'} onClick={this.triggerCancel}>
-                      Cancel subscription
-                    </Button>
-                  </SectionCardFooter>
-                </SectionCard>
-              )}
+                )}
+                {community.billingSettings.invoices.map(
+                  invoice =>
+                    invoice && <Invoice key={invoice.id} invoice={invoice} />
+                )}
+              </SectionCard>
+            </SentryErrorBoundary>
+
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              {community.billingSettings.subscriptions.length > 0 &&
+                community.billingSettings.subscriptions[0].items.length > 0 && (
+                  <SectionCard>
+                    <SectionTitle>Cancel your subscription</SectionTitle>
+                    <SectionSubtitle>
+                      Canceling your subscription will immediately remove access
+                      to all paid features, including private channels and
+                      moderator seats.
+                    </SectionSubtitle>
+                    <SectionCardFooter>
+                      <Button
+                        gradientTheme={'warn'}
+                        onClick={this.triggerCancel}
+                      >
+                        Cancel subscription
+                      </Button>
+                    </SectionCardFooter>
+                  </SectionCard>
+                )}
+            </SentryErrorBoundary>
           </Column>
         </SectionsContainer>
       );

--- a/src/views/communityMembers/index.js
+++ b/src/views/communityMembers/index.js
@@ -16,6 +16,7 @@ import {
   SectionTitle,
   Column,
 } from '../../components/settingsViews/style';
+import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   currentUser: Object,
@@ -33,19 +34,26 @@ class CommunityMembersSettings extends React.Component<Props> {
       return (
         <SectionsContainer>
           <Column>
-            <CommunityMembers
-              history={history}
-              id={community.id}
-              community={community}
-            />
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <CommunityMembers
+                history={history}
+                id={community.id}
+                community={community}
+              />
+            </SentryErrorBoundary>
           </Column>
 
           <Column>
-            <SlackConnection type={'import-only'} id={community.id} />
-            <SectionCard>
-              <SectionTitle>Invite by email</SectionTitle>
-              <CommunityInvitationForm id={community.id} />
-            </SectionCard>
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <SlackConnection type={'import-only'} id={community.id} />
+            </SentryErrorBoundary>
+
+            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+              <SectionCard>
+                <SectionTitle>Invite by email</SectionTitle>
+                <CommunityInvitationForm id={community.id} />
+              </SectionCard>
+            </SentryErrorBoundary>
           </Column>
         </SectionsContainer>
       );

--- a/src/views/communityMembers/index.js
+++ b/src/views/communityMembers/index.js
@@ -16,7 +16,7 @@ import {
   SectionTitle,
   Column,
 } from '../../components/settingsViews/style';
-import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
+import { ErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   currentUser: Object,
@@ -34,26 +34,26 @@ class CommunityMembersSettings extends React.Component<Props> {
       return (
         <SectionsContainer>
           <Column>
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <CommunityMembers
                 history={history}
                 id={community.id}
                 community={community}
               />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           </Column>
 
           <Column>
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <SlackConnection type={'import-only'} id={community.id} />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
 
-            <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ErrorBoundary fallbackComponent={SettingsFallback}>
               <SectionCard>
                 <SectionTitle>Invite by email</SectionTitle>
                 <CommunityInvitationForm id={community.id} />
               </SectionCard>
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           </Column>
         </SectionsContainer>
       );

--- a/src/views/communitySettings/components/overview.js
+++ b/src/views/communitySettings/components/overview.js
@@ -5,7 +5,7 @@ import ChannelList from './channelList';
 import BrandedLogin from './brandedLogin';
 import { SectionsContainer, Column } from 'src/components/settingsViews/style';
 import SlackSettings from './slack';
-import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
+import { ErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   communitySlug: string,
@@ -19,22 +19,22 @@ class Overview extends React.Component<Props> {
     return (
       <SectionsContainer>
         <Column>
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <EditForm community={community} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <ChannelList id={community.id} communitySlug={communitySlug} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         </Column>
         <Column>
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <SlackSettings id={community.id} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <BrandedLogin id={community.id} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         </Column>
       </SectionsContainer>
     );

--- a/src/views/communitySettings/components/overview.js
+++ b/src/views/communitySettings/components/overview.js
@@ -5,11 +5,13 @@ import ChannelList from './channelList';
 import BrandedLogin from './brandedLogin';
 import { SectionsContainer, Column } from 'src/components/settingsViews/style';
 import SlackSettings from './slack';
+import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   communitySlug: string,
   community: Object,
 };
+
 class Overview extends React.Component<Props> {
   render() {
     const { community, communitySlug } = this.props;
@@ -17,12 +19,22 @@ class Overview extends React.Component<Props> {
     return (
       <SectionsContainer>
         <Column>
-          <EditForm community={community} />
-          <ChannelList id={community.id} communitySlug={communitySlug} />
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <EditForm community={community} />
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <ChannelList id={community.id} communitySlug={communitySlug} />
+          </SentryErrorBoundary>
         </Column>
         <Column>
-          <SlackSettings id={community.id} />
-          <BrandedLogin id={community.id} />
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <SlackSettings id={community.id} />
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <BrandedLogin id={community.id} />
+          </SentryErrorBoundary>
         </Column>
       </SectionsContainer>
     );

--- a/src/views/dashboard/components/communityList.js
+++ b/src/views/dashboard/components/communityList.js
@@ -105,9 +105,8 @@ class CommunityList extends React.Component<Props> {
             <CommunityListName>Everything</CommunityListName>
           </CommunityListItem>
           {sortedCommunities.map(c => (
-            <SentryErrorBoundary fallbackComponent={null}>
+            <SentryErrorBoundary fallbackComponent={null} key={c.id}>
               <CommunityListItem
-                key={c.id}
                 onClick={() => this.handleOnClick(c.id)}
                 active={c.id === activeCommunity}
               >

--- a/src/views/dashboard/components/communityList.js
+++ b/src/views/dashboard/components/communityList.js
@@ -25,6 +25,7 @@ import {
 import type { GetCommunityType } from 'shared/graphql/queries/community/getCommunity';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   dispatch: Dispatch<Object>,
@@ -104,36 +105,40 @@ class CommunityList extends React.Component<Props> {
             <CommunityListName>Everything</CommunityListName>
           </CommunityListItem>
           {sortedCommunities.map(c => (
-            <CommunityListItem
-              key={c.id}
-              onClick={() => this.handleOnClick(c.id)}
-              active={c.id === activeCommunity}
-            >
-              <CommunityListAvatar
+            <SentryErrorBoundary fallbackComponent={null}>
+              <CommunityListItem
+                key={c.id}
+                onClick={() => this.handleOnClick(c.id)}
                 active={c.id === activeCommunity}
-                src={c.profilePhoto}
-              />
-              <CommunityListMeta>
-                <CommunityListName>{c.name}</CommunityListName>
-                <Reputation
-                  ignoreClick
-                  size={'mini'}
-                  tipText={`Rep in ${c.name}`}
-                  reputation={c.communityPermissions.reputation}
+              >
+                <CommunityListAvatar
+                  active={c.id === activeCommunity}
+                  src={c.profilePhoto}
                 />
-              </CommunityListMeta>
+                <CommunityListMeta>
+                  <CommunityListName>{c.name}</CommunityListName>
+                  <Reputation
+                    ignoreClick
+                    size={'mini'}
+                    tipText={`Rep in ${c.name}`}
+                    reputation={c.communityPermissions.reputation}
+                  />
+                </CommunityListMeta>
 
-              {c.id === activeCommunity && (
-                <SidebarChannels
-                  activeChannel={activeChannel}
-                  communitySlug={c.slug}
-                  permissions={c.communityPermissions}
-                  slug={c.slug}
-                  id={c.id}
-                  setActiveChannelObject={this.props.setActiveChannelObject}
-                />
-              )}
-            </CommunityListItem>
+                {c.id === activeCommunity && (
+                  <SentryErrorBoundary>
+                    <SidebarChannels
+                      activeChannel={activeChannel}
+                      communitySlug={c.slug}
+                      permissions={c.communityPermissions}
+                      slug={c.slug}
+                      id={c.id}
+                      setActiveChannelObject={this.props.setActiveChannelObject}
+                    />
+                  </SentryErrorBoundary>
+                )}
+              </CommunityListItem>
+            </SentryErrorBoundary>
           ))}
         </CommunityListScroller>
 
@@ -149,12 +154,14 @@ class CommunityList extends React.Component<Props> {
           </Link>
           {// if user has joined less than 5 communities, upsell some popular ones
           communities.length < 5 && (
-            <UpsellExploreCommunities
-              activeCommunity={activeCommunity}
-              communities={communities}
-              handleOnClick={this.handleOnClick}
-              curatedContentType={'top-communities-by-members'}
-            />
+            <SentryErrorBoundary fallbackComponent={null}>
+              <UpsellExploreCommunities
+                activeCommunity={activeCommunity}
+                communities={communities}
+                handleOnClick={this.handleOnClick}
+                curatedContentType={'top-communities-by-members'}
+              />
+            </SentryErrorBoundary>
           )}
         </Fixed>
       </CommunityListWrapper>

--- a/src/views/dashboard/components/communityList.js
+++ b/src/views/dashboard/components/communityList.js
@@ -25,7 +25,7 @@ import {
 import type { GetCommunityType } from 'shared/graphql/queries/community/getCommunity';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   dispatch: Dispatch<Object>,
@@ -105,7 +105,7 @@ class CommunityList extends React.Component<Props> {
             <CommunityListName>Everything</CommunityListName>
           </CommunityListItem>
           {sortedCommunities.map(c => (
-            <SentryErrorBoundary fallbackComponent={null} key={c.id}>
+            <ErrorBoundary fallbackComponent={null} key={c.id}>
               <CommunityListItem
                 onClick={() => this.handleOnClick(c.id)}
                 active={c.id === activeCommunity}
@@ -125,7 +125,7 @@ class CommunityList extends React.Component<Props> {
                 </CommunityListMeta>
 
                 {c.id === activeCommunity && (
-                  <SentryErrorBoundary>
+                  <ErrorBoundary>
                     <SidebarChannels
                       activeChannel={activeChannel}
                       communitySlug={c.slug}
@@ -134,10 +134,10 @@ class CommunityList extends React.Component<Props> {
                       id={c.id}
                       setActiveChannelObject={this.props.setActiveChannelObject}
                     />
-                  </SentryErrorBoundary>
+                  </ErrorBoundary>
                 )}
               </CommunityListItem>
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           ))}
         </CommunityListScroller>
 
@@ -153,14 +153,14 @@ class CommunityList extends React.Component<Props> {
           </Link>
           {// if user has joined less than 5 communities, upsell some popular ones
           communities.length < 5 && (
-            <SentryErrorBoundary fallbackComponent={null}>
+            <ErrorBoundary fallbackComponent={null}>
               <UpsellExploreCommunities
                 activeCommunity={activeCommunity}
                 communities={communities}
                 handleOnClick={this.handleOnClick}
                 curatedContentType={'top-communities-by-members'}
               />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           )}
         </Fixed>
       </CommunityListWrapper>

--- a/src/views/dashboard/components/inboxThread.js
+++ b/src/views/dashboard/components/inboxThread.js
@@ -24,7 +24,7 @@ import {
   MiniLinkPreview,
   EllipsisText,
 } from '../style';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   active: boolean,
@@ -140,7 +140,7 @@ class InboxThread extends React.Component<Props> {
     }
 
     return (
-      <SentryErrorBoundary fallbackComponent={null}>
+      <ErrorBoundary fallbackComponent={null}>
         <InboxThreadItem active={active}>
           <InboxLinkWrapper
             to={{
@@ -158,7 +158,7 @@ class InboxThread extends React.Component<Props> {
             }
           />
           <InboxThreadContent>
-            <SentryErrorBoundary fallbackComponent={null}>
+            <ErrorBoundary fallbackComponent={null}>
               <ThreadCommunityInfo
                 thread={data}
                 active={active}
@@ -166,13 +166,13 @@ class InboxThread extends React.Component<Props> {
                 activeChannel={hasActiveChannel}
                 isPinned={isPinned}
               />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
 
             <ThreadTitle active={active}>
               {truncate(data.content.title, 80)}
             </ThreadTitle>
 
-            <SentryErrorBoundary fallbackComponent={null}>
+            <ErrorBoundary fallbackComponent={null}>
               {attachmentsExist &&
                 attachments
                   .filter(att => att && att.attachmentType === 'linkPreview')
@@ -191,24 +191,24 @@ class InboxThread extends React.Component<Props> {
                       </AttachmentsContainer>
                     );
                   })}
-            </SentryErrorBoundary>
+            </ErrorBoundary>
 
             <ThreadMeta>
               {(participantsExist || author) && (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <Facepile
                     active={active}
                     participants={participants}
                     author={data.author.user}
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               )}
 
               {this.generatePillOrMessageCount()}
             </ThreadMeta>
           </InboxThreadContent>
         </InboxThreadItem>
-      </SentryErrorBoundary>
+      </ErrorBoundary>
     );
   }
 }
@@ -225,7 +225,7 @@ class WatercoolerThreadPure extends React.Component<Props> {
     const participantsExist = participants && participants.length > 0;
 
     return (
-      <SentryErrorBoundary fallbackComponent={null}>
+      <ErrorBoundary fallbackComponent={null}>
         <InboxThreadItem active={active}>
           <InboxLinkWrapper
             to={{
@@ -248,13 +248,13 @@ class WatercoolerThreadPure extends React.Component<Props> {
 
             <ThreadMeta>
               {(participantsExist || author) && (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <Facepile
                     active={active}
                     participants={participants}
                     author={author.user}
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               )}
 
               {messageCount > 0 && (
@@ -267,7 +267,7 @@ class WatercoolerThreadPure extends React.Component<Props> {
             </ThreadMeta>
           </InboxThreadContent>
         </InboxThreadItem>
-      </SentryErrorBoundary>
+      </ErrorBoundary>
     );
   }
 }

--- a/src/views/dashboard/components/inboxThread.js
+++ b/src/views/dashboard/components/inboxThread.js
@@ -24,6 +24,7 @@ import {
   MiniLinkPreview,
   EllipsisText,
 } from '../style';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   active: boolean,
@@ -139,67 +140,75 @@ class InboxThread extends React.Component<Props> {
     }
 
     return (
-      <InboxThreadItem active={active}>
-        <InboxLinkWrapper
-          to={{
-            pathname: window.location.pathname,
-            search:
-              window.innerWidth < 768 || viewContext
-                ? `?thread=${data.id}`
-                : `?t=${data.id}`,
-          }}
-          onClick={e =>
-            window.innerWidth > 768 &&
-            !viewContext &&
-            !e.metaKey &&
-            this.props.dispatch(changeActiveThread(data.id))
-          }
-        />
-        <InboxThreadContent>
-          <ThreadCommunityInfo
-            thread={data}
-            active={active}
-            activeCommunity={hasActiveCommunity}
-            activeChannel={hasActiveChannel}
-            isPinned={isPinned}
+      <SentryErrorBoundary fallbackComponent={null}>
+        <InboxThreadItem active={active}>
+          <InboxLinkWrapper
+            to={{
+              pathname: window.location.pathname,
+              search:
+                window.innerWidth < 768 || viewContext
+                  ? `?thread=${data.id}`
+                  : `?t=${data.id}`,
+            }}
+            onClick={e =>
+              window.innerWidth > 768 &&
+              !viewContext &&
+              !e.metaKey &&
+              this.props.dispatch(changeActiveThread(data.id))
+            }
           />
-
-          <ThreadTitle active={active}>
-            {truncate(data.content.title, 80)}
-          </ThreadTitle>
-
-          {attachmentsExist &&
-            attachments
-              .filter(att => att && att.attachmentType === 'linkPreview')
-              .map(att => {
-                if (!att) return null;
-                const attData = JSON.parse(att.data);
-                const url = attData.trueUrl || attData.url;
-                if (!url) return null;
-
-                return (
-                  <AttachmentsContainer active={active} key={url}>
-                    <MiniLinkPreview href={url} target="_blank">
-                      <Icon glyph="link" size={18} />
-                      <EllipsisText>{url}</EllipsisText>
-                    </MiniLinkPreview>
-                  </AttachmentsContainer>
-                );
-              })}
-
-          <ThreadMeta>
-            {(participantsExist || author) && (
-              <Facepile
+          <InboxThreadContent>
+            <SentryErrorBoundary fallbackComponent={null}>
+              <ThreadCommunityInfo
+                thread={data}
                 active={active}
-                participants={participants}
-                author={data.author.user}
+                activeCommunity={hasActiveCommunity}
+                activeChannel={hasActiveChannel}
+                isPinned={isPinned}
               />
-            )}
+            </SentryErrorBoundary>
 
-            {this.generatePillOrMessageCount()}
-          </ThreadMeta>
-        </InboxThreadContent>
-      </InboxThreadItem>
+            <ThreadTitle active={active}>
+              {truncate(data.content.title, 80)}
+            </ThreadTitle>
+
+            <SentryErrorBoundary fallbackComponent={null}>
+              {attachmentsExist &&
+                attachments
+                  .filter(att => att && att.attachmentType === 'linkPreview')
+                  .map(att => {
+                    if (!att) return null;
+                    const attData = JSON.parse(att.data);
+                    const url = attData.trueUrl || attData.url;
+                    if (!url) return null;
+
+                    return (
+                      <AttachmentsContainer active={active} key={url}>
+                        <MiniLinkPreview href={url} target="_blank">
+                          <Icon glyph="link" size={18} />
+                          <EllipsisText>{url}</EllipsisText>
+                        </MiniLinkPreview>
+                      </AttachmentsContainer>
+                    );
+                  })}
+            </SentryErrorBoundary>
+
+            <ThreadMeta>
+              {(participantsExist || author) && (
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <Facepile
+                    active={active}
+                    participants={participants}
+                    author={data.author.user}
+                  />
+                </SentryErrorBoundary>
+              )}
+
+              {this.generatePillOrMessageCount()}
+            </ThreadMeta>
+          </InboxThreadContent>
+        </InboxThreadItem>
+      </SentryErrorBoundary>
     );
   }
 }
@@ -216,45 +225,49 @@ class WatercoolerThreadPure extends React.Component<Props> {
     const participantsExist = participants && participants.length > 0;
 
     return (
-      <InboxThreadItem active={active}>
-        <InboxLinkWrapper
-          to={{
-            pathname: window.location.pathname,
-            search:
-              window.innerWidth < 768 || viewContext
-                ? `?thread=${id}`
-                : `?t=${id}`,
-          }}
-          onClick={() =>
-            window.innerWidth > 768 &&
-            this.props.dispatch(changeActiveThread(id))
-          }
-        />
-        <InboxThreadContent>
-          <WaterCoolerPill active={active} />
-          <ThreadTitle active={active}>
-            {community.name} Watercooler
-          </ThreadTitle>
+      <SentryErrorBoundary fallbackComponent={null}>
+        <InboxThreadItem active={active}>
+          <InboxLinkWrapper
+            to={{
+              pathname: window.location.pathname,
+              search:
+                window.innerWidth < 768 || viewContext
+                  ? `?thread=${id}`
+                  : `?t=${id}`,
+            }}
+            onClick={() =>
+              window.innerWidth > 768 &&
+              this.props.dispatch(changeActiveThread(id))
+            }
+          />
+          <InboxThreadContent>
+            <WaterCoolerPill active={active} />
+            <ThreadTitle active={active}>
+              {community.name} Watercooler
+            </ThreadTitle>
 
-          <ThreadMeta>
-            {(participantsExist || author) && (
-              <Facepile
-                active={active}
-                participants={participants}
-                author={author.user}
-              />
-            )}
+            <ThreadMeta>
+              {(participantsExist || author) && (
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <Facepile
+                    active={active}
+                    participants={participants}
+                    author={author.user}
+                  />
+                </SentryErrorBoundary>
+              )}
 
-            {messageCount > 0 && (
-              <StatusText offset={participants.length} active={active}>
-                {messageCount > 1
-                  ? `${messageCount} messages`
-                  : `${messageCount} message`}
-              </StatusText>
-            )}
-          </ThreadMeta>
-        </InboxThreadContent>
-      </InboxThreadItem>
+              {messageCount > 0 && (
+                <StatusText offset={participants.length} active={active}>
+                  {messageCount > 1
+                    ? `${messageCount} messages`
+                    : `${messageCount} message`}
+                </StatusText>
+              )}
+            </ThreadMeta>
+          </InboxThreadContent>
+        </InboxThreadItem>
+      </SentryErrorBoundary>
     );
   }
 }

--- a/src/views/dashboard/components/sidebarChannels.js
+++ b/src/views/dashboard/components/sidebarChannels.js
@@ -22,6 +22,7 @@ import {
 } from '../style';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   dispatch: Dispatch<Object>,
@@ -123,23 +124,25 @@ class SidebarChannels extends React.Component<Props> {
             sortedChannels.length > 1 &&
             sortedChannels.map(channel => {
               return (
-                <ChannelListItem
-                  key={channel.id}
-                  active={activeChannel === channel.id}
-                  onClick={evt => {
-                    evt.stopPropagation();
-                    this.changeChannel(channel.id);
-                    this.setActiveChannelObject(channel);
-                  }}
-                >
-                  {channel.isPrivate ? (
-                    <Icon glyph="channel-private" size={24} />
-                  ) : (
-                    <Icon glyph="channel" size={24} />
-                  )}
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <ChannelListItem
+                    key={channel.id}
+                    active={activeChannel === channel.id}
+                    onClick={evt => {
+                      evt.stopPropagation();
+                      this.changeChannel(channel.id);
+                      this.setActiveChannelObject(channel);
+                    }}
+                  >
+                    {channel.isPrivate ? (
+                      <Icon glyph="channel-private" size={24} />
+                    ) : (
+                      <Icon glyph="channel" size={24} />
+                    )}
 
-                  <CommunityListName>{channel.name}</CommunityListName>
-                </ChannelListItem>
+                    <CommunityListName>{channel.name}</CommunityListName>
+                  </ChannelListItem>
+                </SentryErrorBoundary>
               );
             })}
         </ChannelsContainer>

--- a/src/views/dashboard/components/sidebarChannels.js
+++ b/src/views/dashboard/components/sidebarChannels.js
@@ -124,9 +124,8 @@ class SidebarChannels extends React.Component<Props> {
             sortedChannels.length > 1 &&
             sortedChannels.map(channel => {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <SentryErrorBoundary fallbackComponent={null} key={channel.id}>
                   <ChannelListItem
-                    key={channel.id}
                     active={activeChannel === channel.id}
                     onClick={evt => {
                       evt.stopPropagation();

--- a/src/views/dashboard/components/sidebarChannels.js
+++ b/src/views/dashboard/components/sidebarChannels.js
@@ -22,7 +22,7 @@ import {
 } from '../style';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   dispatch: Dispatch<Object>,
@@ -124,7 +124,7 @@ class SidebarChannels extends React.Component<Props> {
             sortedChannels.length > 1 &&
             sortedChannels.map(channel => {
               return (
-                <SentryErrorBoundary fallbackComponent={null} key={channel.id}>
+                <ErrorBoundary fallbackComponent={null} key={channel.id}>
                   <ChannelListItem
                     active={activeChannel === channel.id}
                     onClick={evt => {
@@ -141,7 +141,7 @@ class SidebarChannels extends React.Component<Props> {
 
                     <CommunityListName>{channel.name}</CommunityListName>
                   </ChannelListItem>
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             })}
         </ChannelsContainer>

--- a/src/views/dashboard/components/threadFeed.js
+++ b/src/views/dashboard/components/threadFeed.js
@@ -310,9 +310,8 @@ class ThreadFeed extends React.Component<Props, State> {
           <FlipMove duration={350}>
             {uniqueThreads.map(thread => {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <SentryErrorBoundary fallbackComponent={null} key={thread.id}>
                   <InboxThread
-                    key={thread.id}
                     data={thread}
                     active={selectedId === thread.id}
                     hasActiveCommunity={this.props.hasActiveCommunity}

--- a/src/views/dashboard/components/threadFeed.js
+++ b/src/views/dashboard/components/threadFeed.js
@@ -21,6 +21,7 @@ import type { ViewNetworkHandlerType } from '../../../components/viewNetworkHand
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
 import type { GetCommunityThreadConnectionType } from 'shared/graphql/queries/community/getCommunityThreadConnection';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Node = {
   node: {
@@ -271,22 +272,28 @@ class ThreadFeed extends React.Component<Props, State> {
         {this.props.data.community &&
           this.props.data.community.watercooler &&
           this.props.data.community.watercooler.id && (
-            <WatercoolerThread
-              data={this.props.data.community.watercooler}
-              active={selectedId === this.props.data.community.watercooler.id}
-            />
+            <SentryErrorBoundary fallbackComponent={null}>
+              <WatercoolerThread
+                data={this.props.data.community.watercooler}
+                active={selectedId === this.props.data.community.watercooler.id}
+              />
+            </SentryErrorBoundary>
           )}
 
         {this.props.data.community &&
           this.props.data.community.pinnedThread &&
           this.props.data.community.pinnedThread.id && (
-            <InboxThread
-              data={this.props.data.community.pinnedThread}
-              active={selectedId === this.props.data.community.pinnedThread.id}
-              hasActiveCommunity={this.props.hasActiveCommunity}
-              hasActiveChannel={this.props.hasActiveChannel}
-              pinnedThreadId={this.props.data.community.pinnedThread.id}
-            />
+            <SentryErrorBoundary fallbackComponent={null}>
+              <InboxThread
+                data={this.props.data.community.pinnedThread}
+                active={
+                  selectedId === this.props.data.community.pinnedThread.id
+                }
+                hasActiveCommunity={this.props.hasActiveCommunity}
+                hasActiveChannel={this.props.hasActiveChannel}
+                pinnedThreadId={this.props.data.community.pinnedThread.id}
+              />
+            </SentryErrorBoundary>
           )}
         <InfiniteList
           pageStart={0}
@@ -303,13 +310,15 @@ class ThreadFeed extends React.Component<Props, State> {
           <FlipMove duration={350}>
             {uniqueThreads.map(thread => {
               return (
-                <InboxThread
-                  key={thread.id}
-                  data={thread}
-                  active={selectedId === thread.id}
-                  hasActiveCommunity={this.props.hasActiveCommunity}
-                  hasActiveChannel={this.props.hasActiveChannel}
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <InboxThread
+                    key={thread.id}
+                    data={thread}
+                    active={selectedId === thread.id}
+                    hasActiveCommunity={this.props.hasActiveCommunity}
+                    hasActiveChannel={this.props.hasActiveChannel}
+                  />
+                </SentryErrorBoundary>
               );
             })}
           </FlipMove>

--- a/src/views/dashboard/components/threadFeed.js
+++ b/src/views/dashboard/components/threadFeed.js
@@ -21,7 +21,7 @@ import type { ViewNetworkHandlerType } from '../../../components/viewNetworkHand
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
 import type { GetCommunityThreadConnectionType } from 'shared/graphql/queries/community/getCommunityThreadConnection';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Node = {
   node: {
@@ -272,18 +272,18 @@ class ThreadFeed extends React.Component<Props, State> {
         {this.props.data.community &&
           this.props.data.community.watercooler &&
           this.props.data.community.watercooler.id && (
-            <SentryErrorBoundary fallbackComponent={null}>
+            <ErrorBoundary fallbackComponent={null}>
               <WatercoolerThread
                 data={this.props.data.community.watercooler}
                 active={selectedId === this.props.data.community.watercooler.id}
               />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           )}
 
         {this.props.data.community &&
           this.props.data.community.pinnedThread &&
           this.props.data.community.pinnedThread.id && (
-            <SentryErrorBoundary fallbackComponent={null}>
+            <ErrorBoundary fallbackComponent={null}>
               <InboxThread
                 data={this.props.data.community.pinnedThread}
                 active={
@@ -293,7 +293,7 @@ class ThreadFeed extends React.Component<Props, State> {
                 hasActiveChannel={this.props.hasActiveChannel}
                 pinnedThreadId={this.props.data.community.pinnedThread.id}
               />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           )}
         <InfiniteList
           pageStart={0}
@@ -310,14 +310,14 @@ class ThreadFeed extends React.Component<Props, State> {
           <FlipMove duration={350}>
             {uniqueThreads.map(thread => {
               return (
-                <SentryErrorBoundary fallbackComponent={null} key={thread.id}>
+                <ErrorBoundary fallbackComponent={null} key={thread.id}>
                   <InboxThread
                     data={thread}
                     active={selectedId === thread.id}
                     hasActiveCommunity={this.props.hasActiveCommunity}
                     hasActiveChannel={this.props.hasActiveChannel}
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             })}
           </FlipMove>

--- a/src/views/dashboard/index.js
+++ b/src/views/dashboard/index.js
@@ -33,7 +33,7 @@ import {
   Sidebar,
 } from './style';
 import { track, events } from 'src/helpers/analytics';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 const EverythingThreadFeed = compose(connect(), getEverythingThreads)(
   DashboardThreadFeed
@@ -154,18 +154,18 @@ class Dashboard extends React.Component<Props, State> {
           <Head title={title} description={description} />
           <Titlebar hasChildren hasSearch filter={searchFilter}>
             <Menu darkContext hasTabBar>
-              <SentryErrorBoundary>
+              <ErrorBoundary>
                 <CommunityList
                   communities={communities}
                   user={user}
                   activeCommunity={activeCommunity}
                   activeChannel={activeChannel}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             </Menu>
           </Titlebar>
           <Sidebar>
-            <SentryErrorBoundary>
+            <ErrorBoundary>
               <CommunityList
                 communities={communities}
                 user={user}
@@ -173,11 +173,11 @@ class Dashboard extends React.Component<Props, State> {
                 activeChannel={activeChannel}
                 setActiveChannelObject={this.setActiveChannelObject}
               />
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           </Sidebar>
           <InboxWrapper>
             <FeedHeaderContainer>
-              <SentryErrorBoundary>
+              <ErrorBoundary>
                 <Header
                   filter={searchFilter}
                   communities={communities}
@@ -187,7 +187,7 @@ class Dashboard extends React.Component<Props, State> {
                   activeChannel={activeChannel}
                   activeChannelObject={activeChannelObject}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             </FeedHeaderContainer>
             {newActivityIndicator && (
               <NewActivityIndicator elem="scroller-for-inbox" />
@@ -202,28 +202,28 @@ class Dashboard extends React.Component<Props, State> {
               {searchQueryString &&
                 searchQueryString.length > 0 &&
                 searchFilter && (
-                  <SentryErrorBoundary>
+                  <ErrorBoundary>
                     <SearchThreadFeed
                       queryString={searchQueryString}
                       filter={searchFilter}
                       selectedId={activeThread}
                     />
-                  </SentryErrorBoundary>
+                  </ErrorBoundary>
                 )}
 
               {// no community, no search results
               !activeCommunity &&
                 !searchQueryString && (
-                  <SentryErrorBoundary>
+                  <ErrorBoundary>
                     <EverythingThreadFeed selectedId={activeThread} />
-                  </SentryErrorBoundary>
+                  </ErrorBoundary>
                 )}
 
               {// community, no channel, no search results
               activeCommunity &&
                 !activeChannel &&
                 !searchQueryString && (
-                  <SentryErrorBoundary>
+                  <ErrorBoundary>
                     <CommunityThreadFeed
                       id={activeCommunity}
                       selectedId={activeThread}
@@ -234,14 +234,14 @@ class Dashboard extends React.Component<Props, State> {
                         activeCommunityObject.pinnedThreadId
                       }
                     />
-                  </SentryErrorBoundary>
+                  </ErrorBoundary>
                 )}
 
               {// channel and community, no search results
               activeChannel &&
                 activeCommunity &&
                 !searchQueryString && (
-                  <SentryErrorBoundary>
+                  <ErrorBoundary>
                     <ChannelThreadFeed
                       id={activeChannel}
                       selectedId={activeThread}
@@ -254,14 +254,14 @@ class Dashboard extends React.Component<Props, State> {
                       }
                       channelId={activeChannel}
                     />
-                  </SentryErrorBoundary>
+                  </ErrorBoundary>
                 )}
             </InboxScroller>
           </InboxWrapper>
 
           <ThreadWrapper>
             <ThreadScroller id="scroller-for-inbox-thread-view">
-              <SentryErrorBoundary>
+              <ErrorBoundary>
                 <DashboardThread
                   threadId={activeThread}
                   activeCommunity={
@@ -269,7 +269,7 @@ class Dashboard extends React.Component<Props, State> {
                   }
                   activeChannel={activeChannel}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             </ThreadScroller>
           </ThreadWrapper>
         </DashboardWrapper>

--- a/src/views/dashboard/index.js
+++ b/src/views/dashboard/index.js
@@ -33,6 +33,7 @@ import {
   Sidebar,
 } from './style';
 import { track, events } from 'src/helpers/analytics';
+import { SentryErrorBoundary } from 'src/components/error';
 
 const EverythingThreadFeed = compose(connect(), getEverythingThreads)(
   DashboardThreadFeed
@@ -153,34 +154,40 @@ class Dashboard extends React.Component<Props, State> {
           <Head title={title} description={description} />
           <Titlebar hasChildren hasSearch filter={searchFilter}>
             <Menu darkContext hasTabBar>
+              <SentryErrorBoundary>
+                <CommunityList
+                  communities={communities}
+                  user={user}
+                  activeCommunity={activeCommunity}
+                  activeChannel={activeChannel}
+                />
+              </SentryErrorBoundary>
+            </Menu>
+          </Titlebar>
+          <Sidebar>
+            <SentryErrorBoundary>
               <CommunityList
                 communities={communities}
                 user={user}
                 activeCommunity={activeCommunity}
                 activeChannel={activeChannel}
+                setActiveChannelObject={this.setActiveChannelObject}
               />
-            </Menu>
-          </Titlebar>
-          <Sidebar>
-            <CommunityList
-              communities={communities}
-              user={user}
-              activeCommunity={activeCommunity}
-              activeChannel={activeChannel}
-              setActiveChannelObject={this.setActiveChannelObject}
-            />
+            </SentryErrorBoundary>
           </Sidebar>
           <InboxWrapper>
             <FeedHeaderContainer>
-              <Header
-                filter={searchFilter}
-                communities={communities}
-                user={user}
-                activeCommunity={activeCommunity}
-                activeCommunityObject={activeCommunityObject}
-                activeChannel={activeChannel}
-                activeChannelObject={activeChannelObject}
-              />
+              <SentryErrorBoundary>
+                <Header
+                  filter={searchFilter}
+                  communities={communities}
+                  user={user}
+                  activeCommunity={activeCommunity}
+                  activeCommunityObject={activeCommunityObject}
+                  activeChannel={activeChannel}
+                  activeChannelObject={activeChannelObject}
+                />
+              </SentryErrorBoundary>
             </FeedHeaderContainer>
             {newActivityIndicator && (
               <NewActivityIndicator elem="scroller-for-inbox" />
@@ -195,64 +202,74 @@ class Dashboard extends React.Component<Props, State> {
               {searchQueryString &&
                 searchQueryString.length > 0 &&
                 searchFilter && (
-                  <SearchThreadFeed
-                    queryString={searchQueryString}
-                    filter={searchFilter}
-                    selectedId={activeThread}
-                  />
+                  <SentryErrorBoundary>
+                    <SearchThreadFeed
+                      queryString={searchQueryString}
+                      filter={searchFilter}
+                      selectedId={activeThread}
+                    />
+                  </SentryErrorBoundary>
                 )}
 
               {// no community, no search results
               !activeCommunity &&
                 !searchQueryString && (
-                  <EverythingThreadFeed selectedId={activeThread} />
+                  <SentryErrorBoundary>
+                    <EverythingThreadFeed selectedId={activeThread} />
+                  </SentryErrorBoundary>
                 )}
 
               {// community, no channel, no search results
               activeCommunity &&
                 !activeChannel &&
                 !searchQueryString && (
-                  <CommunityThreadFeed
-                    id={activeCommunity}
-                    selectedId={activeThread}
-                    hasActiveCommunity={activeCommunity}
-                    community={activeCommunityObject}
-                    pinnedThreadId={
-                      activeCommunityObject &&
-                      activeCommunityObject.pinnedThreadId
-                    }
-                  />
+                  <SentryErrorBoundary>
+                    <CommunityThreadFeed
+                      id={activeCommunity}
+                      selectedId={activeThread}
+                      hasActiveCommunity={activeCommunity}
+                      community={activeCommunityObject}
+                      pinnedThreadId={
+                        activeCommunityObject &&
+                        activeCommunityObject.pinnedThreadId
+                      }
+                    />
+                  </SentryErrorBoundary>
                 )}
 
               {// channel and community, no search results
               activeChannel &&
                 activeCommunity &&
                 !searchQueryString && (
-                  <ChannelThreadFeed
-                    id={activeChannel}
-                    selectedId={activeThread}
-                    hasActiveCommunity={activeCommunity}
-                    hasActiveChannel={activeChannel}
-                    community={activeCommunityObject}
-                    pinnedThreadId={
-                      activeCommunityObject &&
-                      activeCommunityObject.pinnedThreadId
-                    }
-                    channelId={activeChannel}
-                  />
+                  <SentryErrorBoundary>
+                    <ChannelThreadFeed
+                      id={activeChannel}
+                      selectedId={activeThread}
+                      hasActiveCommunity={activeCommunity}
+                      hasActiveChannel={activeChannel}
+                      community={activeCommunityObject}
+                      pinnedThreadId={
+                        activeCommunityObject &&
+                        activeCommunityObject.pinnedThreadId
+                      }
+                      channelId={activeChannel}
+                    />
+                  </SentryErrorBoundary>
                 )}
             </InboxScroller>
           </InboxWrapper>
 
           <ThreadWrapper>
             <ThreadScroller id="scroller-for-inbox-thread-view">
-              <DashboardThread
-                threadId={activeThread}
-                activeCommunity={
-                  activeCommunityObject && activeCommunityObject.slug
-                }
-                activeChannel={activeChannel}
-              />
+              <SentryErrorBoundary>
+                <DashboardThread
+                  threadId={activeThread}
+                  activeCommunity={
+                    activeCommunityObject && activeCommunityObject.slug
+                  }
+                  activeChannel={activeChannel}
+                />
+              </SentryErrorBoundary>
             </ThreadScroller>
           </ThreadWrapper>
         </DashboardWrapper>

--- a/src/views/directMessages/components/messages.js
+++ b/src/views/directMessages/components/messages.js
@@ -11,7 +11,7 @@ import type { GetDirectMessageThreadMessageConnectionType } from 'shared/graphql
 import setLastSeenMutation from 'shared/graphql/mutations/directMessageThread/setDMThreadLastSeen';
 import toggleReactionMutation from 'shared/graphql/mutations/reaction/toggleReaction';
 import { MessagesScrollWrapper } from './style';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   id: string,
@@ -124,7 +124,7 @@ class MessagesWithData extends React.Component<Props, State> {
 
       return (
         <MessagesScrollWrapper>
-          <SentryErrorBoundary>
+          <ErrorBoundary>
             {hasNextPage && (
               <NextPageButton
                 isFetchingMore={isFetchingMore}
@@ -139,7 +139,7 @@ class MessagesWithData extends React.Component<Props, State> {
               threadId={this.props.id}
               threadType={'directMessageThread'}
             />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         </MessagesScrollWrapper>
       );
     }

--- a/src/views/directMessages/components/messages.js
+++ b/src/views/directMessages/components/messages.js
@@ -11,6 +11,7 @@ import type { GetDirectMessageThreadMessageConnectionType } from 'shared/graphql
 import setLastSeenMutation from 'shared/graphql/mutations/directMessageThread/setDMThreadLastSeen';
 import toggleReactionMutation from 'shared/graphql/mutations/reaction/toggleReaction';
 import { MessagesScrollWrapper } from './style';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   id: string,
@@ -123,20 +124,22 @@ class MessagesWithData extends React.Component<Props, State> {
 
       return (
         <MessagesScrollWrapper>
-          {hasNextPage && (
-            <NextPageButton
-              isFetchingMore={isFetchingMore}
-              fetchMore={fetchMore}
+          <SentryErrorBoundary>
+            {hasNextPage && (
+              <NextPageButton
+                isFetchingMore={isFetchingMore}
+                fetchMore={fetchMore}
+              />
+            )}
+            <ChatMessages
+              toggleReaction={toggleReaction}
+              messages={sortedMessages}
+              forceScrollToBottom={this.props.forceScrollToBottom}
+              contextualScrollToBottom={this.props.contextualScrollToBottom}
+              threadId={this.props.id}
+              threadType={'directMessageThread'}
             />
-          )}
-          <ChatMessages
-            toggleReaction={toggleReaction}
-            messages={sortedMessages}
-            forceScrollToBottom={this.props.forceScrollToBottom}
-            contextualScrollToBottom={this.props.contextualScrollToBottom}
-            threadId={this.props.id}
-            threadType={'directMessageThread'}
-          />
+          </SentryErrorBoundary>
         </MessagesScrollWrapper>
       );
     }

--- a/src/views/directMessages/components/threadsList.js
+++ b/src/views/directMessages/components/threadsList.js
@@ -5,6 +5,7 @@ import InfiniteList from 'src/components/infiniteScroll';
 import { deduplicateChildren } from 'src/components/infiniteScroll/deduplicateChildren';
 import { LoadingDM } from 'src/components/loading';
 import { ThreadsListScrollContainer } from './style';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   threads: Array<?Object>,
@@ -87,12 +88,14 @@ class ThreadsList extends React.Component<Props, State> {
           {uniqueThreads.map(thread => {
             if (!thread) return null;
             return (
-              <ListCardItemDirectMessageThread
-                thread={thread}
-                key={thread.id}
-                currentUser={currentUser}
-                active={active === thread.id}
-              />
+              <SentryErrorBoundary fallbackComponent={null}>
+                <ListCardItemDirectMessageThread
+                  thread={thread}
+                  key={thread.id}
+                  currentUser={currentUser}
+                  active={active === thread.id}
+                />
+              </SentryErrorBoundary>
             );
           })}
         </InfiniteList>

--- a/src/views/directMessages/components/threadsList.js
+++ b/src/views/directMessages/components/threadsList.js
@@ -5,7 +5,7 @@ import InfiniteList from 'src/components/infiniteScroll';
 import { deduplicateChildren } from 'src/components/infiniteScroll/deduplicateChildren';
 import { LoadingDM } from 'src/components/loading';
 import { ThreadsListScrollContainer } from './style';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   threads: Array<?Object>,
@@ -88,13 +88,13 @@ class ThreadsList extends React.Component<Props, State> {
           {uniqueThreads.map(thread => {
             if (!thread) return null;
             return (
-              <SentryErrorBoundary fallbackComponent={null} key={thread.id}>
+              <ErrorBoundary fallbackComponent={null} key={thread.id}>
                 <ListCardItemDirectMessageThread
                   thread={thread}
                   currentUser={currentUser}
                   active={active === thread.id}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             );
           })}
         </InfiniteList>

--- a/src/views/directMessages/components/threadsList.js
+++ b/src/views/directMessages/components/threadsList.js
@@ -88,10 +88,9 @@ class ThreadsList extends React.Component<Props, State> {
           {uniqueThreads.map(thread => {
             if (!thread) return null;
             return (
-              <SentryErrorBoundary fallbackComponent={null}>
+              <SentryErrorBoundary fallbackComponent={null} key={thread.id}>
                 <ListCardItemDirectMessageThread
                   thread={thread}
-                  key={thread.id}
                   currentUser={currentUser}
                   active={active === thread.id}
                 />

--- a/src/views/directMessages/containers/existingThread.js
+++ b/src/views/directMessages/containers/existingThread.js
@@ -12,7 +12,7 @@ import getDirectMessageThread from 'shared/graphql/queries/directMessageThread/g
 import { MessagesContainer, ViewContent } from '../style';
 import { Loading } from 'src/components/loading';
 import ViewError from 'src/components/viewError';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   data: Object,
@@ -97,9 +97,9 @@ class ExistingThread extends React.Component<Props> {
             <ViewContent
               innerRef={scrollBody => (this.scrollBody = scrollBody)}
             >
-              <SentryErrorBoundary>
+              <ErrorBoundary>
                 <Header thread={thread} currentUser={currentUser} />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
 
               <Messages
                 id={id}

--- a/src/views/directMessages/containers/existingThread.js
+++ b/src/views/directMessages/containers/existingThread.js
@@ -6,12 +6,13 @@ import { withApollo } from 'react-apollo';
 import setLastSeenMutation from 'shared/graphql/mutations/directMessageThread/setDMThreadLastSeen';
 import Messages from '../components/messages';
 import Header from '../components/header';
-import ChatInput from '../../../components/chatInput';
-import viewNetworkHandler from '../../../components/viewNetworkHandler';
+import ChatInput from 'src/components/chatInput';
+import viewNetworkHandler from 'src/components/viewNetworkHandler';
 import getDirectMessageThread from 'shared/graphql/queries/directMessageThread/getDirectMessageThread';
 import { MessagesContainer, ViewContent } from '../style';
-import { Loading } from '../../../components/loading';
-import ViewError from '../../../components/viewError';
+import { Loading } from 'src/components/loading';
+import ViewError from 'src/components/viewError';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   data: Object,
@@ -96,7 +97,10 @@ class ExistingThread extends React.Component<Props> {
             <ViewContent
               innerRef={scrollBody => (this.scrollBody = scrollBody)}
             >
-              <Header thread={thread} currentUser={currentUser} />
+              <SentryErrorBoundary>
+                <Header thread={thread} currentUser={currentUser} />
+              </SentryErrorBoundary>
+
               <Messages
                 id={id}
                 threadType={thread.threadType}

--- a/src/views/explore/index.js
+++ b/src/views/explore/index.js
@@ -11,7 +11,7 @@ import CommunitySearchWrapper from './components/communitySearchWrapper';
 import { Wrapper } from './style';
 import { Charts } from './view';
 import { track, events } from 'src/helpers/analytics';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   currentUser?: Object,
@@ -36,18 +36,18 @@ class Explore extends React.Component<Props> {
         <Wrapper data-cy="explore-page" id="main">
           <Head title={title} description={description} />
           <Titlebar title={'Explore'} noComposer />
-          <SentryErrorBoundary fallbackComponent={null}>
+          <ErrorBoundary fallbackComponent={null}>
             <CommunitySearchWrapper
               currentUser={this.props.currentUser}
               redirectPath={window.location}
             >
               <Search />
             </CommunitySearchWrapper>
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary>
+          <ErrorBoundary>
             <Charts />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         </Wrapper>
       </AppViewWrapper>
     );

--- a/src/views/explore/index.js
+++ b/src/views/explore/index.js
@@ -11,6 +11,7 @@ import CommunitySearchWrapper from './components/communitySearchWrapper';
 import { Wrapper } from './style';
 import { Charts } from './view';
 import { track, events } from 'src/helpers/analytics';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   currentUser?: Object,
@@ -35,13 +36,18 @@ class Explore extends React.Component<Props> {
         <Wrapper data-cy="explore-page" id="main">
           <Head title={title} description={description} />
           <Titlebar title={'Explore'} noComposer />
-          <CommunitySearchWrapper
-            currentUser={this.props.currentUser}
-            redirectPath={window.location}
-          >
-            <Search />
-          </CommunitySearchWrapper>
-          <Charts />
+          <SentryErrorBoundary fallbackComponent={null}>
+            <CommunitySearchWrapper
+              currentUser={this.props.currentUser}
+              redirectPath={window.location}
+            >
+              <Search />
+            </CommunitySearchWrapper>
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary>
+            <Charts />
+          </SentryErrorBoundary>
         </Wrapper>
       </AppViewWrapper>
     );

--- a/src/views/explore/view.js
+++ b/src/views/explore/view.js
@@ -20,7 +20,7 @@ import type { GetCommunitiesType } from 'shared/graphql/queries/community/getCom
 import { Loading } from '../../components/loading';
 import { SegmentedControl, Segment } from '../../components/segmentedControl';
 import { track, transformations, events } from 'src/helpers/analytics';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 export const Charts = () => {
   const ChartGrid = styled.div`
@@ -152,7 +152,7 @@ class CategoryList extends React.Component<CategoryListProps> {
             <ListWrapper>
               {filteredCommunities.map((community, i) => (
                 // $FlowFixMe
-                <SentryErrorBoundary fallbackComponent={null} key={i}>
+                <ErrorBoundary fallbackComponent={null} key={i}>
                   <CommunityProfile
                     profileSize={'upsell'}
                     data={{ community }}
@@ -160,7 +160,7 @@ class CategoryList extends React.Component<CategoryListProps> {
                     onLeave={this.onLeave}
                     onJoin={this.onJoin}
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               ))}
             </ListWrapper>
           </ListWithTitle>
@@ -183,14 +183,14 @@ class CategoryList extends React.Component<CategoryListProps> {
                 <ListWrapper>
                   {filteredCommunities.map((community, i) => (
                     // $FlowFixMe
-                    <SentryErrorBoundary fallbackComponent={null}>
+                    <ErrorBoundary fallbackComponent={null}>
                       <CommunityProfile
                         key={i}
                         profileSize={'upsell'}
                         data={{ community }}
                         currentUser={currentUser}
                       />
-                    </SentryErrorBoundary>
+                    </ErrorBoundary>
                   ))}
                 </ListWrapper>
               </ListWithTitle>

--- a/src/views/explore/view.js
+++ b/src/views/explore/view.js
@@ -20,6 +20,7 @@ import type { GetCommunitiesType } from 'shared/graphql/queries/community/getCom
 import { Loading } from '../../components/loading';
 import { SegmentedControl, Segment } from '../../components/segmentedControl';
 import { track, transformations, events } from 'src/helpers/analytics';
+import { SentryErrorBoundary } from 'src/components/error';
 
 export const Charts = () => {
   const ChartGrid = styled.div`
@@ -151,14 +152,16 @@ class CategoryList extends React.Component<CategoryListProps> {
             <ListWrapper>
               {filteredCommunities.map((community, i) => (
                 // $FlowFixMe
-                <CommunityProfile
-                  key={i}
-                  profileSize={'upsell'}
-                  data={{ community }}
-                  currentUser={currentUser}
-                  onLeave={this.onLeave}
-                  onJoin={this.onJoin}
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <CommunityProfile
+                    key={i}
+                    profileSize={'upsell'}
+                    data={{ community }}
+                    currentUser={currentUser}
+                    onLeave={this.onLeave}
+                    onJoin={this.onJoin}
+                  />
+                </SentryErrorBoundary>
               ))}
             </ListWrapper>
           </ListWithTitle>
@@ -181,12 +184,14 @@ class CategoryList extends React.Component<CategoryListProps> {
                 <ListWrapper>
                   {filteredCommunities.map((community, i) => (
                     // $FlowFixMe
-                    <CommunityProfile
-                      key={i}
-                      profileSize={'upsell'}
-                      data={{ community }}
-                      currentUser={currentUser}
-                    />
+                    <SentryErrorBoundary fallbackComponent={null}>
+                      <CommunityProfile
+                        key={i}
+                        profileSize={'upsell'}
+                        data={{ community }}
+                        currentUser={currentUser}
+                      />
+                    </SentryErrorBoundary>
                   ))}
                 </ListWrapper>
               </ListWithTitle>

--- a/src/views/explore/view.js
+++ b/src/views/explore/view.js
@@ -152,9 +152,8 @@ class CategoryList extends React.Component<CategoryListProps> {
             <ListWrapper>
               {filteredCommunities.map((community, i) => (
                 // $FlowFixMe
-                <SentryErrorBoundary fallbackComponent={null}>
+                <SentryErrorBoundary fallbackComponent={null} key={i}>
                   <CommunityProfile
-                    key={i}
                     profileSize={'upsell'}
                     data={{ community }}
                     currentUser={currentUser}

--- a/src/views/notifications/components/notificationDropdownList.js
+++ b/src/views/notifications/components/notificationDropdownList.js
@@ -45,9 +45,8 @@ export class NotificationDropdownList extends React.Component<Props> {
           switch (notification.event) {
             case 'MESSAGE_CREATED': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniNewMessageNotification
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
@@ -57,9 +56,8 @@ export class NotificationDropdownList extends React.Component<Props> {
             }
             case 'REACTION_CREATED': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniNewReactionNotification
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
@@ -69,9 +67,8 @@ export class NotificationDropdownList extends React.Component<Props> {
             }
             case 'CHANNEL_CREATED': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniNewChannelNotification
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
@@ -84,9 +81,8 @@ export class NotificationDropdownList extends React.Component<Props> {
             }
             case 'USER_JOINED_COMMUNITY': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniNewUserInCommunityNotification
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
@@ -99,9 +95,8 @@ export class NotificationDropdownList extends React.Component<Props> {
             }
             case 'THREAD_CREATED': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniNewThreadNotification
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
@@ -114,9 +109,8 @@ export class NotificationDropdownList extends React.Component<Props> {
             }
             case 'COMMUNITY_INVITE': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniCommunityInviteNotification
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
@@ -129,9 +123,8 @@ export class NotificationDropdownList extends React.Component<Props> {
             }
             case 'MENTION_THREAD': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniMentionThreadNotification
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
@@ -141,9 +134,8 @@ export class NotificationDropdownList extends React.Component<Props> {
             }
             case 'MENTION_MESSAGE': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniMentionMessageNotification
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
@@ -153,9 +145,8 @@ export class NotificationDropdownList extends React.Component<Props> {
             }
             case 'PRIVATE_CHANNEL_REQUEST_SENT': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniPrivateChannelRequestSent
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
@@ -168,9 +159,8 @@ export class NotificationDropdownList extends React.Component<Props> {
             }
             case 'PRIVATE_CHANNEL_REQUEST_APPROVED': {
               return (
-                <ErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null} key={notification.id}>
                   <MiniPrivateChannelRequestApproved
-                    key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}

--- a/src/views/notifications/components/notificationDropdownList.js
+++ b/src/views/notifications/components/notificationDropdownList.js
@@ -13,6 +13,7 @@ import { MiniMentionMessageNotification } from './mentionMessageNotification';
 import { MiniMentionThreadNotification } from './mentionThreadNotification';
 import { MiniPrivateChannelRequestSent } from './privateChannelRequestSentNotification';
 import { MiniPrivateChannelRequestApproved } from './privateChannelRequestApprovedNotification';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   rawNotifications: Array<Object>,
@@ -44,120 +45,140 @@ export class NotificationDropdownList extends React.Component<Props> {
           switch (notification.event) {
             case 'MESSAGE_CREATED': {
               return (
-                <MiniNewMessageNotification
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniNewMessageNotification
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                  />
+                </SentryErrorBoundary>
               );
             }
             case 'REACTION_CREATED': {
               return (
-                <MiniNewReactionNotification
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniNewReactionNotification
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                  />
+                </SentryErrorBoundary>
               );
             }
             case 'CHANNEL_CREATED': {
               return (
-                <MiniNewChannelNotification
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                  markSingleNotificationAsSeenInState={
-                    markSingleNotificationAsSeenInState
-                  }
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniNewChannelNotification
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                    markSingleNotificationAsSeenInState={
+                      markSingleNotificationAsSeenInState
+                    }
+                  />
+                </SentryErrorBoundary>
               );
             }
             case 'USER_JOINED_COMMUNITY': {
               return (
-                <MiniNewUserInCommunityNotification
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                  markSingleNotificationAsSeenInState={
-                    markSingleNotificationAsSeenInState
-                  }
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniNewUserInCommunityNotification
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                    markSingleNotificationAsSeenInState={
+                      markSingleNotificationAsSeenInState
+                    }
+                  />
+                </SentryErrorBoundary>
               );
             }
             case 'THREAD_CREATED': {
               return (
-                <MiniNewThreadNotification
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                  markSingleNotificationAsSeenInState={
-                    markSingleNotificationAsSeenInState
-                  }
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniNewThreadNotification
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                    markSingleNotificationAsSeenInState={
+                      markSingleNotificationAsSeenInState
+                    }
+                  />
+                </SentryErrorBoundary>
               );
             }
             case 'COMMUNITY_INVITE': {
               return (
-                <MiniCommunityInviteNotification
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                  markSingleNotificationAsSeenInState={
-                    markSingleNotificationAsSeenInState
-                  }
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniCommunityInviteNotification
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                    markSingleNotificationAsSeenInState={
+                      markSingleNotificationAsSeenInState
+                    }
+                  />
+                </SentryErrorBoundary>
               );
             }
             case 'MENTION_THREAD': {
               return (
-                <MiniMentionThreadNotification
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniMentionThreadNotification
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                  />
+                </SentryErrorBoundary>
               );
             }
             case 'MENTION_MESSAGE': {
               return (
-                <MiniMentionMessageNotification
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniMentionMessageNotification
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                  />
+                </SentryErrorBoundary>
               );
             }
             case 'PRIVATE_CHANNEL_REQUEST_SENT': {
               return (
-                <MiniPrivateChannelRequestSent
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                  markSingleNotificationAsSeenInState={
-                    markSingleNotificationAsSeenInState
-                  }
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniPrivateChannelRequestSent
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                    markSingleNotificationAsSeenInState={
+                      markSingleNotificationAsSeenInState
+                    }
+                  />
+                </SentryErrorBoundary>
               );
             }
             case 'PRIVATE_CHANNEL_REQUEST_APPROVED': {
               return (
-                <MiniPrivateChannelRequestApproved
-                  key={notification.id}
-                  notification={notification}
-                  currentUser={currentUser}
-                  history={history}
-                  markSingleNotificationAsSeenInState={
-                    markSingleNotificationAsSeenInState
-                  }
-                />
+                <SentryErrorBoundary fallbackComponent={null}>
+                  <MiniPrivateChannelRequestApproved
+                    key={notification.id}
+                    notification={notification}
+                    currentUser={currentUser}
+                    history={history}
+                    markSingleNotificationAsSeenInState={
+                      markSingleNotificationAsSeenInState
+                    }
+                  />
+                </SentryErrorBoundary>
               );
             }
             default: {

--- a/src/views/notifications/components/notificationDropdownList.js
+++ b/src/views/notifications/components/notificationDropdownList.js
@@ -13,7 +13,7 @@ import { MiniMentionMessageNotification } from './mentionMessageNotification';
 import { MiniMentionThreadNotification } from './mentionThreadNotification';
 import { MiniPrivateChannelRequestSent } from './privateChannelRequestSentNotification';
 import { MiniPrivateChannelRequestApproved } from './privateChannelRequestApprovedNotification';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   rawNotifications: Array<Object>,
@@ -45,31 +45,31 @@ export class NotificationDropdownList extends React.Component<Props> {
           switch (notification.event) {
             case 'MESSAGE_CREATED': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniNewMessageNotification
                     key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             case 'REACTION_CREATED': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniNewReactionNotification
                     key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             case 'CHANNEL_CREATED': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniNewChannelNotification
                     key={notification.id}
                     notification={notification}
@@ -79,12 +79,12 @@ export class NotificationDropdownList extends React.Component<Props> {
                       markSingleNotificationAsSeenInState
                     }
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             case 'USER_JOINED_COMMUNITY': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniNewUserInCommunityNotification
                     key={notification.id}
                     notification={notification}
@@ -94,12 +94,12 @@ export class NotificationDropdownList extends React.Component<Props> {
                       markSingleNotificationAsSeenInState
                     }
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             case 'THREAD_CREATED': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniNewThreadNotification
                     key={notification.id}
                     notification={notification}
@@ -109,12 +109,12 @@ export class NotificationDropdownList extends React.Component<Props> {
                       markSingleNotificationAsSeenInState
                     }
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             case 'COMMUNITY_INVITE': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniCommunityInviteNotification
                     key={notification.id}
                     notification={notification}
@@ -124,36 +124,36 @@ export class NotificationDropdownList extends React.Component<Props> {
                       markSingleNotificationAsSeenInState
                     }
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             case 'MENTION_THREAD': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniMentionThreadNotification
                     key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             case 'MENTION_MESSAGE': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniMentionMessageNotification
                     key={notification.id}
                     notification={notification}
                     currentUser={currentUser}
                     history={history}
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             case 'PRIVATE_CHANNEL_REQUEST_SENT': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniPrivateChannelRequestSent
                     key={notification.id}
                     notification={notification}
@@ -163,12 +163,12 @@ export class NotificationDropdownList extends React.Component<Props> {
                       markSingleNotificationAsSeenInState
                     }
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             case 'PRIVATE_CHANNEL_REQUEST_APPROVED': {
               return (
-                <SentryErrorBoundary fallbackComponent={null}>
+                <ErrorBoundary fallbackComponent={null}>
                   <MiniPrivateChannelRequestApproved
                     key={notification.id}
                     notification={notification}
@@ -178,7 +178,7 @@ export class NotificationDropdownList extends React.Component<Props> {
                       markSingleNotificationAsSeenInState
                     }
                   />
-                </SentryErrorBoundary>
+                </ErrorBoundary>
               );
             }
             default: {

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -39,6 +39,7 @@ import generateMetaInfo from 'shared/generate-meta-info';
 import viewNetworkHandler from '../../components/viewNetworkHandler';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   markAllNotificationsSeen?: Function,
@@ -239,92 +240,112 @@ class NotificationsPure extends React.Component<Props, State> {
                 switch (notification.event) {
                   case 'MESSAGE_CREATED': {
                     return (
-                      <NewMessageNotification
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <NewMessageNotification
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   case 'REACTION_CREATED': {
                     return (
-                      <NewReactionNotification
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <NewReactionNotification
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   case 'CHANNEL_CREATED': {
                     return (
-                      <NewChannelNotification
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <NewChannelNotification
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   case 'USER_JOINED_COMMUNITY': {
                     return (
-                      <NewUserInCommunityNotification
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <NewUserInCommunityNotification
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   case 'THREAD_CREATED': {
                     return (
-                      <NewThreadNotification
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <NewThreadNotification
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   case 'COMMUNITY_INVITE': {
                     return (
-                      <CommunityInviteNotification
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <CommunityInviteNotification
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   case 'MENTION_MESSAGE': {
                     return (
-                      <MentionMessageNotification
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <MentionMessageNotification
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   case 'MENTION_THREAD': {
                     return (
-                      <MentionThreadNotification
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <MentionThreadNotification
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   case 'PRIVATE_CHANNEL_REQUEST_SENT': {
                     return (
-                      <PrivateChannelRequestSent
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <PrivateChannelRequestSent
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   case 'PRIVATE_CHANNEL_REQUEST_APPROVED': {
                     return (
-                      <PrivateChannelRequestApproved
-                        key={notification.id}
-                        notification={notification}
-                        currentUser={currentUser}
-                      />
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <PrivateChannelRequestApproved
+                          key={notification.id}
+                          notification={notification}
+                          currentUser={currentUser}
+                        />
+                      </SentryErrorBoundary>
                     );
                   }
                   default: {

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -39,7 +39,7 @@ import generateMetaInfo from 'shared/generate-meta-info';
 import viewNetworkHandler from '../../components/viewNetworkHandler';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   markAllNotificationsSeen?: Function,
@@ -240,112 +240,112 @@ class NotificationsPure extends React.Component<Props, State> {
                 switch (notification.event) {
                   case 'MESSAGE_CREATED': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <NewMessageNotification
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   case 'REACTION_CREATED': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <NewReactionNotification
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   case 'CHANNEL_CREATED': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <NewChannelNotification
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   case 'USER_JOINED_COMMUNITY': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <NewUserInCommunityNotification
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   case 'THREAD_CREATED': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <NewThreadNotification
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   case 'COMMUNITY_INVITE': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <CommunityInviteNotification
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   case 'MENTION_MESSAGE': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <MentionMessageNotification
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   case 'MENTION_THREAD': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <MentionThreadNotification
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   case 'PRIVATE_CHANNEL_REQUEST_SENT': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <PrivateChannelRequestSent
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   case 'PRIVATE_CHANNEL_REQUEST_APPROVED': {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <PrivateChannelRequestApproved
                           key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   }
                   default: {

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -240,9 +240,11 @@ class NotificationsPure extends React.Component<Props, State> {
                 switch (notification.event) {
                   case 'MESSAGE_CREATED': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <NewMessageNotification
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
@@ -251,9 +253,11 @@ class NotificationsPure extends React.Component<Props, State> {
                   }
                   case 'REACTION_CREATED': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <NewReactionNotification
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
@@ -262,9 +266,11 @@ class NotificationsPure extends React.Component<Props, State> {
                   }
                   case 'CHANNEL_CREATED': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <NewChannelNotification
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
@@ -273,9 +279,11 @@ class NotificationsPure extends React.Component<Props, State> {
                   }
                   case 'USER_JOINED_COMMUNITY': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <NewUserInCommunityNotification
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
@@ -284,9 +292,11 @@ class NotificationsPure extends React.Component<Props, State> {
                   }
                   case 'THREAD_CREATED': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <NewThreadNotification
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
@@ -295,9 +305,11 @@ class NotificationsPure extends React.Component<Props, State> {
                   }
                   case 'COMMUNITY_INVITE': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <CommunityInviteNotification
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
@@ -306,9 +318,11 @@ class NotificationsPure extends React.Component<Props, State> {
                   }
                   case 'MENTION_MESSAGE': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <MentionMessageNotification
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
@@ -317,9 +331,11 @@ class NotificationsPure extends React.Component<Props, State> {
                   }
                   case 'MENTION_THREAD': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <MentionThreadNotification
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
@@ -328,9 +344,11 @@ class NotificationsPure extends React.Component<Props, State> {
                   }
                   case 'PRIVATE_CHANNEL_REQUEST_SENT': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <PrivateChannelRequestSent
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />
@@ -339,9 +357,11 @@ class NotificationsPure extends React.Component<Props, State> {
                   }
                   case 'PRIVATE_CHANNEL_REQUEST_APPROVED': {
                     return (
-                      <ErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary
+                        fallbackComponent={null}
+                        key={notification.id}
+                      >
                         <PrivateChannelRequestApproved
-                          key={notification.id}
                           notification={notification}
                           currentUser={currentUser}
                         />

--- a/src/views/thread/components/messages.js
+++ b/src/views/thread/components/messages.js
@@ -16,7 +16,7 @@ import NextPageButton from 'src/components/nextPageButton';
 import { ChatWrapper, NullMessagesWrapper, NullCopy } from '../style';
 import getThreadMessages from 'shared/graphql/queries/thread/getThreadMessageConnection';
 import toggleReactionMutation from 'shared/graphql/mutations/reaction/toggleReaction';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type State = {
   subscription: ?Function,
@@ -176,7 +176,7 @@ class MessagesWithData extends React.Component<Props, State> {
 
       return (
         <ChatWrapper>
-          <SentryErrorBoundary>
+          <ErrorBoundary>
             {pageInfo.hasPreviousPage && (
               <div>
                 <NextPageButton
@@ -226,7 +226,7 @@ class MessagesWithData extends React.Component<Props, State> {
                 lastSeen={lastSeen}
               />
             </InfiniteList>
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         </ChatWrapper>
       );
     }

--- a/src/views/thread/components/sidebar.js
+++ b/src/views/thread/components/sidebar.js
@@ -35,6 +35,7 @@ import {
   Lock,
   SidebarChannelPill,
 } from '../style';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type RecommendedThread = {
   node: GetThreadType,
@@ -96,115 +97,125 @@ class Sidebar extends React.Component<Props> {
     return (
       <ThreadSidebarView>
         {!currentUser && (
-          <SidebarSection data-cy="thread-sidebar-login">
-            <SidebarSectionTitle>Join the conversation</SidebarSectionTitle>
-            <SidebarSectionBody>
-              Sign in to join this conversation, and others like it, in the
-              communities you care about.
-            </SidebarSectionBody>
-            <SidebarSectionAuth>
-              <Link to={loginUrl}>
-                <Button gradientTheme={'brand'} color={'brand.default'}>
-                  Sign up
-                </Button>
-              </Link>
-              <Link to={loginUrl}>
-                <TextButton gradientTheme={'text'} color={'text.alt'}>
-                  Log in
-                </TextButton>
-              </Link>
-            </SidebarSectionAuth>
-          </SidebarSection>
+          <SentryErrorBoundary fallbackComponent={null}>
+            <SidebarSection data-cy="thread-sidebar-login">
+              <SidebarSectionTitle>Join the conversation</SidebarSectionTitle>
+              <SidebarSectionBody>
+                Sign in to join this conversation, and others like it, in the
+                communities you care about.
+              </SidebarSectionBody>
+              <SidebarSectionAuth>
+                <Link to={loginUrl}>
+                  <Button gradientTheme={'brand'} color={'brand.default'}>
+                    Sign up
+                  </Button>
+                </Link>
+                <Link to={loginUrl}>
+                  <TextButton gradientTheme={'text'} color={'text.alt'}>
+                    Log in
+                  </TextButton>
+                </Link>
+              </SidebarSectionAuth>
+            </SidebarSection>
+          </SentryErrorBoundary>
         )}
 
-        <SidebarSection data-cy="thread-sidebar-community-info">
-          <Link to={`/${thread.community.slug}`}>
-            <SidebarCommunityCover src={thread.community.coverPhoto} />
-            <SidebarCommunityProfile
-              community
-              size={48}
-              src={thread.community.profilePhoto}
-            />
-            <SidebarCommunityName>{thread.community.name}</SidebarCommunityName>
-          </Link>
+        <SentryErrorBoundary fallbackComponent={null}>
+          <SidebarSection data-cy="thread-sidebar-community-info">
+            <Link to={`/${thread.community.slug}`}>
+              <SidebarCommunityCover src={thread.community.coverPhoto} />
+              <SidebarCommunityProfile
+                community
+                size={48}
+                src={thread.community.profilePhoto}
+              />
+              <SidebarCommunityName>
+                {thread.community.name}
+              </SidebarCommunityName>
+            </Link>
 
-          <SidebarChannelPill>
-            <PillLink to={`/${thread.community.slug}/${thread.channel.slug}`}>
-              {thread.channel.isPrivate && (
-                <Lock>
-                  <Icon glyph="private" size={12} />
-                </Lock>
-              )}
-              <PillLabel isPrivate={thread.channel.isPrivate}>
-                {thread.channel.name}
-              </PillLabel>
-            </PillLink>
-          </SidebarChannelPill>
+            <SidebarChannelPill>
+              <PillLink to={`/${thread.community.slug}/${thread.channel.slug}`}>
+                {thread.channel.isPrivate && (
+                  <Lock>
+                    <Icon glyph="private" size={12} />
+                  </Lock>
+                )}
+                <PillLabel isPrivate={thread.channel.isPrivate}>
+                  {thread.channel.name}
+                </PillLabel>
+              </PillLink>
+            </SidebarChannelPill>
 
-          <SidebarCommunityDescription>
-            {renderDescriptionWithLinks(thread.community.description)}
-          </SidebarCommunityDescription>
+            <SidebarCommunityDescription>
+              {renderDescriptionWithLinks(thread.community.description)}
+            </SidebarCommunityDescription>
 
-          <SidebarSectionActions>
-            {thread.community.communityPermissions.isMember ? (
-              <Link to={`/${thread.community.slug}`}>
-                <TextButton dataCy="thread-sidebar-view-community-button">
-                  View community
-                </TextButton>
-              </Link>
-            ) : currentUser ? (
-              <ToggleCommunityMembership
-                community={thread.community}
-                render={({ isLoading }) => (
+            <SidebarSectionActions>
+              {thread.community.communityPermissions.isMember ? (
+                <Link to={`/${thread.community.slug}`}>
+                  <TextButton dataCy="thread-sidebar-view-community-button">
+                    View community
+                  </TextButton>
+                </Link>
+              ) : currentUser ? (
+                <ToggleCommunityMembership
+                  community={thread.community}
+                  render={({ isLoading }) => (
+                    <Button
+                      gradientTheme={'success'}
+                      color={'success.default'}
+                      loading={isLoading}
+                      dataCy="thread-sidebar-join-community-button"
+                    >
+                      Join community
+                    </Button>
+                  )}
+                />
+              ) : (
+                <Link to={loginUrl}>
                   <Button
                     gradientTheme={'success'}
                     color={'success.default'}
-                    loading={isLoading}
-                    dataCy="thread-sidebar-join-community-button"
+                    dataCy="thread-sidebar-join-login-button"
                   >
                     Join community
                   </Button>
-                )}
-              />
-            ) : (
-              <Link to={loginUrl}>
-                <Button
-                  gradientTheme={'success'}
-                  color={'success.default'}
-                  dataCy="thread-sidebar-join-login-button"
-                >
-                  Join community
-                </Button>
-              </Link>
-            )}
-          </SidebarSectionActions>
-        </SidebarSection>
+                </Link>
+              )}
+            </SidebarSectionActions>
+          </SidebarSection>
+        </SentryErrorBoundary>
 
         {threadsToRender &&
           threadsToRender.length > 0 && (
-            <SidebarSection data-cy="thread-sidebar-more-threads">
-              <SidebarSectionTitle>More conversations</SidebarSectionTitle>
-              <SidebarRelatedThreadList>
-                {threadsToRender.map(t => {
-                  return (
-                    <SidebarRelatedThread key={t.id}>
-                      <Link
-                        to={{
-                          pathname: window.location.pathname,
-                          search: `?thread=${t.id}`,
-                        }}
-                      >
-                        <RelatedTitle>{t.content.title}</RelatedTitle>
-                        <RelatedCount>
-                          {t.messageCount.toLocaleString()}{' '}
-                          {t.messageCount === 1 ? 'message' : 'messages'}
-                        </RelatedCount>
-                      </Link>
-                    </SidebarRelatedThread>
-                  );
-                })}
-              </SidebarRelatedThreadList>
-            </SidebarSection>
+            <SentryErrorBoundary fallbackComponent={null}>
+              <SidebarSection data-cy="thread-sidebar-more-threads">
+                <SidebarSectionTitle>More conversations</SidebarSectionTitle>
+                <SidebarRelatedThreadList>
+                  {threadsToRender.map(t => {
+                    return (
+                      <SentryErrorBoundary fallbackComponent={null}>
+                        <SidebarRelatedThread key={t.id}>
+                          <Link
+                            to={{
+                              pathname: window.location.pathname,
+                              search: `?thread=${t.id}`,
+                            }}
+                          >
+                            <RelatedTitle>{t.content.title}</RelatedTitle>
+                            <RelatedCount>
+                              {t.messageCount.toLocaleString()}{' '}
+                              {t.messageCount === 1 ? 'message' : 'messages'}
+                            </RelatedCount>
+                          </Link>
+                        </SidebarRelatedThread>
+                      </SentryErrorBoundary>
+                    );
+                  })}
+                </SidebarRelatedThreadList>
+              </SidebarSection>
+            </SentryErrorBoundary>
           )}
       </ThreadSidebarView>
     );

--- a/src/views/thread/components/sidebar.js
+++ b/src/views/thread/components/sidebar.js
@@ -35,7 +35,7 @@ import {
   Lock,
   SidebarChannelPill,
 } from '../style';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type RecommendedThread = {
   node: GetThreadType,
@@ -97,7 +97,7 @@ class Sidebar extends React.Component<Props> {
     return (
       <ThreadSidebarView>
         {!currentUser && (
-          <SentryErrorBoundary fallbackComponent={null}>
+          <ErrorBoundary fallbackComponent={null}>
             <SidebarSection data-cy="thread-sidebar-login">
               <SidebarSectionTitle>Join the conversation</SidebarSectionTitle>
               <SidebarSectionBody>
@@ -117,10 +117,10 @@ class Sidebar extends React.Component<Props> {
                 </Link>
               </SidebarSectionAuth>
             </SidebarSection>
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         )}
 
-        <SentryErrorBoundary fallbackComponent={null}>
+        <ErrorBoundary fallbackComponent={null}>
           <SidebarSection data-cy="thread-sidebar-community-info">
             <Link to={`/${thread.community.slug}`}>
               <SidebarCommunityCover src={thread.community.coverPhoto} />
@@ -185,17 +185,17 @@ class Sidebar extends React.Component<Props> {
               )}
             </SidebarSectionActions>
           </SidebarSection>
-        </SentryErrorBoundary>
+        </ErrorBoundary>
 
         {threadsToRender &&
           threadsToRender.length > 0 && (
-            <SentryErrorBoundary fallbackComponent={null}>
+            <ErrorBoundary fallbackComponent={null}>
               <SidebarSection data-cy="thread-sidebar-more-threads">
                 <SidebarSectionTitle>More conversations</SidebarSectionTitle>
                 <SidebarRelatedThreadList>
                   {threadsToRender.map(t => {
                     return (
-                      <SentryErrorBoundary fallbackComponent={null}>
+                      <ErrorBoundary fallbackComponent={null}>
                         <SidebarRelatedThread key={t.id}>
                           <Link
                             to={{
@@ -210,12 +210,12 @@ class Sidebar extends React.Component<Props> {
                             </RelatedCount>
                           </Link>
                         </SidebarRelatedThread>
-                      </SentryErrorBoundary>
+                      </ErrorBoundary>
                     );
                   })}
                 </SidebarRelatedThreadList>
               </SidebarSection>
-            </SentryErrorBoundary>
+            </ErrorBoundary>
           )}
       </ThreadSidebarView>
     );

--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -33,7 +33,7 @@ import {
 } from '../style';
 import { track, events, transformations } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 const ENDS_IN_WHITESPACE = /(\s|\n)$/;
 
@@ -446,9 +446,9 @@ class ThreadDetailPure extends React.Component<Props, State> {
       <ThreadWrapper>
         <ThreadContent isEditing={isEditing}>
           {/* $FlowFixMe */}
-          <SentryErrorBoundary fallbackComponent={null}>
+          <ErrorBoundary fallbackComponent={null}>
             <ThreadByline author={thread.author} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
           {isEditing ? (
             <Textarea
@@ -495,7 +495,7 @@ class ThreadDetailPure extends React.Component<Props, State> {
           />
         </ThreadContent>
 
-        <SentryErrorBoundary fallbackComponent={null}>
+        <ErrorBoundary fallbackComponent={null}>
           <ActionBar
             toggleEdit={this.toggleEdit}
             currentUser={currentUser}
@@ -510,7 +510,7 @@ class ThreadDetailPure extends React.Component<Props, State> {
             isLockingThread={isLockingThread}
             isPinningThread={isPinningThread}
           />
-        </SentryErrorBoundary>
+        </ErrorBoundary>
       </ThreadWrapper>
     );
   }

--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -33,6 +33,7 @@ import {
 } from '../style';
 import { track, events, transformations } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
+import { SentryErrorBoundary } from 'src/components/error';
 
 const ENDS_IN_WHITESPACE = /(\s|\n)$/;
 
@@ -445,7 +446,9 @@ class ThreadDetailPure extends React.Component<Props, State> {
       <ThreadWrapper>
         <ThreadContent isEditing={isEditing}>
           {/* $FlowFixMe */}
-          <ThreadByline author={thread.author} />
+          <SentryErrorBoundary fallbackComponent={null}>
+            <ThreadByline author={thread.author} />
+          </SentryErrorBoundary>
 
           {isEditing ? (
             <Textarea
@@ -492,20 +495,22 @@ class ThreadDetailPure extends React.Component<Props, State> {
           />
         </ThreadContent>
 
-        <ActionBar
-          toggleEdit={this.toggleEdit}
-          currentUser={currentUser}
-          thread={thread}
-          saveEdit={this.saveEdit}
-          togglePinThread={this.togglePinThread}
-          isSavingEdit={isSavingEdit}
-          threadLock={this.threadLock}
-          triggerDelete={this.triggerDelete}
-          isEditing={isEditing}
-          title={this.state.title}
-          isLockingThread={isLockingThread}
-          isPinningThread={isPinningThread}
-        />
+        <SentryErrorBoundary fallbackComponent={null}>
+          <ActionBar
+            toggleEdit={this.toggleEdit}
+            currentUser={currentUser}
+            thread={thread}
+            saveEdit={this.saveEdit}
+            togglePinThread={this.togglePinThread}
+            isSavingEdit={isSavingEdit}
+            threadLock={this.threadLock}
+            triggerDelete={this.triggerDelete}
+            isEditing={isEditing}
+            title={this.state.title}
+            isLockingThread={isLockingThread}
+            isPinningThread={isPinningThread}
+          />
+        </SentryErrorBoundary>
       </ThreadWrapper>
     );
   }

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -37,7 +37,7 @@ import {
   WatercoolerAvatar,
 } from './style';
 import WatercoolerActionBar from './components/watercoolerActionBar';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 type Props = {
   data: {
@@ -338,7 +338,7 @@ class ThreadContainer extends React.Component<Props, State> {
 
       if (channelPermissions.isBlocked || communityPermissions.isBlocked) {
         return (
-          <SentryErrorBoundary>
+          <ErrorBoundary>
             <ThreadViewContainer
               threadViewContext={threadViewContext}
               constrain={
@@ -357,13 +357,13 @@ class ThreadContainer extends React.Component<Props, State> {
                 />
               </ThreadContentView>
             </ThreadViewContainer>
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         );
       }
 
       if (thread.watercooler)
         return (
-          <SentryErrorBoundary>
+          <ErrorBoundary>
             <ThreadViewContainer
               data-cy="thread-view"
               constrain={
@@ -454,11 +454,11 @@ class ThreadContainer extends React.Component<Props, State> {
                 {this.renderChatInputOrUpsell()}
               </ThreadContentView>
             </ThreadViewContainer>
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         );
 
       return (
-        <SentryErrorBoundary>
+        <ErrorBoundary>
           <ThreadViewContainer
             data-cy="thread-view"
             constrain={
@@ -537,7 +537,7 @@ class ThreadContainer extends React.Component<Props, State> {
               {this.renderChatInputOrUpsell()}
             </ThreadContentView>
           </ThreadViewContainer>
-        </SentryErrorBoundary>
+        </ErrorBoundary>
       );
     }
 
@@ -546,7 +546,7 @@ class ThreadContainer extends React.Component<Props, State> {
     }
 
     return (
-      <SentryErrorBoundary>
+      <ErrorBoundary>
         <ThreadViewContainer
           threadViewContext={threadViewContext}
           data-cy="null-thread-view"
@@ -566,7 +566,7 @@ class ThreadContainer extends React.Component<Props, State> {
             />
           </ThreadContentView>
         </ThreadViewContainer>
-      </SentryErrorBoundary>
+      </ErrorBoundary>
     );
   }
 }

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -37,6 +37,7 @@ import {
   WatercoolerAvatar,
 } from './style';
 import WatercoolerActionBar from './components/watercoolerActionBar';
+import { SentryErrorBoundary } from 'src/components/error';
 
 type Props = {
   data: {
@@ -337,29 +338,127 @@ class ThreadContainer extends React.Component<Props, State> {
 
       if (channelPermissions.isBlocked || communityPermissions.isBlocked) {
         return (
-          <ThreadViewContainer
-            threadViewContext={threadViewContext}
-            constrain={
-              threadViewContext === 'slider' ||
-              threadViewContext === 'fullscreen'
-            }
-            data-cy="blocked-thread-view"
-          >
-            <ThreadContentView slider={slider}>
-              <ViewError
-                emoji={'✋'}
-                heading={'You have been blocked'}
-                subheading={`You are blocked from viewing all conversations in the ${
-                  thread.community.name
-                } community`}
-              />
-            </ThreadContentView>
-          </ThreadViewContainer>
+          <SentryErrorBoundary>
+            <ThreadViewContainer
+              threadViewContext={threadViewContext}
+              constrain={
+                threadViewContext === 'slider' ||
+                threadViewContext === 'fullscreen'
+              }
+              data-cy="blocked-thread-view"
+            >
+              <ThreadContentView slider={slider}>
+                <ViewError
+                  emoji={'✋'}
+                  heading={'You have been blocked'}
+                  subheading={`You are blocked from viewing all conversations in the ${
+                    thread.community.name
+                  } community`}
+                />
+              </ThreadContentView>
+            </ThreadViewContainer>
+          </SentryErrorBoundary>
         );
       }
 
       if (thread.watercooler)
         return (
+          <SentryErrorBoundary>
+            <ThreadViewContainer
+              data-cy="thread-view"
+              constrain={
+                threadViewContext === 'slider' ||
+                threadViewContext === 'fullscreen'
+              }
+              threadViewContext={threadViewContext}
+            >
+              {shouldRenderThreadSidebar && (
+                <Sidebar
+                  thread={thread}
+                  currentUser={currentUser}
+                  slug={thread.community.slug}
+                  id={thread.community.id}
+                />
+              )}
+
+              <ThreadContentView slider={slider}>
+                <Head
+                  title={`The Watercooler · ${thread.community.name}`}
+                  description={`Watercooler chat for the ${
+                    thread.community.name
+                  } community`}
+                  image={thread.community.profilePhoto}
+                />
+                <Titlebar
+                  title={thread.content.title}
+                  subtitle={`${thread.community.name} / ${thread.channel.name}`}
+                  provideBack={true}
+                  backRoute={'/'}
+                  noComposer
+                  style={{ gridArea: 'header' }}
+                />
+                <Content innerRef={this.setMessagesContainer}>
+                  <Detail type={slider ? '' : 'only'}>
+                    <WatercoolerIntroContainer>
+                      <WatercoolerAvatar
+                        src={thread.community.profilePhoto}
+                        community
+                        size={44}
+                        radius={8}
+                      />
+                      <WatercoolerTitle>
+                        The {thread.community.name} watercooler
+                      </WatercoolerTitle>
+                      <WatercoolerDescription>
+                        Welcome to the {thread.community.name} watercooler, a
+                        new space for general chat with everyone in the
+                        community. Jump in to the conversation below or
+                        introduce yourself!
+                      </WatercoolerDescription>
+                    </WatercoolerIntroContainer>
+
+                    <WatercoolerActionBar
+                      thread={thread}
+                      currentUser={currentUser}
+                    />
+
+                    {!isEditing && (
+                      <Messages
+                        threadMessageCount={thread.messageCount}
+                        id={thread.id}
+                        scrollContainer={this.state.messagesContainer}
+                        currentUser={currentUser}
+                        lastSeen={lastSeen}
+                        lastActive={lastActive}
+                        forceScrollToBottom={this.forceScrollToBottom}
+                        forceScrollToTop={this.forceScrollToTop}
+                        contextualScrollToBottom={this.contextualScrollToBottom}
+                        shouldForceScrollOnMessageLoad={true}
+                        shouldForceScrollToTopOnMessageLoad={false}
+                        hasMessagesToLoad={thread.messageCount > 0}
+                        isModerator={isModerator}
+                        isWatercooler={true}
+                      />
+                    )}
+
+                    {!isEditing &&
+                      isLocked && (
+                        <NullState
+                          icon="private"
+                          copy="This conversation has been locked."
+                        />
+                      )}
+                  </Detail>
+                </Content>
+
+                {this.renderChatInputOrUpsell()}
+              </ThreadContentView>
+            </ThreadViewContainer>
+          </SentryErrorBoundary>
+        );
+
+      return (
+        <SentryErrorBoundary>
           <ThreadViewContainer
             data-cy="thread-view"
             constrain={
@@ -379,10 +478,8 @@ class ThreadContainer extends React.Component<Props, State> {
 
             <ThreadContentView slider={slider}>
               <Head
-                title={`The Watercooler · ${thread.community.name}`}
-                description={`Watercooler chat for the ${
-                  thread.community.name
-                } community`}
+                title={title}
+                description={description}
                 image={thread.community.profilePhoto}
               />
               <Titlebar
@@ -395,26 +492,15 @@ class ThreadContainer extends React.Component<Props, State> {
               />
               <Content innerRef={this.setMessagesContainer}>
                 <Detail type={slider ? '' : 'only'}>
-                  <WatercoolerIntroContainer>
-                    <WatercoolerAvatar
-                      src={thread.community.profilePhoto}
-                      community
-                      size={44}
-                      radius={8}
-                    />
-                    <WatercoolerTitle>
-                      The {thread.community.name} watercooler
-                    </WatercoolerTitle>
-                    <WatercoolerDescription>
-                      Welcome to the {thread.community.name} watercooler, a new
-                      space for general chat with everyone in the community.
-                      Jump in to the conversation below or introduce yourself!
-                    </WatercoolerDescription>
-                  </WatercoolerIntroContainer>
-
-                  <WatercoolerActionBar
+                  <ThreadCommunityBanner
+                    hide={threadViewContext === 'fullscreen'}
                     thread={thread}
-                    currentUser={currentUser}
+                  />
+
+                  <ThreadDetail
+                    toggleEdit={this.toggleEdit}
+                    thread={thread}
+                    slider={slider}
                   />
 
                   {!isEditing && (
@@ -428,11 +514,13 @@ class ThreadContainer extends React.Component<Props, State> {
                       forceScrollToBottom={this.forceScrollToBottom}
                       forceScrollToTop={this.forceScrollToTop}
                       contextualScrollToBottom={this.contextualScrollToBottom}
-                      shouldForceScrollOnMessageLoad={true}
-                      shouldForceScrollToTopOnMessageLoad={false}
+                      shouldForceScrollOnMessageLoad={isParticipantOrAuthor}
+                      shouldForceScrollToTopOnMessageLoad={
+                        !isParticipantOrAuthor
+                      }
                       hasMessagesToLoad={thread.messageCount > 0}
                       isModerator={isModerator}
-                      isWatercooler={true}
+                      threadIsLocked={isLocked}
                     />
                   )}
 
@@ -449,84 +537,7 @@ class ThreadContainer extends React.Component<Props, State> {
               {this.renderChatInputOrUpsell()}
             </ThreadContentView>
           </ThreadViewContainer>
-        );
-
-      return (
-        <ThreadViewContainer
-          data-cy="thread-view"
-          constrain={
-            threadViewContext === 'slider' || threadViewContext === 'fullscreen'
-          }
-          threadViewContext={threadViewContext}
-        >
-          {shouldRenderThreadSidebar && (
-            <Sidebar
-              thread={thread}
-              currentUser={currentUser}
-              slug={thread.community.slug}
-              id={thread.community.id}
-            />
-          )}
-
-          <ThreadContentView slider={slider}>
-            <Head
-              title={title}
-              description={description}
-              image={thread.community.profilePhoto}
-            />
-            <Titlebar
-              title={thread.content.title}
-              subtitle={`${thread.community.name} / ${thread.channel.name}`}
-              provideBack={true}
-              backRoute={'/'}
-              noComposer
-              style={{ gridArea: 'header' }}
-            />
-            <Content innerRef={this.setMessagesContainer}>
-              <Detail type={slider ? '' : 'only'}>
-                <ThreadCommunityBanner
-                  hide={threadViewContext === 'fullscreen'}
-                  thread={thread}
-                />
-
-                <ThreadDetail
-                  toggleEdit={this.toggleEdit}
-                  thread={thread}
-                  slider={slider}
-                />
-
-                {!isEditing && (
-                  <Messages
-                    threadMessageCount={thread.messageCount}
-                    id={thread.id}
-                    scrollContainer={this.state.messagesContainer}
-                    currentUser={currentUser}
-                    lastSeen={lastSeen}
-                    lastActive={lastActive}
-                    forceScrollToBottom={this.forceScrollToBottom}
-                    forceScrollToTop={this.forceScrollToTop}
-                    contextualScrollToBottom={this.contextualScrollToBottom}
-                    shouldForceScrollOnMessageLoad={isParticipantOrAuthor}
-                    shouldForceScrollToTopOnMessageLoad={!isParticipantOrAuthor}
-                    hasMessagesToLoad={thread.messageCount > 0}
-                    isModerator={isModerator}
-                    threadIsLocked={isLocked}
-                  />
-                )}
-
-                {!isEditing &&
-                  isLocked && (
-                    <NullState
-                      icon="private"
-                      copy="This conversation has been locked."
-                    />
-                  )}
-              </Detail>
-            </Content>
-
-            {this.renderChatInputOrUpsell()}
-          </ThreadContentView>
-        </ThreadViewContainer>
+        </SentryErrorBoundary>
       );
     }
 
@@ -535,25 +546,27 @@ class ThreadContainer extends React.Component<Props, State> {
     }
 
     return (
-      <ThreadViewContainer
-        threadViewContext={threadViewContext}
-        data-cy="null-thread-view"
-      >
-        <ThreadContentView
+      <SentryErrorBoundary>
+        <ThreadViewContainer
           threadViewContext={threadViewContext}
-          slider={slider}
+          data-cy="null-thread-view"
         >
-          <ViewError
-            heading={'We had trouble loading this thread.'}
-            subheading={
-              !hasError
-                ? 'It may be private, or may have been deleted by an author or moderator.'
-                : ''
-            }
-            refresh={hasError}
-          />
-        </ThreadContentView>
-      </ThreadViewContainer>
+          <ThreadContentView
+            threadViewContext={threadViewContext}
+            slider={slider}
+          >
+            <ViewError
+              heading={'We had trouble loading this thread.'}
+              subheading={
+                !hasError
+                  ? 'It may be private, or may have been deleted by an author or moderator.'
+                  : ''
+              }
+              refresh={hasError}
+            />
+          </ThreadContentView>
+        </ThreadViewContainer>
+      </SentryErrorBoundary>
     );
   }
 }

--- a/src/views/threadSlider/index.js
+++ b/src/views/threadSlider/index.js
@@ -17,6 +17,7 @@ import {
 } from './style';
 import Icon from '../../components/icons';
 import ThreadContainer from '../thread';
+import { SentryErrorBoundary } from 'src/components/error';
 
 const ANIMATION_DURATION = 50;
 
@@ -60,49 +61,51 @@ class ThreadSlider extends Component {
     const threadId = parsed.thread;
 
     return (
-      <div>
-        <Transition in={!!threadId} timeout={ANIMATION_DURATION}>
-          {state => (
-            <div>
-              {threadId && (
-                <Container>
-                  <Link
-                    to={this.props.location.pathname}
-                    onClick={this.closeSlider}
-                  >
-                    <Overlay
-                      entering={state === 'entering'}
-                      entered={state === 'entered'}
-                      duration={ANIMATION_DURATION}
-                    />
-                  </Link>
-                  <Thread
-                    entering={state === 'entering'}
-                    entered={state === 'entered'}
-                    duration={ANIMATION_DURATION}
-                  >
-                    <Close
+      <SentryErrorBoundary>
+        <div>
+          <Transition in={!!threadId} timeout={ANIMATION_DURATION}>
+            {state => (
+              <div>
+                {threadId && (
+                  <Container>
+                    <Link
                       to={this.props.location.pathname}
                       onClick={this.closeSlider}
                     >
-                      <CloseLabel>Close</CloseLabel>
-                      <CloseButton>
-                        <Icon glyph="view-forward" size={24} />
-                      </CloseButton>
-                    </Close>
+                      <Overlay
+                        entering={state === 'entering'}
+                        entered={state === 'entered'}
+                        duration={ANIMATION_DURATION}
+                      />
+                    </Link>
+                    <Thread
+                      entering={state === 'entering'}
+                      entered={state === 'entered'}
+                      duration={ANIMATION_DURATION}
+                    >
+                      <Close
+                        to={this.props.location.pathname}
+                        onClick={this.closeSlider}
+                      >
+                        <CloseLabel>Close</CloseLabel>
+                        <CloseButton>
+                          <Icon glyph="view-forward" size={24} />
+                        </CloseButton>
+                      </Close>
 
-                    <ThreadContainer
-                      threadId={threadId}
-                      threadViewContext={'slider'}
-                      slider
-                    />
-                  </Thread>
-                </Container>
-              )}
-            </div>
-          )}
-        </Transition>
-      </div>
+                      <ThreadContainer
+                        threadId={threadId}
+                        threadViewContext={'slider'}
+                        slider
+                      />
+                    </Thread>
+                  </Container>
+                )}
+              </div>
+            )}
+          </Transition>
+        </div>
+      </SentryErrorBoundary>
     );
   }
 }

--- a/src/views/threadSlider/index.js
+++ b/src/views/threadSlider/index.js
@@ -17,7 +17,7 @@ import {
 } from './style';
 import Icon from '../../components/icons';
 import ThreadContainer from '../thread';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 const ANIMATION_DURATION = 50;
 
@@ -61,7 +61,7 @@ class ThreadSlider extends Component {
     const threadId = parsed.thread;
 
     return (
-      <SentryErrorBoundary>
+      <ErrorBoundary>
         <div>
           <Transition in={!!threadId} timeout={ANIMATION_DURATION}>
             {state => (
@@ -105,7 +105,7 @@ class ThreadSlider extends Component {
             )}
           </Transition>
         </div>
-      </SentryErrorBoundary>
+      </ErrorBoundary>
     );
   }
 }

--- a/src/views/user/index.js
+++ b/src/views/user/index.js
@@ -36,6 +36,7 @@ import {
   DesktopSegment,
   MobileSegment,
 } from '../../components/segmentedControl';
+import { SentryErrorBoundary } from 'src/components/error';
 
 const ThreadFeedWithData = compose(connect(), getUserThreads)(ThreadFeed);
 const ThreadParticipantFeedWithData = compose(connect(), getUserThreads)(
@@ -151,11 +152,13 @@ class UserView extends React.Component<Props, State> {
           <Grid id="main">
             <CoverPhoto src={user.coverPhoto} />
             <Meta>
-              <UserProfile
-                data={{ user }}
-                username={username}
-                profileSize="full"
-              />
+              <SentryErrorBoundary fallbackComponent={null}>
+                <UserProfile
+                  data={{ user }}
+                  username={username}
+                  profileSize="full"
+                />
+              </SentryErrorBoundary>
 
               {currentUser &&
                 user.id !== currentUser.id && (
@@ -169,14 +172,17 @@ class UserView extends React.Component<Props, State> {
                     <LoginButton isMember>My settings</LoginButton>
                   </Link>
                 )}
-              <MetaMemberships>
-                <ColumnHeading>Member of</ColumnHeading>
-                <CommunityList
-                  currentUser={currentUser}
-                  user={user}
-                  id={user.id}
-                />
-              </MetaMemberships>
+
+              <SentryErrorBoundary fallbackComponent={null}>
+                <MetaMemberships>
+                  <ColumnHeading>Member of</ColumnHeading>
+                  <CommunityList
+                    currentUser={currentUser}
+                    user={user}
+                    id={user.id}
+                  />
+                </MetaMemberships>
+              </SentryErrorBoundary>
             </Meta>
             <Content>
               <SegmentedControl style={{ margin: '16px 0 0 0' }}>
@@ -245,12 +251,14 @@ class UserView extends React.Component<Props, State> {
               {!hasThreads && <NullState bg="null" heading={nullHeading} />}
             </Content>
             <Extras>
-              <ColumnHeading>Member of</ColumnHeading>
-              <CommunityList
-                currentUser={currentUser}
-                user={user}
-                id={user.id}
-              />
+              <SentryErrorBoundary fallbackComponent={null}>
+                <ColumnHeading>Member of</ColumnHeading>
+                <CommunityList
+                  currentUser={currentUser}
+                  user={user}
+                  id={user.id}
+                />
+              </SentryErrorBoundary>
             </Extras>
           </Grid>
         </AppViewWrapper>

--- a/src/views/user/index.js
+++ b/src/views/user/index.js
@@ -36,7 +36,7 @@ import {
   DesktopSegment,
   MobileSegment,
 } from '../../components/segmentedControl';
-import { SentryErrorBoundary } from 'src/components/error';
+import { ErrorBoundary } from 'src/components/error';
 
 const ThreadFeedWithData = compose(connect(), getUserThreads)(ThreadFeed);
 const ThreadParticipantFeedWithData = compose(connect(), getUserThreads)(
@@ -152,13 +152,13 @@ class UserView extends React.Component<Props, State> {
           <Grid id="main">
             <CoverPhoto src={user.coverPhoto} />
             <Meta>
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <UserProfile
                   data={{ user }}
                   username={username}
                   profileSize="full"
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
 
               {currentUser &&
                 user.id !== currentUser.id && (
@@ -173,7 +173,7 @@ class UserView extends React.Component<Props, State> {
                   </Link>
                 )}
 
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <MetaMemberships>
                   <ColumnHeading>Member of</ColumnHeading>
                   <CommunityList
@@ -182,7 +182,7 @@ class UserView extends React.Component<Props, State> {
                     id={user.id}
                   />
                 </MetaMemberships>
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             </Meta>
             <Content>
               <SegmentedControl style={{ margin: '16px 0 0 0' }}>
@@ -251,14 +251,14 @@ class UserView extends React.Component<Props, State> {
               {!hasThreads && <NullState bg="null" heading={nullHeading} />}
             </Content>
             <Extras>
-              <SentryErrorBoundary fallbackComponent={null}>
+              <ErrorBoundary fallbackComponent={null}>
                 <ColumnHeading>Member of</ColumnHeading>
                 <CommunityList
                   currentUser={currentUser}
                   user={user}
                   id={user.id}
                 />
-              </SentryErrorBoundary>
+              </ErrorBoundary>
             </Extras>
           </Grid>
         </AppViewWrapper>

--- a/src/views/userSettings/components/overview.js
+++ b/src/views/userSettings/components/overview.js
@@ -9,6 +9,7 @@ import DeleteAccountForm from './deleteAccountForm';
 import DownloadDataForm from './downloadDataForm';
 import RecurringPaymentsList from './recurringPaymentsList';
 import { SectionsContainer, Column } from 'src/components/settingsViews/style';
+import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   user: GetCurrentUserSettingsType,
@@ -21,16 +22,35 @@ class Overview extends React.Component<Props> {
     return (
       <SectionsContainer>
         <Column>
-          <UserEditForm user={user} />
-          <DeleteAccountForm id={user.id} />
-          <DownloadDataForm user={user} />
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <UserEditForm user={user} />
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <DeleteAccountForm id={user.id} />
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <DownloadDataForm user={user} />
+          </SentryErrorBoundary>
         </Column>
         <Column>
-          <RecurringPaymentsList user={user} />
-          <EmailSettings user={user} />
-          {'serviceWorker' in navigator &&
-            'PushManager' in window && <NotificationSettings largeOnly />}
-          <Invoices />
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <RecurringPaymentsList user={user} />
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <EmailSettings user={user} />
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            {'serviceWorker' in navigator &&
+              'PushManager' in window && <NotificationSettings largeOnly />}
+          </SentryErrorBoundary>
+
+          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+            <Invoices />
+          </SentryErrorBoundary>
         </Column>
       </SectionsContainer>
     );

--- a/src/views/userSettings/components/overview.js
+++ b/src/views/userSettings/components/overview.js
@@ -9,7 +9,7 @@ import DeleteAccountForm from './deleteAccountForm';
 import DownloadDataForm from './downloadDataForm';
 import RecurringPaymentsList from './recurringPaymentsList';
 import { SectionsContainer, Column } from 'src/components/settingsViews/style';
-import { SentryErrorBoundary, SettingsFallback } from 'src/components/error';
+import { ErrorBoundary, SettingsFallback } from 'src/components/error';
 
 type Props = {
   user: GetCurrentUserSettingsType,
@@ -22,35 +22,35 @@ class Overview extends React.Component<Props> {
     return (
       <SectionsContainer>
         <Column>
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <UserEditForm user={user} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <DeleteAccountForm id={user.id} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <DownloadDataForm user={user} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         </Column>
         <Column>
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <RecurringPaymentsList user={user} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <EmailSettings user={user} />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             {'serviceWorker' in navigator &&
               'PushManager' in window && <NotificationSettings largeOnly />}
-          </SentryErrorBoundary>
+          </ErrorBoundary>
 
-          <SentryErrorBoundary fallbackComponent={SettingsFallback}>
+          <ErrorBoundary fallbackComponent={SettingsFallback}>
             <Invoices />
-          </SentryErrorBoundary>
+          </ErrorBoundary>
         </Column>
       </SectionsContainer>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8966,10 +8966,6 @@ react-dom@16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-error-boundary@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-1.2.1.tgz#60600750bf2ec03ca22a1e933ea371f38aa20fa3"
-
 react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

@mxstbr would love your feedback on this. Basically I want to make sure that issues like #3127 don't crash the entire app - obviously we have a lot of components that have the possibility of throwing errors, and if those bubble up to the top level error boundary in `routes.js` it means the whole app is in an error state.

So I went through and wrapped a bunch of components in error boundaries. The granularity here is up to us, but my philosophy here was: what are the things that we can live with silently failing in order to preserve the core experience? E.g. if a single message crashes, we error that message not the whole thread. If you're viewing a community and the channel list crashes, we don't error the whole community view. A large result of this mindset is failing individual items in lists - e.g. threads, channels, users, etc. so that if one item in a list fails we don't take the whole list down with it.

Anyways - open to feedback here both on implementation of the error boundary and the granularity of implementation. Hopefully this will help provide a bit more stability around core experiences (reading threads, writing messages) even if tertiary components fail for some reason.