### PR TITLE
Community channel detail views

### DIFF
--- a/mobile/components/Lists/LoadingListItem.js
+++ b/mobile/components/Lists/LoadingListItem.js
@@ -3,11 +3,17 @@ import React, { Component } from 'react';
 import { ListItem } from './ListItem';
 import Loading from '../Loading';
 
-export class LoadingListItem extends Component<{}> {
+type Props = {
+  padding?: number,
+  divider?: boolean,
+};
+
+export class LoadingListItem extends Component<Props> {
   render() {
+    const { divider, padding } = this.props;
     return (
-      <ListItem onPressHandler={() => {}}>
-        <Loading />
+      <ListItem divider={divider} onPressHandler={() => {}}>
+        <Loading padding={padding} />
       </ListItem>
     );
   }

--- a/mobile/views/ChannelDetail/index.js
+++ b/mobile/views/ChannelDetail/index.js
@@ -1,0 +1,141 @@
+// @flow
+import * as React from 'react';
+import { Share } from 'react-native';
+import compose from 'recompose/compose';
+import {
+  getChannelById,
+  type GetChannelType,
+} from '../../../shared/graphql/queries/channel/getChannel';
+import toggleChannelSubscription, {
+  type ToggleChannelSubscriptionProps,
+} from '../../../shared/graphql/mutations/channel/toggleChannelSubscription';
+import ViewNetworkHandler from '../../components/ViewNetworkHandler';
+import Loading from '../../components/Loading';
+import { FullscreenNullState } from '../../components/NullStates';
+import { Wrapper } from './style';
+import {
+  ListItemWithButton,
+  ListSection,
+  ListSectionDivider,
+} from '../../components/Lists';
+import MutationWrapper from '../../components/MutationWrapper';
+import type { NavigationProps } from 'react-navigation';
+import ModeratorList from '../CommunityDetail/ModeratorList';
+
+type Props = {
+  isLoading: boolean,
+  hasError: boolean,
+  navigation: NavigationProps,
+  data: { channel?: GetChannelType },
+  ...$Exact<ToggleChannelSubscriptionProps>,
+};
+
+class ChannelDetail extends React.Component<Props> {
+  shareChannel = () => {
+    const { channel } = this.props.data;
+
+    if (!channel) return;
+
+    return Share.share(
+      {
+        url: `https://spectrum.chat/${channel.community.slug}/${channel.slug}`,
+        title: `${channel.name} channel`,
+      },
+      {
+        subject: `${channel.name} community`,
+      }
+    );
+  };
+
+  render() {
+    const { data: { channel }, isLoading, hasError } = this.props;
+
+    if (channel && channel.id) {
+      const variables = { channelId: channel.id };
+      const { channelPermissions } = channel;
+
+      return (
+        <Wrapper>
+          <ListSectionDivider title={'Team'} />
+
+          <ListSection>
+            <ModeratorList
+              id={channel.community.id}
+              first={20}
+              filter={{ isModerator: true, isOwner: true }}
+            />
+          </ListSection>
+
+          <ListSectionDivider />
+
+          <ListSection>
+            <ListItemWithButton
+              onPressHandler={this.shareChannel}
+              title={'Share'}
+              divider={false}
+            />
+          </ListSection>
+
+          <ListSectionDivider />
+
+          <ListSection>
+            {channelPermissions.isMember && (
+              <MutationWrapper
+                mutation={this.props.toggleChannelSubscription}
+                variables={variables}
+                render={({ onPressHandler, isLoading }) => (
+                  <ListItemWithButton
+                    isLoading={isLoading}
+                    onPressHandler={onPressHandler}
+                    title={`Leave channel`}
+                    divider={false}
+                    type={'destructive'}
+                  />
+                )}
+              />
+            )}
+
+            {!channelPermissions.isMember &&
+              !channelPermissions.isBlocked && (
+                <MutationWrapper
+                  mutation={this.props.toggleChannelSubscription}
+                  variables={variables}
+                  render={({ isLoading, onPressHandler }) => (
+                    <ListItemWithButton
+                      isLoading={isLoading}
+                      onPressHandler={onPressHandler}
+                      title={`Join channel`}
+                      divider={false}
+                    />
+                  )}
+                />
+              )}
+          </ListSection>
+
+          <ListSectionDivider />
+          <ListSectionDivider />
+        </Wrapper>
+      );
+    }
+
+    if (isLoading) {
+      return (
+        <Wrapper>
+          <Loading />
+        </Wrapper>
+      );
+    }
+
+    if (hasError) {
+      return <FullscreenNullState />;
+    }
+
+    return null;
+  }
+}
+
+export default compose(
+  getChannelById,
+  toggleChannelSubscription,
+  ViewNetworkHandler
+)(ChannelDetail);

--- a/mobile/views/ChannelDetail/style.js
+++ b/mobile/views/ChannelDetail/style.js
@@ -1,0 +1,8 @@
+// @flow
+import styled from 'styled-components/native';
+import { ScrollView } from 'react-native';
+
+export const Wrapper = styled(ScrollView)`
+  background-color: ${props => props.theme.bg.wash};
+  flex: 1;
+`;

--- a/mobile/views/CommunityDetail/ChannelList.js
+++ b/mobile/views/CommunityDetail/ChannelList.js
@@ -1,0 +1,73 @@
+// @flow
+import * as React from 'react';
+import compose from 'recompose/compose';
+import { withNavigation, type NavigationProps } from 'react-navigation';
+import getCommunityChannels, {
+  type GetCommunityChannelConnectionType,
+} from '../../../shared/graphql/queries/community/getCommunityChannelConnection';
+import ViewNetworkHandler from '../../components/ViewNetworkHandler';
+import { LoadingListItem, ListItemWithTitle } from '../../components/Lists';
+
+type Props = {
+  data: {
+    community: GetCommunityChannelConnectionType,
+  },
+  navigation: NavigationProps,
+  isLoading: boolean,
+  isFetchingMore: boolean,
+  currentUser: Object,
+};
+
+class ChannelList extends React.Component<Props> {
+  render() {
+    const { data: { community }, isLoading, navigation } = this.props;
+
+    if (community && community.channelConnection) {
+      const nodes = community.channelConnection.edges
+        .map(channel => channel && channel.node)
+        .filter(channel => {
+          if (!channel) return null;
+          if (channel.isPrivate && !channel.channelPermissions.isMember)
+            return null;
+
+          return channel;
+        })
+        .filter(channel => channel && !channel.channelPermissions.isBlocked);
+
+      return (
+        <React.Fragment>
+          {nodes.map((node, index) => {
+            if (!node) return null;
+
+            return (
+              <ListItemWithTitle
+                key={node.id}
+                onPressHandler={() =>
+                  navigation.navigate({
+                    routeName: 'Channel',
+                    key: node.id,
+                    params: { id: node.id },
+                  })
+                }
+                title={`# ${node.name}`}
+                divider={index !== nodes.length - 1}
+              />
+            );
+          })}
+        </React.Fragment>
+      );
+    }
+
+    if (isLoading) {
+      return <LoadingListItem divider={false} />;
+    }
+
+    return null;
+  }
+}
+
+export default compose(
+  withNavigation,
+  getCommunityChannels,
+  ViewNetworkHandler
+)(ChannelList);

--- a/mobile/views/CommunityDetail/ModeratorList.js
+++ b/mobile/views/CommunityDetail/ModeratorList.js
@@ -1,0 +1,77 @@
+// @flow
+import * as React from 'react';
+import compose from 'recompose/compose';
+import { withNavigation, type NavigationProps } from 'react-navigation';
+import getCommunityMembersQuery, {
+  type GetCommunityMembersType,
+} from '../../../shared/graphql/queries/community/getCommunityMembers';
+import ViewNetworkHandler from '../../components/ViewNetworkHandler';
+import { LoadingListItem, UserListItem } from '../../components/Lists';
+
+type Props = {
+  data: {
+    community: GetCommunityMembersType,
+  },
+  navigation: NavigationProps,
+  isLoading: boolean,
+  isFetchingMore: boolean,
+  currentUser: Object,
+};
+
+class ModeratorList extends React.Component<Props> {
+  shouldComponentUpdate() {
+    // NOTE(@brian) This is needed to avoid conflicting the the members tab in
+    // the community view. See https://github.com/withspectrum/spectrum/pull/2613#pullrequestreview-105861623
+    // for discussion
+    // never update once we have the list of team members
+    if (this.props.data && this.props.data.community) return false;
+    return true;
+  }
+
+  render() {
+    const { data: { community }, isLoading, navigation } = this.props;
+
+    if (community && community.members) {
+      const { edges: members } = community.members;
+      const nodes = members
+        .map(member => member && member.node)
+        .filter(node => node && (node.isOwner || node.isModerator));
+
+      return (
+        <React.Fragment>
+          {nodes.map((node, index) => {
+            if (!node) return null;
+            const { user } = node;
+
+            return (
+              <UserListItem
+                key={user.id}
+                onPressHandler={() =>
+                  navigation.navigate({
+                    routeName: 'User',
+                    key: user.id,
+                    params: { id: user.id },
+                  })
+                }
+                user={user}
+                divider={index !== nodes.length - 1}
+              />
+            );
+          })}
+        </React.Fragment>
+      );
+    }
+
+    if (isLoading) {
+      return <LoadingListItem divider={false} />;
+    }
+
+    return null;
+  }
+}
+
+export default compose(
+  withNavigation,
+  getCommunityMembersQuery,
+  ViewNetworkHandler
+)(ModeratorList);

--- a/mobile/views/CommunityDetail/index.js
+++ b/mobile/views/CommunityDetail/index.js
@@ -1,0 +1,149 @@
+// @flow
+import * as React from 'react';
+import { Share } from 'react-native';
+import compose from 'recompose/compose';
+import { getCommunityById } from '../../../shared/graphql/queries/community/getCommunity';
+import ViewNetworkHandler from '../../components/ViewNetworkHandler';
+import Loading from '../../components/Loading';
+import { FullscreenNullState } from '../../components/NullStates';
+import { Wrapper } from './style';
+import {
+  ListItemWithButton,
+  ListSection,
+  ListSectionDivider,
+} from '../../components/Lists';
+import MutationWrapper from '../../components/MutationWrapper';
+import type { GetCommunityType } from '../../../shared/graphql/queries/community/getCommunity';
+import type { NavigationProps } from 'react-navigation';
+import addCommunityMember from '../../../shared/graphql/mutations/communityMember/addCommunityMember';
+import removeCommunityMember from '../../../shared/graphql/mutations/communityMember/removeCommunityMember';
+import ModeratorList from './ModeratorList';
+import ChannelList from './ChannelList';
+
+type Props = {
+  isLoading: boolean,
+  hasError: boolean,
+  navigation: NavigationProps,
+  data: { community?: GetCommunityType },
+  addCommunityMember: Function,
+  removeCommunityMember: Function,
+};
+
+class CommunityDetail extends React.Component<Props> {
+  shareCommunity = () => {
+    const { community } = this.props.data;
+
+    if (!community) return;
+
+    return Share.share(
+      {
+        url: `https://spectrum.chat/${community.slug}`,
+        title: `${community.name} community`,
+      },
+      {
+        subject: `${community.name} community`,
+      }
+    );
+  };
+
+  render() {
+    const { data: { community }, isLoading, hasError } = this.props;
+
+    if (community && community.id) {
+      const variables = { input: { communityId: community.id } };
+      const { communityPermissions } = community;
+
+      return (
+        <Wrapper>
+          <ListSectionDivider title={'Team'} />
+
+          <ListSection>
+            <ModeratorList
+              id={community.id}
+              first={20}
+              filter={{ isModerator: true, isOwner: true }}
+            />
+          </ListSection>
+
+          <ListSectionDivider title={'Channels'} />
+
+          <ListSection>
+            <ChannelList id={community.id} communitySlug={community.slug} />
+          </ListSection>
+
+          <ListSectionDivider />
+
+          <ListSection>
+            <ListItemWithButton
+              onPressHandler={this.shareCommunity}
+              title={'Share'}
+              divider={false}
+            />
+          </ListSection>
+
+          <ListSectionDivider />
+
+          <ListSection>
+            {communityPermissions.isMember &&
+              !communityPermissions.isOwner &&
+              !communityPermissions.isModerator && (
+                <MutationWrapper
+                  mutation={this.props.removeCommunityMember}
+                  variables={variables}
+                  render={({ onPressHandler, isLoading }) => (
+                    <ListItemWithButton
+                      isLoading={isLoading}
+                      onPressHandler={onPressHandler}
+                      title={`Leave community`}
+                      divider={false}
+                      type={'destructive'}
+                    />
+                  )}
+                />
+              )}
+
+            {!communityPermissions.isMember &&
+              !communityPermissions.isBlocked && (
+                <MutationWrapper
+                  mutation={this.props.addCommunityMember}
+                  variables={variables}
+                  render={({ onPressHandler, isLoading }) => (
+                    <ListItemWithButton
+                      isLoading={isLoading}
+                      onPressHandler={onPressHandler}
+                      title={`Join ${community.name}`}
+                      divider={false}
+                    />
+                  )}
+                />
+              )}
+          </ListSection>
+
+          <ListSectionDivider />
+          <ListSectionDivider />
+        </Wrapper>
+      );
+    }
+
+    if (isLoading) {
+      return (
+        <Wrapper>
+          <Loading />
+        </Wrapper>
+      );
+    }
+
+    if (hasError) {
+      return <FullscreenNullState />;
+    }
+
+    return null;
+  }
+}
+
+export default compose(
+  getCommunityById,
+  addCommunityMember,
+  removeCommunityMember,
+  ViewNetworkHandler
+)(CommunityDetail);

--- a/mobile/views/CommunityDetail/style.js
+++ b/mobile/views/CommunityDetail/style.js
@@ -1,0 +1,8 @@
+// @flow
+import styled from 'styled-components/native';
+import { ScrollView } from 'react-native';
+
+export const Wrapper = styled(ScrollView)`
+  background-color: ${props => props.theme.bg.wash};
+  flex: 1;
+`;

--- a/mobile/views/TabBar/BaseStack.js
+++ b/mobile/views/TabBar/BaseStack.js
@@ -7,11 +7,13 @@ import ThreadDetail from '../ThreadDetail';
 import Community from '../Community';
 import CommunityDetail from '../CommunityDetail';
 import Channel from '../Channel';
+import ChannelDetail from '../ChannelDetail';
 import User from '../User';
 import { withMappedNavigationProps } from 'react-navigation-props-mapper';
 import type { NavigationScreenConfigProps } from 'react-navigation';
 import NavigateToThreadDetails from './headerActions/NavigateToThreadDetails';
 import NavigateToCommunityDetails from './headerActions/NavigateToCommunityDetails';
+import NavigateToChannelDetails from './headerActions/NavigateToChannelDetails';
 
 const BaseStack = {
   ThreadDetail: {
@@ -40,10 +42,17 @@ const BaseStack = {
       headerRight: <NavigateToCommunityDetails navigation={navigation} />,
     }),
   },
+  ChannelDetail: {
+    screen: withMappedNavigationProps(ChannelDetail),
+    navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
+      headerTitle: 'Details',
+    }),
+  },
   Channel: {
     screen: withMappedNavigationProps(Channel),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
       headerTitle: navigation.getParam('title', null),
+      headerRight: <NavigateToChannelDetails navigation={navigation} />,
     }),
   },
   User: {

--- a/mobile/views/TabBar/BaseStack.js
+++ b/mobile/views/TabBar/BaseStack.js
@@ -5,11 +5,13 @@ import React from 'react';
 import Thread from '../Thread';
 import ThreadDetail from '../ThreadDetail';
 import Community from '../Community';
+import CommunityDetail from '../CommunityDetail';
 import Channel from '../Channel';
 import User from '../User';
 import { withMappedNavigationProps } from 'react-navigation-props-mapper';
 import type { NavigationScreenConfigProps } from 'react-navigation';
 import NavigateToThreadDetails from './headerActions/NavigateToThreadDetails';
+import NavigateToCommunityDetails from './headerActions/NavigateToCommunityDetails';
 
 const BaseStack = {
   ThreadDetail: {
@@ -25,10 +27,17 @@ const BaseStack = {
       headerRight: <NavigateToThreadDetails navigation={navigation} />,
     }),
   },
+  CommunityDetail: {
+    screen: withMappedNavigationProps(CommunityDetail),
+    navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
+      headerTitle: 'Details',
+    }),
+  },
   Community: {
     screen: withMappedNavigationProps(Community),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
       headerTitle: navigation.getParam('title', null),
+      headerRight: <NavigateToCommunityDetails navigation={navigation} />,
     }),
   },
   Channel: {

--- a/mobile/views/TabBar/headerActions/NavigateToChannelDetails.js
+++ b/mobile/views/TabBar/headerActions/NavigateToChannelDetails.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react';
+import type { NavigationProps } from 'react-navigation';
+import { Button } from 'react-native';
+
+type Props = {
+  navigation: NavigationProps,
+};
+
+export default class NavigateToChannelDetails extends React.Component<Props> {
+  navigate = () => {
+    const { navigation } = this.props;
+    return navigation.navigate({
+      routeName: `ChannelDetail`,
+      key: `channel-detail-${navigation.state.key}`,
+      params: { id: navigation.state.params.id },
+    });
+  };
+  render() {
+    return <Button onPress={this.navigate} title="Settings" />;
+  }
+}

--- a/mobile/views/TabBar/headerActions/NavigateToCommunityDetails.js
+++ b/mobile/views/TabBar/headerActions/NavigateToCommunityDetails.js
@@ -1,0 +1,22 @@
+// @flow
+import * as React from 'react';
+import type { NavigationProps } from 'react-navigation';
+import { Button } from 'react-native';
+
+type Props = {
+  navigation: NavigationProps,
+};
+
+export default class NavigateToCommunityDetails extends React.Component<Props> {
+  navigate = () => {
+    const { navigation } = this.props;
+    return navigation.navigate({
+      routeName: `CommunityDetail`,
+      key: `community-detail-${navigation.state.key}`,
+      params: { id: navigation.state.params.id },
+    });
+  };
+  render() {
+    return <Button onPress={this.navigate} title="Settings" />;
+  }
+}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- mobile

Adds a detail view for communities and channels to share, view the community owner/admins, channels, and actions to leave/join. At some point I will swap out the navigation link from 'Settings' to an icon that better captures the context of this view.