### PR TITLE
Cleanup and hotfixes

### DIFF
--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -154,7 +154,10 @@ if (process.env.NODE_ENV === 'development') {
 
 app.get('*', (req: express$Request, res, next) => {
   // Electron requests should only be client-side rendered
-  if (req.headers['user-agent'].indexOf('Electron') > -1) {
+  if (
+    req.headers['user-agent'] &&
+    req.headers['user-agent'].indexOf('Electron') > -1
+  ) {
     return res.sendFile(path.resolve(__dirname, '../build/index.html'));
   }
   next();

--- a/shared/middlewares/thread-param.js
+++ b/shared/middlewares/thread-param.js
@@ -2,7 +2,7 @@
 
 const threadParamRedirect = (req, res, next) => {
   // Redirect /?t=asdf123 if the user isn't logged in
-  if (!req.user && req.query.t) {
+  if (req.query.t) {
     res.redirect(`/thread/${req.query.t}`);
     // Redirect /anything?thread=asdf123
   } else if (req.query.thread) {

--- a/src/components/profile/style.js
+++ b/src/components/profile/style.js
@@ -1,3 +1,4 @@
+// @flow
 import styled from 'styled-components';
 import Link from 'src/components/link';
 import {
@@ -259,6 +260,11 @@ export const ProfileCard = styled(Card)`
       text-decoration: underline;
     }
   }
+`;
+
+export const ThreadProfileCard = styled(ProfileCard)`
+  border-radius: 8px;
+  box-shadow: ${Shadow.low} ${({ theme }) => hexa(theme.text.default, 0.1)};
 `;
 
 export const ProUpgrade = styled.div`

--- a/src/components/profile/thread.js
+++ b/src/components/profile/thread.js
@@ -5,7 +5,7 @@ import compose from 'recompose/compose';
 import Link from 'src/components/link';
 import { connect } from 'react-redux';
 import { ThreadListItem } from '../listItems';
-import { ProfileCard } from './style';
+import { ThreadProfileCard } from './style';
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
 
 type Props = {
@@ -39,7 +39,7 @@ class ThreadWithData extends React.Component<Props> {
     }
 
     return (
-      <ProfileCard>
+      <ThreadProfileCard>
         <Link
           to={{
             search: `?thread=${thread.id}`,
@@ -53,7 +53,7 @@ class ThreadWithData extends React.Component<Props> {
             }`}
           />
         </Link>
-      </ProfileCard>
+      </ThreadProfileCard>
     );
   }
 }

--- a/src/views/community/index.js
+++ b/src/views/community/index.js
@@ -290,6 +290,7 @@ class CommunityView extends React.Component<Props, State> {
                       icon={isMember ? 'checkmark' : null}
                       loading={state.isLoading}
                       dataCy={'join-community-button'}
+                      style={{ marginTop: '16px' }}
                     >
                       {isMember ? 'Member' : `Join ${community.name}`}
                     </LoginButton>

--- a/src/views/notifications/components/newMessageNotification.js
+++ b/src/views/notifications/components/newMessageNotification.js
@@ -31,7 +31,11 @@ export const NewMessageNotification = ({ notification, currentUser }) => {
   const date = parseNotificationDate(notification.modifiedAt);
   const context = parseContext(notification.context, currentUser);
   const unsortedMessages = notification.entities.map(notif => notif.payload);
-  const messages = sortAndGroupNotificationMessages(unsortedMessages);
+  let messages = sortAndGroupNotificationMessages(unsortedMessages);
+
+  if (messages.length > 3) {
+    messages = messages.splice(0, messages.length - 3);
+  }
 
   return (
     <NotificationCard isSeen={notification.isSeen}>

--- a/src/views/notifications/style.js
+++ b/src/views/notifications/style.js
@@ -23,6 +23,8 @@ export const NotificationCard = styled(Card)`
   padding-bottom: 24px;
   overflow: hidden;
   transition: ${Transition.hover.off};
+  border-radius: 8px;
+  box-shadow: ${Shadow.low} ${({ theme }) => hexa(theme.text.default, 0.1)};
 
   &:hover {
     transition: none;
@@ -34,6 +36,8 @@ export const SegmentedNotificationCard = styled(Card)`
   padding: 0;
   padding-top: 16px;
   transition: ${Transition.hover.off};
+  border-radius: 8px;
+  box-shadow: ${Shadow.low} ${({ theme }) => hexa(theme.text.default, 0.1)};
 
   &:hover {
     transition: none;
@@ -259,6 +263,8 @@ export const RequestCard = styled(Card)`
   align-items: center;
   justify-content: space-between;
   padding: 16px 16px 16px 24px;
+  border-radius: 8px;
+  box-shadow: ${Shadow.low} ${({ theme }) => hexa(theme.text.default, 0.1)};
 
   > p {
     font-weight: 700;

--- a/src/views/thread/components/actionBar.js
+++ b/src/views/thread/components/actionBar.js
@@ -306,56 +306,8 @@ class ActionBar extends React.Component<Props, State> {
                 Notify me
               </FollowButton>
             )}
-            {!thread.channel.isPrivate && (
+            {thread.channel.isPrivate && (
               <ShareButtons>
-                <ShareButton
-                  facebook
-                  tipText={'Share'}
-                  tipLocation={'top-left'}
-                  data-cy="thread-facebook-button"
-                >
-                  <a
-                    href={`https://www.facebook.com/sharer/sharer.php?u=https://spectrum.chat/thread/${
-                      thread.id
-                    }&t=${thread.content.title}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Icon
-                      glyph={'facebook'}
-                      size={24}
-                      onClick={() =>
-                        track(events.THREAD_SHARED, { method: 'facebook' })
-                      }
-                    />
-                  </a>
-                </ShareButton>
-
-                <ShareButton
-                  twitter
-                  tipText={'Tweet'}
-                  tipLocation={'top-left'}
-                  data-cy="thread-tweet-button"
-                >
-                  <a
-                    href={`https://twitter.com/share?text=${
-                      thread.content.title
-                    } on @withspectrum&url=https://spectrum.chat/thread/${
-                      thread.id
-                    }`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <Icon
-                      glyph={'twitter'}
-                      size={24}
-                      onClick={() =>
-                        track(events.THREAD_SHARED, { method: 'twitter' })
-                      }
-                    />
-                  </a>
-                </ShareButton>
-
                 <Clipboard
                   style={{ background: 'none' }}
                   data-clipboard-text={`https://spectrum.chat/thread/${

--- a/src/views/thread/components/actionBar.js
+++ b/src/views/thread/components/actionBar.js
@@ -306,6 +306,85 @@ class ActionBar extends React.Component<Props, State> {
                 Notify me
               </FollowButton>
             )}
+            {!thread.channel.isPrivate && (
+              <ShareButtons>
+                <ShareButton
+                  facebook
+                  tipText={'Share'}
+                  tipLocation={'top-left'}
+                  data-cy="thread-facebook-button"
+                >
+                  <a
+                    href={`https://www.facebook.com/sharer/sharer.php?u=https://spectrum.chat/thread/${
+                      thread.id
+                    }&t=${thread.content.title}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Icon
+                      glyph={'facebook'}
+                      size={24}
+                      onClick={() =>
+                        track(events.THREAD_SHARED, { method: 'facebook' })
+                      }
+                    />
+                  </a>
+                </ShareButton>
+
+                <ShareButton
+                  twitter
+                  tipText={'Tweet'}
+                  tipLocation={'top-left'}
+                  data-cy="thread-tweet-button"
+                >
+                  <a
+                    href={`https://twitter.com/share?text=${
+                      thread.content.title
+                    } on @withspectrum&url=https://spectrum.chat/thread/${
+                      thread.id
+                    }`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <Icon
+                      glyph={'twitter'}
+                      size={24}
+                      onClick={() =>
+                        track(events.THREAD_SHARED, { method: 'twitter' })
+                      }
+                    />
+                  </a>
+                </ShareButton>
+
+                <Clipboard
+                  style={{ background: 'none' }}
+                  data-clipboard-text={`https://spectrum.chat/thread/${
+                    thread.id
+                  }`}
+                  onSuccess={() =>
+                    this.props.dispatch(
+                      addToastWithTimeout('success', 'Copied to clipboard')
+                    )
+                  }
+                >
+                  <ShareButton
+                    tipText={'Copy link'}
+                    tipLocation={'top-left'}
+                    data-cy="thread-copy-link-button"
+                  >
+                    <a>
+                      <Icon
+                        glyph={'link'}
+                        size={24}
+                        onClick={() =>
+                          track(events.THREAD_SHARED, { method: 'link' })
+                        }
+                      />
+                    </a>
+                  </ShareButton>
+                </Clipboard>
+              </ShareButtons>
+            )}
             {thread.channel.isPrivate && (
               <ShareButtons>
                 <Clipboard


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

cc @mxstbr - I'm hot shipped a change to the thread param redirect: https://github.com/withspectrum/spectrum/commit/cf554b8e5dce793a28b8cbe8d80766d785371c9f
This update will cause anyone who hits a `?t=` link via SSR (e.g. coming in from spectrum externally) will just get pushed to the thread view, versus landing in the dashboard in us figuring out which thread to load. This is because SSR is somehow triggering a re-render which breaks the persistence of the `?t=` in the dashboard for people who come in via SSR, so they never hit the thread they expect.

All the other things I'm piggybacking in because they are super small requests from users :)