### PR TITLE
Continuous deployment for desktop app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,16 @@ jobs:
           name: Deploy and alias Hyperion
           command: npx now-cd --alias "alpha=hyperion.alpha.spectrum.chat" --team spaceprogram
 
+  deploy_desktop:
+    <<: *js_defaults
+    docker:
+      - image: circleci/node:8
+    steps:
+      - attach_workspace:
+          at: ~/spectrum
+      - run:
+          name: Build and release desktop app
+          command: yarn run release:desktop
 
   # Run eslint, flow etc.
   test_static_js:
@@ -212,3 +222,10 @@ workflows:
           filters:
             branches:
               only: alpha
+      - deploy_desktop:
+          requires:
+            - test_static_js
+            - test_web
+          filters:
+            branches:
+              only: production

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,16 +1,12 @@
 # Desktop
 
-**This folder contains all sources used to build spectrum desktop application.**
-
-The project uses [Electron](https://electronjs.org/) to build cross platform desktop apps with JavaScript, HTML, and CSS.
+This folder contains the [Electron](https://electronjs.org/)-based desktop app for Spectrum. Electron renders a web view, which renders the main `Spectrum.chat` webpage.
 
 ## Directory Structure
 
-* `release/` - the release build for each platform (mac, win, linux).
-* `resources/` - the resources folder (icons, images ...).
-* `src/` the source code of electron application.
-* `package.json` - dependencies & devdependencies.
-* `yarn.lock` - Yarn lockfile to get consistent installs across machine.
+* `release/` - the release build for each platform (mac, win, linux)
+* `resources/` - the resources folder (icons, images ...)
+* `src/` the source code of electron application
 
 ## Scripts
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -35,6 +35,9 @@
     "appId": "chat.spectrum",
     "copyright": "Copyright © 2018 Space Program Inc.",
     "publish": "github",
+    "releaseInfo": {
+      "releaseName": "${name} Desktop App v${version}"
+    },
     "files": [
       "src/**/*",
       "node_modules/**/*",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -6,7 +6,8 @@
     "name": "Space Program Inc.",
     "email": "hey@spectrum.chat"
   },
-  "version": "1.0.0",
+  "repository": "https://github.com/withspectrum/spectrum",
+  "version": "1.0.0-beta.1",
   "main": "src/main.js",
   "private": true,
   "dependencies": {
@@ -16,21 +17,24 @@
   },
   "devDependencies": {
     "electron": "^1.8.4",
-    "electron-builder": "^20.8.1"
+    "electron-builder": "^20.8.1",
+    "rimraf": "^2.6.2"
   },
   "scripts": {
     "dev": "electron ./src/main.js",
-    "package": "build --dir",
-    "package:mac": "build --mac",
-    "package:linux": "build --linux",
-    "package:win": "build --win --x64",
-    "package:all": "build -mwl",
-    "ship": "build -p always"
+    "prepackage": "rimraf release",
+    "package": "build",
+    "package:mac": "yarn run package --mac",
+    "package:linux": "yarn run package --linux",
+    "package:win": "yarn run package --win --x64",
+    "package:all": "yarn run package -mwl",
+    "release": "yarn run package:all --publish always"
   },
   "build": {
     "productName": "Spectrum",
     "appId": "chat.spectrum",
     "copyright": "Copyright © 2018 Space Program Inc.",
+    "publish": "github",
     "files": [
       "src/**/*",
       "node_modules/**/*",

--- a/desktop/resources/release-notes.md
+++ b/desktop/resources/release-notes.md
@@ -1,0 +1,12 @@
+<!-- PUT MORE INFO ABOUT CHANGES IN THIS RELEASE HERE -->
+
+
+<!-- NOTE: LEAVE THE BELOW TEXT ALONE -->
+----
+- **If you've already downloaded the app you don't need to download it again!** You will automatically get prompted to upgrade to new versions
+- If you're installing the app for the first time, download the right file for your operating system and execute it:
+  - MacOS: `Spectrum-{version}-mac.zip`
+  - Windows: `Spectrum-{version}.exe`
+  - Linux: `Spectrum-{version}_amd64.deb` or `Spectrum-{version}-x86_64.AppImage`
+
+Enjoy!

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -1553,7 +1553,7 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
-rimraf@^2.2.8:
+rimraf@^2.2.8, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:

--- a/package.json
+++ b/package.json
@@ -248,6 +248,7 @@
     "postbuild:hyperion": "cp now.json build-hyperion/now.json",
     "build:web": "cross-env NODE_PATH=./ react-app-rewired build",
     "build:desktop": "(cd desktop && yarn run package:all)",
+    "release:desktop": "(cd desktop && yarn run release)",
     "jest": "cross-env NODE_PATH=./ jest",
     "test": "npm run jest -- --runInBand --watch",
     "test:ci": "npm run jest -- --forceExit --outputFile test-results.json --json --maxWorkers=2",


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

This sets up continuous deployment for the desktop app. The way this works is as follows:

1. We merge the latest changes from `alpha` to `production`
2. This prompts a CircleCI build, which packages all the apps and uploads them to GitHub as a draft release that looks like this:

  ![screen shot 2018-05-30 at 15 42 22](https://user-images.githubusercontent.com/7525670/40724411-4b5fe9ec-6421-11e8-8e4b-d0df96b46f72.png)

3. Test the app locally, if you're happy with how it works click the "Edit" button on the draft release and you get to this screen:

  ![screenshot-2018-5-30 withspectrum spectrum](https://user-images.githubusercontent.com/7525670/40724488-77256642-6421-11e8-9911-999ed0fa5957.png)

4. Fill out the title and release notes of the release (like I've already done above), then click "Publish release"

This is what it'll look like once published: https://github.com/withspectrum/spectrum/releases/tag/v1.0.0-beta.1 As soon as it's published, the app will prompt existing users to upgrade to the newest version and download and install it for them.

> Note: I haven't been able to test the CI part of this whole thing, but from my local testing (which is how I generated the release above) it _should_ work!
