### PR TITLE
Don't server-side render for desktop app

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -88,7 +88,7 @@ module.exports = function override(config, env) {
   config.plugins.push(
     new webpack.optimize.CommonsChunkPlugin({
       names: ['bootstrap'],
-      filename: './static/js/[name].js',
+      filename: 'static/js/[name].js',
       minChunks: Infinity,
     })
   );

--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -146,6 +146,14 @@ if (process.env.NODE_ENV === 'development') {
   );
 }
 
+app.get('*', (req: express$Request, res, next) => {
+  // Electron requests should only be client-side rendered
+  if (req.headers['user-agent'].indexOf('Electron') > -1) {
+    return res.sendFile(path.resolve(__dirname, '../build/index.html'));
+  }
+  next();
+});
+
 import cache from './cache';
 app.use(cache);
 


### PR DESCRIPTION
The desktop app requests the same paths as the browser would, which
means previously it would also get the server-side rendered HTML.

The problem is that the server-side rendered frontend doesn't know that
it's being rendered for the desktop app, and thusly renders the standard
frontend, which looks crappy in the desktop app.

This patch disables server-side rendering enterily when a req from the
desktop app comes in, which fixes that issue.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Maybe fixes #3210