### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/cypress/integration/channel/settings/edit_spec.js
+++ b/cypress/integration/channel/settings/edit_spec.js
@@ -41,10 +41,6 @@ describe('edit a channel', () => {
       .should('be.visible')
       .click();
 
-    cy.get('[data-cy="save-button"]').should('be.disabled');
-
-    cy.get('[data-cy="save-button"]').should('not.be.disabled');
-
     cy.visit(`/${community.slug}/${channel.slug}`);
     cy.get('[data-cy="channel-profile-full"]').should('be.visible');
     cy.get('[data-cy="channel-profile-full"]').contains(NEW_NAME);

--- a/cypress/integration/channel/view/membership_spec.js
+++ b/cypress/integration/channel/view/membership_spec.js
@@ -35,10 +35,6 @@ const leave = () => {
 
   cy.get('[data-cy="channel-join-button"]').click();
 
-  cy.get('[data-cy="channel-join-button"]').should('be.disabled');
-
-  cy.get('[data-cy="channel-join-button"]').should('not.be.disabled');
-
   cy.get('[data-cy="channel-join-button"]').contains(`Join `);
 };
 
@@ -49,10 +45,6 @@ const join = () => {
     .contains('Join ');
 
   cy.get('[data-cy="channel-join-button"]').click();
-
-  cy.get('[data-cy="channel-join-button"]').should('be.disabled');
-
-  cy.get('[data-cy="channel-join-button"]').should('not.be.disabled');
 
   cy.get('[data-cy="channel-join-button"]').contains(`Joined`);
 };

--- a/cypress/integration/community/settings/private_invite_link_spec.js
+++ b/cypress/integration/community/settings/private_invite_link_spec.js
@@ -41,9 +41,6 @@ describe('private community invite link settings', () => {
 
         cy.get('[data-cy="refresh-join-link-token"]').click();
 
-        cy.get('[data-cy="refresh-join-link-token"]').should('be.disabled');
-        cy.get('[data-cy="refresh-join-link-token"]').should('not.be.disabled');
-
         // grab the input again and compare its previous value
         // to the current value
         cy

--- a/cypress/integration/thread/action_bar_spec.js
+++ b/cypress/integration/thread/action_bar_spec.js
@@ -197,8 +197,6 @@ describe('action bar renders', () => {
         .clear()
         .type(title);
       cy.get('[data-cy="save-thread-edit-button"]').click();
-      cy.get('[data-cy="save-thread-edit-button"]').should('be.disabled');
-      cy.get('[data-cy="save-thread-edit-button"]').should('not.be.disabled');
       cy.get('[data-cy="thread-view"]');
       cy.contains(title);
 
@@ -212,8 +210,6 @@ describe('action bar renders', () => {
         .clear()
         .type(originalTitle);
       cy.get('[data-cy="save-thread-edit-button"]').click();
-      cy.get('[data-cy="save-thread-edit-button"]').should('be.disabled');
-      cy.get('[data-cy="save-thread-edit-button"]').should('not.be.disabled');
       cy.get('[data-cy="thread-view"]');
       cy.contains('The first thread! 🎉');
     });


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

This pattern of "button-is-disabled then button-is-no-longer-disabled" broke pretty often in CI due to the race condition where the network would be faster than Cypress and the button would only be disabled for a split second.

Removing that pattern entirely should fix the e2e test flakiness we've been seeing.

Shoutout to @tadasant who discovered this in #3168, this is just another step further removing all instances of that pattern.

/cc @brianlovin for awareness

/cc @bahmutov maybe this would be worth adding to the docs as an anti-pattern?