### PR TITLE
Fixes reference to Background Jobs in Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Spectrum has been under full-time development since March, 2017. See [the roadma
   - [Roadmap](https://github.com/withspectrum/spectrum/projects/19)
 - [Technical](docs/)
   - [Testing](docs/testing/intro.md)
-  - [Background Jobs](docs/backend/background-jobs.md)
+  - [Background Jobs](docs/workers/background-jobs.md)
   - [Deployment](docs/deployments.md)
   - [API](docs/backend/api/)
     - [Fragments](docs/backend/api/fragments.md)


### PR DESCRIPTION
Hello,

I've discovered that the reference to _Background Jobs_ in the README was leading to a `404`. This fixes it with the, hopefully, correct reference. Nothing else has been changed.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)
- desktop
- athena
- vulcan
- mercury
- hermes
- chronos
- pluto
- mobile

**Run database migrations (delete if no migration was added)**
YES

**Release notes for users (delete if codebase-only change)**
-
<!--
If your pull request introduces changes to the user interface on Spectrum, please share before and after screenshots of the changes (gifs or videos are encouraged for interaction changes). Please include screenshots of desktop and mobile viewports to ensure that all responsive cases are reviewed.
-->

**Related issues (delete if you don't know any existing issue(s) that could be related to this PR)**
<!--
If your PR closes an existing issue you can write "Closes #issue_number" or if it's related to another issue you can write "Related to #issue_number"
-->
