### PR TITLE
Fix mobile overflow

### DIFF
--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -400,8 +400,8 @@ export const MarkAllSeen = styled.span`
 export const SkipLink = Tab.withComponent('a').extend`
   grid-area: logo;
   overflow: hidden;
-  height: 1px;
-  width: 1px;
+  height: 0;
+  width: 0;
 
   &:focus {
     height: auto;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know any existing issue(s) that could be related to this PR)**
<!--
If your PR closes an existing issue you can write "Closes #issue_number" or if it's related to another issue you can write "Related to #issue_number"
-->
Closes #3158 

**Additional comments**

Took a stab at fixing the issue I opened regarding a slow overflow and scrollbar that resulted on mobile. I was able to narrow down the source of the overflow to the SkipLink component in the Nav. It had a 1x1 pixel dimension, but this PR changes it to 0x0.

Was able to confirm the scroll goes away on Firefox Quantum responsive mode.

If for some reason the SkipLink needs to have non-zero dimensions, I can tackle this differently!