### PR TITLE
Track first mobile Amplitude events

### DIFF
--- a/mobile/components/Login/index.js
+++ b/mobile/components/Login/index.js
@@ -17,6 +17,7 @@ import {
   CodeOfConduct,
   Link,
 } from './style';
+import { events, track } from '../../utils/analytics';
 
 const API_URL =
   process.env.NODE_ENV === 'production'
@@ -30,7 +31,12 @@ type Props = {
 };
 
 class Login extends React.Component<Props> {
+  componentDidMount() {
+    track(events.LOGIN_PAGE_VIEWED);
+  }
+
   authenticate = (provider: Provider) => async () => {
+    track(events.LOGIN_PAGE_AUTH_CLICKED, { provider });
     const redirectUrl = AuthSession.getRedirectUrl();
     const result = await AuthSession.startAsync({
       authUrl: `${API_URL}/auth/${provider}?r=${redirectUrl}&authType=token`,

--- a/mobile/views/Community/index.js
+++ b/mobile/views/Community/index.js
@@ -12,6 +12,7 @@ import ThreadFeed from '../../components/ThreadFeed';
 import { ThreadListItem } from '../../components/Lists';
 import { getThreadById } from '../../../shared/graphql/queries/thread/getThread';
 import Loading from '../../components/Loading';
+import { track, events, transformations } from '../../utils/analytics';
 
 import {
   Wrapper,
@@ -61,6 +62,30 @@ const RemoteThreadItem = compose(getThreadById, withNavigation)(
 const CommunityThreadFeed = compose(getCommunityThreads)(ThreadFeed);
 
 class Community extends Component<Props> {
+  trackView = () => {
+    const { data: { community } } = this.props;
+    if (!community) return;
+    track(events.COMMUNITY_VIEWED, {
+      community: transformations.analyticsCommunity(community),
+    });
+  };
+
+  componentDidMount() {
+    this.trackView();
+  }
+
+  componentDidUpdate(prev) {
+    const curr = this.props;
+    const first = !prev.data.community && curr.data.community;
+    const changed =
+      prev.data.community &&
+      curr.data.community &&
+      prev.data.community.id !== curr.data.community.id;
+    if (first || changed) {
+      this.trackView();
+    }
+  }
+
   render() {
     const { data: { community }, isLoading, hasError, navigation } = this.props;
 

--- a/mobile/views/Dashboard/index.js
+++ b/mobile/views/Dashboard/index.js
@@ -12,6 +12,7 @@ import {
 } from '../../../shared/graphql/queries/user/getUser';
 import { Wrapper } from './style';
 import ErrorBoundary from '../../components/ErrorBoundary';
+import { track, events } from '../../utils/analytics';
 
 const EverythingThreadFeed = compose(getCurrentUserEverythingFeed)(ThreadFeed);
 
@@ -23,6 +24,10 @@ type Props = {
 };
 
 class Dashboard extends Component<Props> {
+  componentDidMount() {
+    track(events.INBOX_EVERYTHING_VIEWED);
+  }
+
   render() {
     const { navigation } = this.props;
 

--- a/mobile/views/DirectMessageThread/components/DirectMessageThread.js
+++ b/mobile/views/DirectMessageThread/components/DirectMessageThread.js
@@ -13,6 +13,7 @@ import ViewNetworkHandler, {
 } from '../../../components/ViewNetworkHandler';
 import Loading from '../../../components/Loading';
 import ErrorBoundary from '../../../components/ErrorBoundary';
+import { track, events, transformations } from '../../../utils/analytics';
 
 import sentencify from '../../../../shared/sentencify';
 import getDirectMessageThread, {
@@ -40,6 +41,29 @@ type Props = {
 };
 
 class DirectMessageThread extends Component<Props> {
+  trackView = () => {
+    const { data: { directMessageThread } } = this.props;
+    if (!directMessageThread) return;
+    track(events.DIRECT_MESSAGE_THREAD_VIEWED);
+  };
+
+  componentDidMount() {
+    this.trackView();
+  }
+
+  componentDidUpdate(prev) {
+    const curr = this.props;
+    const first =
+      !prev.data.directMessageThread && curr.data.directMessageThread;
+    const changed =
+      prev.data.directMessageThread &&
+      curr.data.directMessageThread &&
+      prev.data.directMessageThread.id !== curr.data.directMessageThread.id;
+    if (first || changed) {
+      this.trackView();
+    }
+  }
+
   sendMessage = text => {
     if (!this.props.data.directMessageThread) return;
     this.props.sendDirectMessage({

--- a/mobile/views/DirectMessages/index.js
+++ b/mobile/views/DirectMessages/index.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import DirectMessageThreadsList from './components/DirectMessageThreadsList';
 import { Wrapper } from './style';
 import ErrorBoundary from '../../components/ErrorBoundary';
+import { track, events } from '../../utils/analytics';
 import type { NavigationProps } from 'react-navigation';
 
 type Props = {
@@ -10,6 +11,14 @@ type Props = {
 };
 
 class DirectMessages extends Component<Props> {
+  trackView = () => {
+    track(events.DIRECT_MESSAGES_VIEWED);
+  };
+
+  componentDidMount() {
+    this.trackView();
+  }
+
   render() {
     const { navigation } = this.props;
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- mobile


**Related issues (delete if you don't know any existing issue(s) that could be related to this PR)**

Ref: #3265

This adds first tracking of view events to the mobile apps. This is
based on #3291, so until that's merged you'll also see those changes
here.

Sidenote, we should make sure to track everything automatically as we
build features in the mobile apps from now on! I'll try and get
everything backfilled as good as possible.