### PR TITLE
ajust desktop draggable region area

### DIFF
--- a/src/views/navbar/components/messagesTab.js
+++ b/src/views/navbar/components/messagesTab.js
@@ -9,7 +9,7 @@ import { updateNotificationsCount } from 'src/actions/notifications';
 import getUnreadDMQuery from 'shared/graphql/queries/notification/getDirectMessageNotifications';
 import type { GetDirectMessageNotificationsType } from 'shared/graphql/queries/notification/getDirectMessageNotifications';
 import markDirectMessageNotificationsSeenMutation from 'shared/graphql/mutations/notification/markDirectMessageNotificationsSeen';
-import { MessageTab, Label } from '../style';
+import { Tab, Label } from '../style';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
 
@@ -209,7 +209,7 @@ class MessagesTab extends React.Component<Props, State> {
     }
 
     return (
-      <MessageTab
+      <Tab
         data-active={active}
         aria-current={active ? 'page' : undefined}
         to="/messages"
@@ -226,7 +226,7 @@ class MessagesTab extends React.Component<Props, State> {
           size={isDesktopApp() ? 28 : 32}
         />
         <Label>Messages</Label>
-      </MessageTab>
+      </Tab>
     );
   }
 }

--- a/src/views/navbar/components/messagesTab.js
+++ b/src/views/navbar/components/messagesTab.js
@@ -9,7 +9,7 @@ import { updateNotificationsCount } from 'src/actions/notifications';
 import getUnreadDMQuery from 'shared/graphql/queries/notification/getDirectMessageNotifications';
 import type { GetDirectMessageNotificationsType } from 'shared/graphql/queries/notification/getDirectMessageNotifications';
 import markDirectMessageNotificationsSeenMutation from 'shared/graphql/mutations/notification/markDirectMessageNotificationsSeen';
-import { Tab, Label } from '../style';
+import { MessageTab, Label } from '../style';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
 
@@ -209,7 +209,7 @@ class MessagesTab extends React.Component<Props, State> {
     }
 
     return (
-      <Tab
+      <MessageTab
         data-active={active}
         aria-current={active ? 'page' : undefined}
         to="/messages"
@@ -226,7 +226,7 @@ class MessagesTab extends React.Component<Props, State> {
           size={isDesktopApp() ? 28 : 32}
         />
         <Label>Messages</Label>
-      </Tab>
+      </MessageTab>
     );
   }
 }

--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -21,7 +21,6 @@ import {
   Label,
   Navatar,
   SkipLink,
-  DraggableRegion,
 } from './style';
 import { track, events } from 'src/helpers/analytics';
 import { isViewingMarketingPage } from 'src/helpers/is-viewing-marketing-page';
@@ -142,7 +141,6 @@ class Navbar extends React.Component<Props, State> {
     if (loggedInUser) {
       return (
         <Nav hideOnMobile={hideNavOnMobile} data-cy="navbar">
-          {isDesktopApp() && <DraggableRegion />}
           <Head>
             {notificationCounts.directMessageNotifications > 0 ||
             notificationCounts.notifications > 0 ? (
@@ -255,7 +253,6 @@ class Navbar extends React.Component<Props, State> {
           loggedOut={!loggedInUser}
           data-cy="navbar"
         >
-          {isDesktopApp() && <DraggableRegion />}
           <Logo
             to="/"
             aria-hidden

--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -21,6 +21,7 @@ import {
   Label,
   Navatar,
   SkipLink,
+  DraggableRegion,
 } from './style';
 import { track, events } from 'src/helpers/analytics';
 import { isViewingMarketingPage } from 'src/helpers/is-viewing-marketing-page';
@@ -141,6 +142,7 @@ class Navbar extends React.Component<Props, State> {
     if (loggedInUser) {
       return (
         <Nav hideOnMobile={hideNavOnMobile} data-cy="navbar">
+          {isDesktopApp() && <DraggableRegion />}
           <Head>
             {notificationCounts.directMessageNotifications > 0 ||
             notificationCounts.notifications > 0 ? (
@@ -253,6 +255,7 @@ class Navbar extends React.Component<Props, State> {
           loggedOut={!loggedInUser}
           data-cy="navbar"
         >
+          {isDesktopApp() && <DraggableRegion />}
           <Logo
             to="/"
             aria-hidden

--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -235,14 +235,27 @@ export const Logo = styled(Tab)`
 
 export const HomeTab = styled(Tab)`
   grid-area: home;
+  ${isDesktopApp() &&
+    css`
+      -webkit-app-region: no-drag;
+    `};
 `;
 
 export const MessageTab = styled(Tab)`
   grid-area: messages;
+  ${isDesktopApp() &&
+    css`
+      -webkit-app-region: no-drag;
+    `};
 `;
 
 export const ExploreTab = styled(Tab)`
   grid-area: explore;
+
+  ${isDesktopApp() &&
+    css`
+      -webkit-app-region: no-drag;
+    `};
 
   ${props =>
     props.loggedOut &&
@@ -270,6 +283,11 @@ export const PricingTab = styled(MessageTab)`
 export const NotificationTab = styled(DropTab)`
   grid-area: notifications;
 
+  ${isDesktopApp() &&
+    css`
+      -webkit-app-region: no-drag;
+    `};
+
   > a {
     &:hover {
       box-shadow: none;
@@ -280,6 +298,11 @@ export const NotificationTab = styled(DropTab)`
 
 export const ProfileDrop = styled(DropTab)`
   grid-area: profile;
+
+  ${isDesktopApp() &&
+    css`
+      -webkit-app-region: no-drag;
+    `};
 
   > a {
     &:hover {

--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -1,3 +1,4 @@
+// @noflow
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import { Transition, FlexRow, hexa, zIndex } from 'src/components/globals';

--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -1,29 +1,14 @@
-import React from 'react';
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import { Transition, FlexRow, hexa, zIndex } from 'src/components/globals';
 import Avatar from 'src/components/avatar';
 import { isDesktopApp } from 'src/helpers/is-desktop-app';
 
-/**
- * For Desctop App Configuration
- * @see https://github.com/electron/electron/blob/master/docs/api/frameless-window.md#draggable-region
- */
-export const DraggableRegion = () => <div className="draggableRegion" />;
-
 export const Nav = styled.nav`
   display: grid;
   grid-template-columns: repeat(4, auto) 1fr repeat(2, auto);
   grid-template-rows: 1fr;
   grid-template-areas: 'logo home messages explore . notifications profile';
-  ${isDesktopApp() &&
-    css`
-      user-select: none;
-      grid-template-rows: 10px 1fr;
-      grid-template-areas:
-        'draggableRegion draggableRegion draggableRegion draggableRegion draggableRegion draggableRegion draggableRegion'
-        'logo home messages explore . notifications profile';
-    `};
   align-items: stretch;
   width: 100%;
   flex: 0 0 ${isDesktopApp() ? '38px' : '48px'};
@@ -31,14 +16,11 @@ export const Nav = styled.nav`
   line-height: 1;
   box-shadow: 0 4px 8px ${({ theme }) => hexa(theme.bg.reverse, 0.15)};
   z-index: ${zIndex.navBar};
-
-  .draggableRegion {
-    grid-area: draggableRegion;
-    width: 100%;
-    -webkit-app-region: drag;
-    user-select: none;
-  }
-
+  ${isDesktopApp() &&
+    css`
+      -webkit-app-region: drag;
+      user-select: none;
+    `}
   background: ${({ theme }) =>
     process.env.NODE_ENV === 'production' ? theme.bg.reverse : theme.warn.alt};
 
@@ -74,31 +56,12 @@ export const Nav = styled.nav`
         grid-template-areas: 'home explore support pricing';
       }
     `} ${props =>
-    props.hideOnMobile &&
-    css`
-      @media (max-width: 768px) {
-        display: none;
-      }
-    `};
-
-  ${props =>
-    props.loggedOut &&
-    isDesktopApp() &&
-    css`
-      grid-template-columns: auto auto auto auto 1fr;
-      grid-template-rows: 10px 1fr;
-      grid-template-areas:
-        'draggableRegion draggableRegion draggableRegion draggableRegion draggableRegion'
-        'logo explore support pricing .';
-
-      @media (max-width: 768px) {
-        grid-template-columns: auto auto auto auto;
-        grid-template-rows: 10px 1fr;
-        grid-template-areas:
-          'draggableRegion draggableRegion draggableRegion draggableRegion'
-          'home explore support pricing';
-      }
-    `};
+  props.hideOnMobile &&
+  css`
+    @media (max-width: 768px) {
+      display: none;
+    }
+  `};
 `;
 
 export const Label = styled.span`
@@ -249,10 +212,6 @@ export const DropTab = styled(FlexRow)`
 export const Logo = styled(Tab)`
   grid-area: logo;
   padding: ${isDesktopApp() ? '0 32px 0 4px' : '0 24px 0 4px'};
-  ${isDesktopApp() &&
-    css`
-      margin-top: -10px;
-    `};
   color: ${({ theme }) => theme.text.reverse};
   opacity: 1;
 
@@ -276,27 +235,14 @@ export const Logo = styled(Tab)`
 
 export const HomeTab = styled(Tab)`
   grid-area: home;
-  ${isDesktopApp() &&
-    css`
-      margin-top: -10px;
-    `};
 `;
 
 export const MessageTab = styled(Tab)`
   grid-area: messages;
-  ${isDesktopApp() &&
-    css`
-      margin-top: -10px;
-    `};
 `;
 
 export const ExploreTab = styled(Tab)`
   grid-area: explore;
-
-  ${isDesktopApp() &&
-    css`
-      margin-top: -10px;
-    `};
 
   ${props =>
     props.loggedOut &&
@@ -315,27 +261,14 @@ export const ExploreTab = styled(Tab)`
 
 export const SupportTab = styled(Tab)`
   grid-area: support;
-  ${isDesktopApp() &&
-    css`
-      margin-top: -10px;
-    `};
 `;
 
 export const PricingTab = styled(MessageTab)`
   grid-area: pricing;
-  ${isDesktopApp() &&
-    css`
-      margin-top: -10px;
-    `};
 `;
 
 export const NotificationTab = styled(DropTab)`
   grid-area: notifications;
-
-  ${isDesktopApp() &&
-    css`
-      margin-top: -10px;
-    `};
 
   > a {
     &:hover {
@@ -347,11 +280,6 @@ export const NotificationTab = styled(DropTab)`
 
 export const ProfileDrop = styled(DropTab)`
   grid-area: profile;
-
-  ${isDesktopApp() &&
-    css`
-      margin-top: -10px;
-    `};
 
   > a {
     &:hover {

--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -1,14 +1,29 @@
+import React from 'react';
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import { Transition, FlexRow, hexa, zIndex } from 'src/components/globals';
 import Avatar from 'src/components/avatar';
 import { isDesktopApp } from 'src/helpers/is-desktop-app';
 
+/**
+ * For Desctop App Configuration
+ * @see https://github.com/electron/electron/blob/master/docs/api/frameless-window.md#draggable-region
+ */
+export const DraggableRegion = () => <div className="draggableRegion" />;
+
 export const Nav = styled.nav`
   display: grid;
   grid-template-columns: repeat(4, auto) 1fr repeat(2, auto);
   grid-template-rows: 1fr;
   grid-template-areas: 'logo home messages explore . notifications profile';
+  ${isDesktopApp() &&
+    css`
+      user-select: none;
+      grid-template-rows: 10px 1fr;
+      grid-template-areas:
+        'draggableRegion draggableRegion draggableRegion draggableRegion draggableRegion draggableRegion draggableRegion'
+        'logo home messages explore . notifications profile';
+    `};
   align-items: stretch;
   width: 100%;
   flex: 0 0 ${isDesktopApp() ? '38px' : '48px'};
@@ -16,11 +31,14 @@ export const Nav = styled.nav`
   line-height: 1;
   box-shadow: 0 4px 8px ${({ theme }) => hexa(theme.bg.reverse, 0.15)};
   z-index: ${zIndex.navBar};
-  ${isDesktopApp() &&
-    css`
-      -webkit-app-region: drag;
-      user-select: none;
-    `}
+
+  .draggableRegion {
+    grid-area: draggableRegion;
+    width: 100%;
+    -webkit-app-region: drag;
+    user-select: none;
+  }
+
   background: ${({ theme }) =>
     process.env.NODE_ENV === 'production' ? theme.bg.reverse : theme.warn.alt};
 
@@ -56,12 +74,31 @@ export const Nav = styled.nav`
         grid-template-areas: 'home explore support pricing';
       }
     `} ${props =>
-  props.hideOnMobile &&
-  css`
-    @media (max-width: 768px) {
-      display: none;
-    }
-  `};
+    props.hideOnMobile &&
+    css`
+      @media (max-width: 768px) {
+        display: none;
+      }
+    `};
+
+  ${props =>
+    props.loggedOut &&
+    isDesktopApp() &&
+    css`
+      grid-template-columns: auto auto auto auto 1fr;
+      grid-template-rows: 10px 1fr;
+      grid-template-areas:
+        'draggableRegion draggableRegion draggableRegion draggableRegion draggableRegion'
+        'logo explore support pricing .';
+
+      @media (max-width: 768px) {
+        grid-template-columns: auto auto auto auto;
+        grid-template-rows: 10px 1fr;
+        grid-template-areas:
+          'draggableRegion draggableRegion draggableRegion draggableRegion'
+          'home explore support pricing';
+      }
+    `};
 `;
 
 export const Label = styled.span`
@@ -212,6 +249,10 @@ export const DropTab = styled(FlexRow)`
 export const Logo = styled(Tab)`
   grid-area: logo;
   padding: ${isDesktopApp() ? '0 32px 0 4px' : '0 24px 0 4px'};
+  ${isDesktopApp() &&
+    css`
+      margin-top: -10px;
+    `};
   color: ${({ theme }) => theme.text.reverse};
   opacity: 1;
 
@@ -235,14 +276,27 @@ export const Logo = styled(Tab)`
 
 export const HomeTab = styled(Tab)`
   grid-area: home;
+  ${isDesktopApp() &&
+    css`
+      margin-top: -10px;
+    `};
 `;
 
 export const MessageTab = styled(Tab)`
   grid-area: messages;
+  ${isDesktopApp() &&
+    css`
+      margin-top: -10px;
+    `};
 `;
 
 export const ExploreTab = styled(Tab)`
   grid-area: explore;
+
+  ${isDesktopApp() &&
+    css`
+      margin-top: -10px;
+    `};
 
   ${props =>
     props.loggedOut &&
@@ -261,14 +315,27 @@ export const ExploreTab = styled(Tab)`
 
 export const SupportTab = styled(Tab)`
   grid-area: support;
+  ${isDesktopApp() &&
+    css`
+      margin-top: -10px;
+    `};
 `;
 
 export const PricingTab = styled(MessageTab)`
   grid-area: pricing;
+  ${isDesktopApp() &&
+    css`
+      margin-top: -10px;
+    `};
 `;
 
 export const NotificationTab = styled(DropTab)`
   grid-area: notifications;
+
+  ${isDesktopApp() &&
+    css`
+      margin-top: -10px;
+    `};
 
   > a {
     &:hover {
@@ -280,6 +347,11 @@ export const NotificationTab = styled(DropTab)`
 
 export const ProfileDrop = styled(DropTab)`
   grid-area: profile;
+
+  ${isDesktopApp() &&
+    css`
+      margin-top: -10px;
+    `};
 
   > a {
     &:hover {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- desktop

**Release notes for users (delete if codebase-only change)**
- ajust desctop draggable region area

## overview

When, "home", "Messages", "Explore" Clicked, Electron reacting as a draggableRegion.
this is might be give a slightly frustration if user doesn't expected drag window.
so, this commit ajusted draggable region area to 10px of navbar top;

## Image
highlight element is the draggable area.

### Not Login
<img width="1263" alt="screen shot 2018-06-01 at 6 43 33" src="https://user-images.githubusercontent.com/5501268/40810753-c3b70af8-6569-11e8-9c20-3467c229696d.png">


### Login
<img width="1279" alt="screen shot 2018-06-01 at 6 51 08" src="https://user-images.githubusercontent.com/5501268/40810758-c85ef4e4-6569-11e8-9022-b10183e28662.png">

thnak you for your every feedbacks😄✨