### PR TITLE
Fix viewing new profiles on mobile 

### DIFF
--- a/mobile/views/Channel/index.js
+++ b/mobile/views/Channel/index.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
 import compose from 'recompose/compose';
-import idx from 'idx';
 import {
   getChannelById,
   type GetChannelType,
@@ -58,7 +57,7 @@ class Channel extends Component<Props> {
     } else {
       title = 'Loading channel...';
     }
-    const oldTitle = idx(navigation, _ => _.state.params.title);
+    const oldTitle = navigation.getParam('title', null);
     if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };

--- a/mobile/views/Channel/index.js
+++ b/mobile/views/Channel/index.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import compose from 'recompose/compose';
+import idx from 'idx';
 import {
   getChannelById,
   type GetChannelType,
@@ -57,7 +58,8 @@ class Channel extends Component<Props> {
     } else {
       title = 'Loading channel...';
     }
-    if (navigation.state.params.title === title) return;
+    const oldTitle = idx(navigation, _ => _.state.params.title);
+    if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };
 

--- a/mobile/views/Community/index.js
+++ b/mobile/views/Community/index.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import compose from 'recompose/compose';
 import { withNavigation } from 'react-navigation';
-import idx from 'idx';
 import {
   getCommunityById,
   type GetCommunityType,
@@ -79,7 +78,7 @@ class Community extends Component<Props> {
     } else {
       title = 'Loading community...';
     }
-    const oldTitle = idx(navigation, _ => _.state.params.title);
+    const oldTitle = navigation.getParam('title', null);
     if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };

--- a/mobile/views/Community/index.js
+++ b/mobile/views/Community/index.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import compose from 'recompose/compose';
 import { withNavigation } from 'react-navigation';
+import idx from 'idx';
 import {
   getCommunityById,
   type GetCommunityType,
@@ -78,7 +79,8 @@ class Community extends Component<Props> {
     } else {
       title = 'Loading community...';
     }
-    if (navigation.state.params.title === title) return;
+    const oldTitle = idx(navigation, _ => _.state.params.title);
+    if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };
 

--- a/mobile/views/DirectMessageThread/components/DirectMessageThread.js
+++ b/mobile/views/DirectMessageThread/components/DirectMessageThread.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
 import compose from 'recompose/compose';
+import idx from 'idx';
 import Text from '../../../components/Text';
 import ChatInput from '../../../components/ChatInput';
 import Messages from '../../../components/Messages';
@@ -52,7 +53,8 @@ class DirectMessageThread extends Component<Props> {
     let title = directMessageThread
       ? sentencify(directMessageThread.participants.map(({ name }) => name))
       : 'Loading thread...';
-    if (navigation.state.params.title === title) return;
+    const oldTitle = idx(navigation, _ => _.state.params.title);
+    if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };
 

--- a/mobile/views/DirectMessageThread/components/DirectMessageThread.js
+++ b/mobile/views/DirectMessageThread/components/DirectMessageThread.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import { View } from 'react-native';
 import compose from 'recompose/compose';
-import idx from 'idx';
 import Text from '../../../components/Text';
 import ChatInput from '../../../components/ChatInput';
 import Messages from '../../../components/Messages';
@@ -53,7 +52,7 @@ class DirectMessageThread extends Component<Props> {
     let title = directMessageThread
       ? sentencify(directMessageThread.participants.map(({ name }) => name))
       : 'Loading thread...';
-    const oldTitle = idx(navigation, _ => _.state.params.title);
+    const oldTitle = navigation.getParam('title', null);
     if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };

--- a/mobile/views/DirectMessageThread/index.js
+++ b/mobile/views/DirectMessageThread/index.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import compose from 'recompose/compose';
-import idx from 'idx';
 import Text from '../../components/Text';
 import { withCurrentUser } from '../../components/WithCurrentUser';
 import DirectMessageThread from './components/DirectMessageThread';
@@ -17,8 +16,8 @@ type Props = {
 
 class DirectMessageThreadView extends React.Component<Props> {
   render() {
-    const id = idx(this.props, props => props.navigation.state.params.id);
     const { currentUser, navigation } = this.props;
+    const id = navigation.getParam('id', null);
     if (!id) return <Text>Non-existant DM thread</Text>;
 
     if (!currentUser) return null;

--- a/mobile/views/TabBar/BaseStack.js
+++ b/mobile/views/TabBar/BaseStack.js
@@ -1,6 +1,7 @@
 // @flow
 // The basic view stack that's used on all of our screens
 // Any view that's added here can be visited from any of our tabs
+import idx from 'idx';
 import Thread from '../Thread';
 import Community from '../Community';
 import Channel from '../Channel';
@@ -12,26 +13,26 @@ const BaseStack = {
   Thread: {
     screen: withMappedNavigationProps(Thread),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
-      headerTitle: navigation.state.params.title || null,
+      headerTitle: idx(navigation, _ => _.state.params.title) || null,
       tabBarVisible: false,
     }),
   },
   Community: {
     screen: withMappedNavigationProps(Community),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
-      headerTitle: navigation.state.params.title || null,
+      headerTitle: idx(navigation, _ => _.state.params.title) || null,
     }),
   },
   Channel: {
     screen: withMappedNavigationProps(Channel),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
-      headerTitle: navigation.state.params.title || null,
+      headerTitle: idx(navigation, _ => _.state.params.title) || null,
     }),
   },
   User: {
     screen: withMappedNavigationProps(User),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
-      headerTitle: navigation.state.params.title || null,
+      headerTitle: idx(navigation, _ => _.state.params.title) || null,
     }),
   },
 };

--- a/mobile/views/TabBar/BaseStack.js
+++ b/mobile/views/TabBar/BaseStack.js
@@ -1,7 +1,6 @@
 // @flow
 // The basic view stack that's used on all of our screens
 // Any view that's added here can be visited from any of our tabs
-import idx from 'idx';
 import Thread from '../Thread';
 import Community from '../Community';
 import Channel from '../Channel';
@@ -13,26 +12,26 @@ const BaseStack = {
   Thread: {
     screen: withMappedNavigationProps(Thread),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
-      headerTitle: idx(navigation, _ => _.state.params.title) || null,
+      headerTitle: navigation.getParam('title', null),
       tabBarVisible: false,
     }),
   },
   Community: {
     screen: withMappedNavigationProps(Community),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
-      headerTitle: idx(navigation, _ => _.state.params.title) || null,
+      headerTitle: navigation.getParam('title', null),
     }),
   },
   Channel: {
     screen: withMappedNavigationProps(Channel),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
-      headerTitle: idx(navigation, _ => _.state.params.title) || null,
+      headerTitle: navigation.getParam('title', null),
     }),
   },
   User: {
     screen: withMappedNavigationProps(User),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
-      headerTitle: idx(navigation, _ => _.state.params.title) || null,
+      headerTitle: navigation.getParam('title', null),
     }),
   },
 };

--- a/mobile/views/TabBar/DirectMessageStack.js
+++ b/mobile/views/TabBar/DirectMessageStack.js
@@ -1,6 +1,5 @@
 // @flow
 import { createStackNavigator } from 'react-navigation';
-import idx from 'idx';
 import BaseStack from './BaseStack';
 import DirectMessages from '../DirectMessages';
 import DirectMessageThread from '../DirectMessageThread';
@@ -10,13 +9,13 @@ const DMStack = createStackNavigator(
     DirectMessages: {
       screen: DirectMessages,
       navigationOptions: ({ navigation }) => ({
-        headerTitle: idx(navigation, _ => _.state.params.title) || 'Messages',
+        headerTitle: navigation.getParam('title', 'Messages'),
       }),
     },
     DirectMessageThread: {
       screen: DirectMessageThread,
       navigationOptions: ({ navigation }) => ({
-        headerTitle: idx(navigation, _ => _.state.params.title) || '',
+        headerTitle: navigation.getParam('title', null),
         tabBarVisible: false,
       }),
     },

--- a/mobile/views/Thread/index.js
+++ b/mobile/views/Thread/index.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { ScrollView } from 'react-native';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';
+import idx from 'idx';
 import { getThreadById } from '../../../shared/graphql/queries/thread/getThread';
 import ViewNetworkHandler from '../../components/ViewNetworkHandler';
 import withSafeView from '../../components/SafeAreaView';
@@ -59,7 +60,8 @@ class Thread extends Component<Props> {
     } else {
       title = 'Loading thread...';
     }
-    if (navigation.state.params.title === title) return;
+    const oldTitle = idx(navigation, _ => _.state.params.title);
+    if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };
 

--- a/mobile/views/Thread/index.js
+++ b/mobile/views/Thread/index.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { ScrollView } from 'react-native';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';
-import idx from 'idx';
 import { getThreadById } from '../../../shared/graphql/queries/thread/getThread';
 import ViewNetworkHandler from '../../components/ViewNetworkHandler';
 import withSafeView from '../../components/SafeAreaView';
@@ -60,7 +59,7 @@ class Thread extends Component<Props> {
     } else {
       title = 'Loading thread...';
     }
-    const oldTitle = idx(navigation, _ => _.state.params.title);
+    const oldTitle = navigation.getParam('title', null);
     if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };

--- a/mobile/views/User/profile.js
+++ b/mobile/views/User/profile.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import compose from 'recompose/compose';
+import idx from 'idx';
 import getUserThreadConnection from '../../../shared/graphql/queries/user/getUserThreadConnection';
 import ThreadFeed from '../../components/ThreadFeed';
 import type { GetUserType } from '../../../shared/graphql/queries/user/getUser';
@@ -50,7 +51,9 @@ class User extends Component<Props, State> {
     } else {
       title = 'Loading user...';
     }
-    if (navigation.state.params.title === title) return;
+
+    const oldTitle = idx(navigation, _ => _.state.params.title);
+    if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };
 

--- a/mobile/views/User/profile.js
+++ b/mobile/views/User/profile.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
 import compose from 'recompose/compose';
-import idx from 'idx';
 import getUserThreadConnection from '../../../shared/graphql/queries/user/getUserThreadConnection';
 import ThreadFeed from '../../components/ThreadFeed';
 import type { GetUserType } from '../../../shared/graphql/queries/user/getUser';
@@ -52,7 +51,7 @@ class User extends Component<Props, State> {
       title = 'Loading user...';
     }
 
-    const oldTitle = idx(navigation, _ => _.state.params.title);
+    const oldTitle = navigation.getParam('title', null);
     if (oldTitle && oldTitle === title) return;
     navigation.setParams({ title });
   };


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

Viewing a profile that didn't have any data loaded for it yet was broken due to `navigation.state.params` being undefined. This patch switches us to using the standard `.getParam` method which accounts for this.