### PR TITLE
Run desktop CD from the alpha branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,10 +201,11 @@ workflows:
   test:
     jobs:
       - checkout_environment
+
+      # Testing
       - test_mobile_js:
           requires:
             - checkout_environment
-
       # Disabled as Expo is fixing their critical issue with Detox
       # - test_mobile_native:
       #     requires:
@@ -215,6 +216,8 @@ workflows:
       - test_static_js:
           requires:
             - checkout_environment
+
+      # Deployment
       - deploy_alpha:
           requires:
             - test_static_js
@@ -228,4 +231,4 @@ workflows:
             - test_web
           filters:
             branches:
-              only: production
+              only: alpha


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

As @brianlovin noticed in #3199, the CD for the desktop app wasn't working because CircleCI only runs builds for commits that are associated with a PR.

While we could set CircleCI to run builds for all branches, that's a very suboptimal solution as it would run a ton of unnecessary builds.

I came to wondering, why does the CD for alpha work if it doesn't build branches? Hidden in the CircleCI docs I found this snippet:

> Note: For your default branch, we will always build all commits.

Which explains why alpha CD works, but production CD doesn't.

This patch is a very simple solution to this problem: we run desktop CD on the alpha branch. That is fine because the desktop CD only creates a draft GitHub release and we have to manually publish that release for anybody to get the update, so it doesn't matter if we CD from alpha or production!