### PR TITLE
Add share sheet and action handlers for thread items

### DIFF
--- a/mobile/components/DeleteAlert/index.js
+++ b/mobile/components/DeleteAlert/index.js
@@ -1,0 +1,19 @@
+// @flow
+import { Alert } from 'react-native';
+
+type Props = {
+  deleteHandler: Function,
+  title: string,
+  subtitle: string,
+};
+
+export default ({
+  deleteHandler,
+  title = 'Are you sure?',
+  subtitle = 'Deleting this cannot be undone',
+}: Props) => {
+  return Alert.alert(title, subtitle, [
+    { text: 'Delete', onPress: () => deleteHandler(), style: 'destructive' },
+    { text: 'Cancel', style: 'cancel' },
+  ]);
+};

--- a/mobile/components/Lists/ListItem.js
+++ b/mobile/components/Lists/ListItem.js
@@ -6,15 +6,19 @@ import { ListItemView } from './style';
 
 type ListItemProps = {
   onPressHandler: Function,
+  onLongPressHandler?: Function,
   children?: any,
 };
 
 export class ListItem extends Component<ListItemProps> {
   render() {
-    const { onPressHandler, children } = this.props;
+    const { onPressHandler, onLongPressHandler, children } = this.props;
     return (
       <ListItemView>
-        <TouchableOpacity onPress={onPressHandler}>
+        <TouchableOpacity
+          onPress={onPressHandler}
+          onLongPress={onLongPressHandler ? onLongPressHandler : null}
+        >
           <Row>{children}</Row>
         </TouchableOpacity>
       </ListItemView>

--- a/mobile/components/Lists/ThreadListItem/PillOrMessageCount.js
+++ b/mobile/components/Lists/ThreadListItem/PillOrMessageCount.js
@@ -1,0 +1,77 @@
+// @flow
+import * as React from 'react';
+import compose from 'recompose/compose';
+import { withCurrentUser } from '../../WithCurrentUser';
+import type { GetThreadType } from '../../../../shared/graphql/queries/thread/getThread';
+import type { GetUserType } from '../../../../shared/graphql/queries/user/getUser';
+import { Subtitle } from '../style';
+import { MetaTextPill } from './style';
+
+type Props = {
+  thread: GetThreadType,
+  currentUser: GetUserType,
+};
+
+class PillOrMessageCount extends React.Component<Props> {
+  render() {
+    const {
+      currentUser,
+      thread: {
+        isLocked,
+        currentUserLastSeen,
+        lastActive,
+        messageCount,
+        createdAt,
+        channel,
+        community,
+        author,
+      },
+    } = this.props;
+
+    const isAuthor = currentUser.id === author.user.id;
+    const isChannelMember = channel.channelPermissions.isMember;
+    const isCommunityMember = community.communityPermissions.isMember;
+
+    const now = new Date().getTime() / 1000;
+    const createdAtTime = new Date(createdAt).getTime() / 1000;
+    const lastActiveTime = lastActive && new Date(lastActive).getTime() / 1000;
+
+    const defaultMessageCountString = (
+      <Subtitle>
+        {messageCount === 0
+          ? `${messageCount} messages`
+          : messageCount > 1
+            ? `${messageCount} messages`
+            : `${messageCount} message`}
+      </Subtitle>
+    );
+
+    if (!isChannelMember || !isCommunityMember) {
+      return defaultMessageCountString;
+    }
+
+    if (isLocked) {
+      return <MetaTextPill locked>{`Locked`.toUpperCase()}</MetaTextPill>;
+    }
+
+    if (!isAuthor && !currentUserLastSeen) {
+      if (now - createdAtTime > 86400) {
+        return defaultMessageCountString;
+      }
+
+      return <MetaTextPill new>{`New thread!`.toUpperCase()}</MetaTextPill>;
+    }
+
+    if (currentUserLastSeen && lastActive && currentUserLastSeen < lastActive) {
+      if (lastActiveTime && now - lastActiveTime > 86400 * 7) {
+        return defaultMessageCountString;
+      }
+
+      return <Subtitle color={theme => theme.warn.alt}>New messages!</Subtitle>;
+    }
+
+    return defaultMessageCountString;
+  }
+}
+
+export default compose(withCurrentUser)(PillOrMessageCount);

--- a/mobile/components/Lists/ThreadListItem/index.js
+++ b/mobile/components/Lists/ThreadListItem/index.js
@@ -1,28 +1,229 @@
 // @flow
 import React, { Component } from 'react';
+import { Share } from 'react-native';
+import { connectActionSheet } from '@expo/react-native-action-sheet';
+import compose from 'recompose/compose';
 import { ListItem } from '../ListItem';
-import { TextColumnContainer, Title, Subtitle } from '../style';
-import { MetaTextPill, ThreadFacepileRowContainer } from './style';
+import { TextColumnContainer, Title } from '../style';
+import { ThreadFacepileRowContainer } from './style';
 import type { GetThreadType } from '../../../../shared/graphql/queries/thread/getThread';
 import ThreadCommunityInfo from './ThreadCommunityInfo';
+import PillOrMessageCount from './PillOrMessageCount';
 import Facepile from '../../Facepile';
 import ErrorBoundary from '../../ErrorBoundary';
+import { withNavigation, type NavigationProps } from 'react-navigation';
+import type { GetUserType } from '../../../../shared/graphql/queries/user/getUser';
+import setThreadLockMutation from '../../../../shared/graphql/mutations/thread/lockThread';
+import deleteThreadMutation, {
+  type DeleteThreadType,
+} from '../../../../shared/graphql/mutations/thread/deleteThread';
+import pinThreadMutation from '../../../../shared/graphql/mutations/community/pinCommunityThread';
+import triggerDeleteAlert from '../../DeleteAlert';
 
 type Props = {
   thread: GetThreadType,
   activeChannel?: string,
   activeCommunity?: string,
   onPressHandler: Function,
+  currentUser: GetUserType,
+  showActionSheetWithOptions: Function,
+  navigation: NavigationProps,
+  setThreadLock: Function,
+  pinThread: Function,
+  deleteThread: Function,
+  // refetches the parent query that resolved this thread - used when
+  // a thread is deleted and we want to refetch the parent query, regardless
+  // of where that query was called from
+  refetch: Function,
 };
 
-export class ThreadListItem extends Component<Props> {
+const SHARE = 'Share';
+const MESSAGE_AUTHOR = 'Message author';
+const PIN_CONVERSATION = 'Pin conversation';
+const UNPIN_CONVERSATION = 'Unpin conversation';
+const LOCK_CONVERSATION = 'Lock conversation';
+const UNLOCK_CONVERSATION = 'Unlock conversation';
+const DELETE_CONVERSATION = 'Delete conversation';
+
+class ThreadListItemHandlers extends Component<Props> {
   shouldComponentUpdate(nextProps: Props) {
     const currProps = this.props;
     if (nextProps.thread.id !== currProps.thread.id) return true;
     if (nextProps.thread.lastActive !== currProps.thread.lastActive)
       return true;
+    if (nextProps.thread.isLocked !== currProps.thread.isLocked) return true;
     return false;
   }
+
+  shareThread = () => {
+    const { thread } = this.props;
+
+    return Share.share(
+      {
+        url: `https://spectrum.chat/thread/${thread.id}`,
+        title: `${thread.content.title}`,
+      },
+      {
+        subject: `${thread.content.title}`,
+      }
+    );
+  };
+
+  toggleLockThread = () => {
+    const { thread, setThreadLock } = this.props;
+
+    return setThreadLock({
+      threadId: thread.id,
+      value: !thread.isLocked,
+    });
+  };
+
+  togglePinThread = () => {
+    const { thread, pinThread } = this.props;
+    const isPinned = thread.community.pinnedThreadId === thread.id;
+
+    return pinThread({
+      threadId: thread.id,
+      communityId: thread.community.id,
+      value: isPinned ? null : thread.id,
+    });
+  };
+
+  getActionSheetOptions = () => {
+    const { thread, currentUser } = this.props;
+    const {
+      channel: { channelPermissions },
+      community: { communityPermissions },
+    } = thread;
+
+    const isThreadAuthor = currentUser.id === thread.author.user.id;
+    const isChannelModerator = channelPermissions.isModerator;
+    const isCommunityModerator = communityPermissions.isModerator;
+    const isChannelOwner = channelPermissions.isOwner;
+    const isCommunityOwner = communityPermissions.isOwner;
+    const canModerateGlobally =
+      isChannelModerator ||
+      isCommunityModerator ||
+      isChannelOwner ||
+      isCommunityOwner;
+    const canModerateCommunity = isCommunityModerator || isCommunityOwner;
+
+    let options, cancelButtonIndex, destructiveButtonIndex;
+    options = [SHARE, MESSAGE_AUTHOR];
+
+    if (canModerateCommunity) {
+      options = options.concat(
+        thread.community.pinnedThreadId === thread.id
+          ? UNPIN_CONVERSATION
+          : PIN_CONVERSATION
+      );
+    }
+
+    if (canModerateGlobally) {
+      options = options.concat(
+        thread.isLocked ? UNLOCK_CONVERSATION : LOCK_CONVERSATION
+      );
+    }
+
+    if (isThreadAuthor || canModerateGlobally) {
+      options = options.concat(DELETE_CONVERSATION);
+    }
+
+    options = options.concat('Cancel');
+    cancelButtonIndex = options.length - 1;
+    destructiveButtonIndex = options.indexOf(DELETE_CONVERSATION);
+
+    return {
+      options,
+      cancelButtonIndex,
+      destructiveButtonIndex,
+    };
+  };
+
+  actionSheetEventHandlers = (options, index) => {
+    const { navigation, thread, currentUser, deleteThread } = this.props;
+
+    const isAuthor = currentUser.id === thread.author.user.id;
+
+    const action = options[index];
+    if (action === 'Share') {
+      return this.shareThread();
+    }
+
+    if (action === MESSAGE_AUTHOR) {
+      return navigation.navigate({
+        routeName: 'User',
+        key: thread.author.user.id,
+        params: {
+          id: thread.author.user.id,
+        },
+      });
+    }
+
+    if (action === UNPIN_CONVERSATION) {
+      return this.togglePinThread();
+    }
+
+    if (action === PIN_CONVERSATION) {
+      return this.togglePinThread();
+    }
+
+    if (action === UNLOCK_CONVERSATION) {
+      return this.toggleLockThread();
+    }
+
+    if (action === LOCK_CONVERSATION) {
+      return this.toggleLockThread();
+    }
+
+    if (action === DELETE_CONVERSATION) {
+      return triggerDeleteAlert({
+        title: 'Delete this conversation?',
+        subtitle: isAuthor
+          ? 'This can’t be undone.'
+          : 'This can’t be undone. The author will be notified.',
+        deleteHandler: () =>
+          deleteThread(thread.id).then(result =>
+            this.handlePostThreadDelete(result)
+          ),
+      });
+    }
+  };
+
+  handlePostThreadDelete = (mutationResult: DeleteThreadType) => {
+    const { navigation, refetch } = this.props;
+    const { routeName } = navigation.state;
+    // depending on where the user was when the thread was deleted, we need to figure out
+    // which queries to refetch or how to navigate the user back to a view so that the deleted
+    // thread will not be visible
+    switch (routeName) {
+      case 'Dashboard':
+      case 'Community':
+      case 'Channel':
+      case 'User': {
+        return refetch();
+      }
+      case 'Thread': {
+        return navigation.goBack();
+      }
+      default: {
+        return () => {};
+      }
+    }
+  };
+
+  onLongPressHandler = () => {
+    const { showActionSheetWithOptions } = this.props;
+    const actionSheetConfig = this.getActionSheetOptions();
+    return showActionSheetWithOptions(
+      {
+        options: actionSheetConfig.options,
+        cancelButtonIndex: actionSheetConfig.cancelButtonIndex,
+        destructiveButtonIndex: actionSheetConfig.destructiveButtonIndex,
+      },
+      index => this.actionSheetEventHandlers(actionSheetConfig.options, index)
+    );
+  };
 
   render() {
     const {
@@ -41,7 +242,10 @@ export class ThreadListItem extends Component<Props> {
     ];
 
     return (
-      <ListItem onPressHandler={onPressHandler}>
+      <ListItem
+        onPressHandler={onPressHandler}
+        onLongPressHandler={this.onLongPressHandler}
+      >
         <TextColumnContainer>
           <ErrorBoundary fallbackComponent={null}>
             <ThreadCommunityInfo
@@ -56,18 +260,7 @@ export class ThreadListItem extends Component<Props> {
           <ErrorBoundary fallbackComponent={null}>
             <ThreadFacepileRowContainer>
               <Facepile users={facepileUsers} />
-
-              {thread.messageCount > 0 ? (
-                <Subtitle>
-                  {thread.messageCount > 1
-                    ? `${thread.messageCount} messages`
-                    : `${thread.messageCount} message`}
-                </Subtitle>
-              ) : (
-                <MetaTextPill offset={thread.participants.length} new>
-                  {'New thread!'.toUpperCase()}
-                </MetaTextPill>
-              )}
+              <PillOrMessageCount thread={thread} />
             </ThreadFacepileRowContainer>
           </ErrorBoundary>
         </TextColumnContainer>
@@ -75,3 +268,11 @@ export class ThreadListItem extends Component<Props> {
     );
   }
 }
+
+export const ThreadListItem = compose(
+  setThreadLockMutation,
+  deleteThreadMutation,
+  pinThreadMutation,
+  connectActionSheet,
+  withNavigation
+)(ThreadListItemHandlers);

--- a/mobile/components/Lists/ThreadListItem/style.js
+++ b/mobile/components/Lists/ThreadListItem/style.js
@@ -38,7 +38,8 @@ export const MessageCount = styled.Text`
 
 export const MetaTextPill = styled(MetaText)`
   color: ${props => props.theme.text.reverse};
-  background: ${props => props.theme.success.alt};
+  background: ${props =>
+    props.locked ? props.theme.text.placeholder : props.theme.success.alt};
   border-radius: 11px;
   font-size: 12px;
   font-weight: 800;

--- a/mobile/components/Lists/style.js
+++ b/mobile/components/Lists/style.js
@@ -57,7 +57,8 @@ export const Title = styled.Text`
 export const Subtitle = styled.Text`
   font-size: 15px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${props =>
+    props.color ? props.color(props.theme) : props.theme.text.alt};
   line-height: 21;
 `;
 

--- a/mobile/components/ThreadFeed/index.js
+++ b/mobile/components/ThreadFeed/index.js
@@ -9,6 +9,8 @@ import Loading from '../Loading';
 import type { ThreadConnectionType } from '../../../shared/graphql/fragments/community/communityThreadConnection';
 import type { FlatListProps } from 'react-native';
 import ErrorBoundary from '../ErrorBoundary';
+import { withCurrentUser } from '../WithCurrentUser';
+import type { GetUserType } from '../../../shared/graphql/queries/user/getUser';
 
 /*
   The thread feed always expects a prop of 'threads' - this means that in
@@ -33,6 +35,7 @@ type Props = {|
   navigation: Object,
   activeChannel?: string,
   activeCommunity?: string,
+  currentUser: GetUserType,
   // This is necessary so we can listen to updates
   channels?: string[],
   noThreadsFallback?: any,
@@ -120,6 +123,7 @@ class ThreadFeed extends Component<Props, State> {
       isFetchingMore,
       isRefetching,
       channels,
+      currentUser,
       noThreadsFallback: NoThreadsFallback,
       ...flatListProps
     } = this.props;
@@ -134,9 +138,11 @@ class ThreadFeed extends Component<Props, State> {
             renderItem={({ item }) => (
               <ErrorBoundary fallbackComponent={null}>
                 <ThreadListItem
+                  refetch={this.props.data.refetch}
                   thread={item.node}
                   activeChannel={activeChannel}
                   activeCommunity={activeCommunity}
+                  currentUser={currentUser}
                   onPressHandler={() =>
                     navigation.navigate({
                       routeName: `Thread`,
@@ -184,4 +190,4 @@ class ThreadFeed extends Component<Props, State> {
   }
 }
 
-export default compose(ViewNetworkHandler)(ThreadFeed);
+export default compose(withCurrentUser, ViewNetworkHandler)(ThreadFeed);

--- a/mobile/views/Community/index.js
+++ b/mobile/views/Community/index.js
@@ -43,6 +43,7 @@ const RemoteThreadItem = compose(getThreadById, withNavigation)(
     if (!data.thread) return null;
     return (
       <ThreadListItem
+        refetch={data.refetch}
         activeCommunity={data.thread.community.id}
         thread={data.thread}
         onPressHandler={() =>

--- a/shared/graphql/queries/channel/getChannelThreadConnection.js
+++ b/shared/graphql/queries/channel/getChannelThreadConnection.js
@@ -45,6 +45,7 @@ const getChannelThreadConnectionOptions = {
       channel,
       networkStatus,
       subscribeToMore,
+      refetch,
     },
   }) => ({
     data: {
@@ -52,6 +53,7 @@ const getChannelThreadConnectionOptions = {
       loading,
       networkStatus,
       channel,
+      refetch,
       threadConnection: channel && channel.threadConnection,
       threads:
         channel && channel.threadConnection

--- a/shared/graphql/queries/community/getCommunityThreadConnection.js
+++ b/shared/graphql/queries/community/getCommunityThreadConnection.js
@@ -48,6 +48,7 @@ const getCommunityThreadConnectionOptions = {
       community,
       networkStatus,
       subscribeToMore,
+      refetch,
     },
   }) => ({
     data: {
@@ -55,6 +56,7 @@ const getCommunityThreadConnectionOptions = {
       loading,
       networkStatus,
       community,
+      refetch,
       threadConnection: community && community.threadConnection,
       threads:
         community && community.threadConnection

--- a/shared/graphql/queries/user/getUserThreadConnection.js
+++ b/shared/graphql/queries/user/getUserThreadConnection.js
@@ -46,13 +46,22 @@ export const getUserThreadConnectionQuery = gql`
 const getUserThreadConnectionOptions = {
   props: ({
     ownProps,
-    data: { fetchMore, error, loading, networkStatus, user, subscribeToMore },
+    data: {
+      fetchMore,
+      error,
+      loading,
+      networkStatus,
+      user,
+      subscribeToMore,
+      refetch,
+    },
   }) => ({
     data: {
       error,
       loading,
       user,
       networkStatus,
+      refetch,
       threadConnection: user && user.threadConnection,
       threads: user && user.threadConnection ? user.threadConnection.edges : '',
       hasNextPage:


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- mobile

This adds some handy helpers for thread actions. Next step for me will be to abstract this a bit more generally so that the sheet can be triggered from within the thread view - should be easy!