### PR TITLE
Flaky cypress test

### DIFF
--- a/cypress/integration/community/view/profile_spec.js
+++ b/cypress/integration/community/view/profile_spec.js
@@ -167,7 +167,6 @@ describe('public community signed in without permission', () => {
       .contains(`Join ${publicCommunity.name}`)
       .click();
 
-    cy.get('[data-cy="join-community-button"]').should('be.disabled');
     cy.get('[data-cy="join-community-button"]').should('not.be.disabled');
 
     cy
@@ -175,12 +174,10 @@ describe('public community signed in without permission', () => {
       .contains(`Member`)
       .click();
 
-    cy.get('[data-cy="join-community-button"]').should('be.disabled');
-    cy.get('[data-cy="join-community-button"]').should('not.be.disabled');
-
     cy
       .get('[data-cy="join-community-button"]')
-      .contains(`Join ${publicCommunity.name}`);
+      .contains(`Join ${publicCommunity.name}`)
+      .should('not.be.disabled');
   });
 });
 


### PR DESCRIPTION
Tiny PR: was looking through the E2E tests and this one kept failing locally. If it wasn't failing the CI build previously, I imagine it's due to a difference in machine specs.

Problem was that the `cy.get('[data-cy="join-community-button"]').should('be.disabled');` was getting invoked too late. Sequence that occurred:

1. Test clicks button, invokes async request
2. Button becomes disabled
3. Async request returns, button becomes enabled
4. Test begins waiting for button to become disabled

Sometimes happened on the first `.should('be.disabled')`, sometimes on the second. With the changes, haven't experienced any failures.

Screenshot of failure prior to change:

![flaky test](https://www.evernote.com/shard/s74/sh/408a5cfb-4456-4786-9a18-ee476a68b494/fbef3a163ec40f5a/res/d134e91e-153e-46cc-97f4-43692de27c1e/skitch.png?resizeSmall&width=832)

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [X] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
N/A

<!--

If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.

-->
