### PR TITLE
Fix emails not sending to admins

### DIFF
--- a/hermes/send-email.js
+++ b/hermes/send-email.js
@@ -59,23 +59,6 @@ const sendEmail = (options: Options) => {
     return;
   }
 
-  if (!isEmail(To)) {
-    if (userId) {
-      trackQueue.add({
-        userId: userId,
-        event: events.EMAIL_BOUNCED,
-        // we can safely log the To field because it's not a valid email, thus not PII
-        properties: {
-          tag: Tag,
-          to: To,
-          error: 'To field was not a valid email address',
-        },
-      });
-    }
-
-    return;
-  }
-
   // $FlowFixMe
   return new Promise((res, rej) => {
     client.sendEmailWithTemplate(


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hermes

This was dumb of me - basically it was stopping all admin emails coming to us because the way `To` is formatted for postmark as a comma-separated list, so `isEmail(string)` would fail :P