### PR TITLE
Add User Details Screen

### DIFF
--- a/mobile/components/Lists/CommunityListItem.js
+++ b/mobile/components/Lists/CommunityListItem.js
@@ -11,9 +11,10 @@ import {
   ViewForwardContainer,
 } from './style';
 import type { GetCommunityType } from '../../../shared/graphql/queries/community/getCommunity';
+import type { CommunityInfoType } from '../../../shared/graphql/fragments/community/communityInfo';
 
 type Props = {
-  community: GetCommunityType,
+  community: GetCommunityType | CommunityInfoType,
   onPressHandler: Function,
   divider?: boolean,
 };
@@ -35,11 +36,12 @@ export class CommunityListItem extends Component<Props> {
 
         <TextColumnContainer>
           <Title numberOfLines={1}>{community.name}</Title>
-          {community.metaData && (
-            <Subtitle numberOfLines={1}>
-              {community.metaData.members} members
-            </Subtitle>
-          )}
+          {community.metaData &&
+            community.metaData.members && (
+              <Subtitle numberOfLines={1}>
+                {community.metaData.members} members
+              </Subtitle>
+            )}
         </TextColumnContainer>
 
         <ViewForwardContainer>

--- a/mobile/views/TabBar/BaseStack.js
+++ b/mobile/views/TabBar/BaseStack.js
@@ -8,12 +8,14 @@ import Community from '../Community';
 import CommunityDetail from '../CommunityDetail';
 import Channel from '../Channel';
 import ChannelDetail from '../ChannelDetail';
+import UserDetail from '../UserDetail';
 import User from '../User';
 import { withMappedNavigationProps } from 'react-navigation-props-mapper';
 import type { NavigationScreenConfigProps } from 'react-navigation';
 import NavigateToThreadDetails from './headerActions/NavigateToThreadDetails';
 import NavigateToCommunityDetails from './headerActions/NavigateToCommunityDetails';
 import NavigateToChannelDetails from './headerActions/NavigateToChannelDetails';
+import NavigateToUserDetails from './headerActions/NavigateToUserDetails';
 
 const BaseStack = {
   ThreadDetail: {
@@ -59,6 +61,13 @@ const BaseStack = {
     screen: withMappedNavigationProps(User),
     navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
       headerTitle: navigation.getParam('title', null),
+      headerRight: <NavigateToUserDetails navigation={navigation} />,
+    }),
+  },
+  UserDetail: {
+    screen: withMappedNavigationProps(UserDetail),
+    navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
+      headerTitle: 'Details',
     }),
   },
 };

--- a/mobile/views/TabBar/HomeStack.js
+++ b/mobile/views/TabBar/HomeStack.js
@@ -16,9 +16,6 @@ const HomeStack = createStackNavigator(
       screen: withMappedNavigationProps(Dashboard),
       navigationOptions: ({ navigation }: NavigationScreenConfigProps) => ({
         headerTitle: 'Home',
-        headerLeft: (
-          <Button onPress={() => store.dispatch(logout())} title="Log out" />
-        ),
         headerRight: (
           <Button
             onPress={() => navigation.navigate('ThreadComposer')}

--- a/mobile/views/TabBar/headerActions/NavigateToUserDetails.js
+++ b/mobile/views/TabBar/headerActions/NavigateToUserDetails.js
@@ -1,0 +1,23 @@
+// @flow
+import * as React from 'react';
+import type { NavigationProps } from 'react-navigation';
+import { Button } from 'react-native';
+
+type Props = {
+  navigation: NavigationProps,
+};
+
+export default class NavigateToThreadDetails extends React.Component<Props> {
+  navigate = () => {
+    const { navigation } = this.props;
+    return navigation.navigate({
+      routeName: `UserDetail`,
+      key: `user-detail-${navigation.state.key}`,
+      params: { id: navigation.state.params.id },
+    });
+  };
+
+  render() {
+    return <Button onPress={this.navigate} title="Details" />;
+  }
+}

--- a/mobile/views/User/profile.js
+++ b/mobile/views/User/profile.js
@@ -56,12 +56,22 @@ class User extends Component<Props, State> {
     navigation.setParams({ title });
   };
 
+  setId = () => {
+    const { data: { user }, navigation } = this.props;
+    if (!user) return;
+    const oldId = navigation.getParam('id', null);
+    if (oldId === user.id) return;
+    navigation.setParams({ id: user.id });
+  };
+
   componentDidMount() {
     this.setTitle();
+    this.setId();
   }
 
   componentDidUpdate() {
     this.setTitle();
+    this.setId();
   }
 
   toggleFeed = (feed: string) => this.setState({ feed });

--- a/mobile/views/UserDetail/index.js
+++ b/mobile/views/UserDetail/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Fragment } from 'react';
+import * as React from 'react';
 import { Share } from 'react-native';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';
@@ -7,11 +7,10 @@ import {
   ListItemWithButton,
   ListSectionDivider,
   ListSection,
-  ListItemWithTitle,
   CommunityListItem,
 } from '../../components/Lists';
 import Loading from '../../components/Loading';
-import Text from '../../components/Text';
+import { FullscreenNullState } from '../../components/NullStates';
 import {
   withCurrentUser,
   type WithCurrentUserProps,
@@ -73,48 +72,80 @@ class UserDetail extends React.Component<Props> {
 
     if (user) {
       return (
-        <Fragment>
-          <ListSectionDivider title="Member of" />
-          <ListSection>
-            {user.communityConnection.edges
-              .filter(Boolean)
-              .map(({ node: community }, index) => (
-                <CommunityListItem
-                  key={community.id}
-                  community={community}
-                  divider={index !== user.communityConnection.edges.length - 1}
-                  onPressHandler={() =>
-                    navigation.navigate({
-                      routeName: 'Community',
-                      key: community.id,
-                      params: { id: community.id },
-                    })
-                  }
-                />
-              ))}
-          </ListSection>
+        <React.Fragment>
+          {user.communityConnection.edges &&
+            user.communityConnection.edges.length > 0 && (
+              <React.Fragment>
+                <ListSectionDivider title="Member of" />
+                <ListSection>
+                  {user.communityConnection.edges
+                    .filter(Boolean)
+                    .map(({ node: community }, index) => (
+                      <CommunityListItem
+                        key={community.id}
+                        community={community}
+                        divider={
+                          index !== user.communityConnection.edges.length - 1
+                        }
+                        onPressHandler={() =>
+                          navigation.navigate({
+                            routeName: 'Community',
+                            key: community.id,
+                            params: { id: community.id },
+                          })
+                        }
+                      />
+                    ))}
+                </ListSection>
+              </React.Fragment>
+            )}
 
           <ListSectionDivider />
+
           <ListSection>
-            <ListItemWithButton title="Share" onPressHandler={this.share} />
-            {currentUser &&
-              currentUser.id === user.id && (
-                <ListItemWithButton
-                  type="destructive"
-                  title="Log Out"
-                  onPressHandler={this.logout}
-                />
-              )}
+            <ListItemWithButton
+              title="Share"
+              onPressHandler={this.share}
+              divider={false}
+            />
           </ListSection>
-        </Fragment>
+
+          {currentUser &&
+            currentUser.id === user.id && (
+              <React.Fragment>
+                <ListSectionDivider />
+
+                <ListSection>
+                  <ListItemWithButton
+                    type="destructive"
+                    title="Log Out"
+                    onPressHandler={this.logout}
+                    divider={false}
+                  />
+                </ListSection>
+              </React.Fragment>
+            )}
+
+          <ListSectionDivider />
+          <ListSectionDivider />
+        </React.Fragment>
       );
     }
 
-    if (hasError) return <Text type="title1">Error!</Text>;
+    if (hasError) {
+      return <FullscreenNullState />;
+    }
 
-    if (isLoading) return <Loading />;
+    if (isLoading) {
+      return <Loading />;
+    }
 
-    return null;
+    return (
+      <FullscreenNullState
+        title={'We had trouble loading this user’s details'}
+        subtitle={''}
+      />
+    );
   }
 }
 

--- a/mobile/views/UserDetail/index.js
+++ b/mobile/views/UserDetail/index.js
@@ -1,0 +1,126 @@
+// @flow
+import React, { Fragment } from 'react';
+import { Share } from 'react-native';
+import compose from 'recompose/compose';
+import { connect } from 'react-redux';
+import {
+  ListItemWithButton,
+  ListSectionDivider,
+  ListSection,
+  ListItemWithTitle,
+  CommunityListItem,
+} from '../../components/Lists';
+import Loading from '../../components/Loading';
+import Text from '../../components/Text';
+import {
+  withCurrentUser,
+  type WithCurrentUserProps,
+} from '../../components/WithCurrentUser';
+import viewNetworkHandler, {
+  type ViewNetworkHandlerProps,
+} from '../../components/ViewNetworkHandler';
+import { logout } from '../../actions/authentication';
+import {
+  getUserCommunityConnection,
+  type GetUserCommunityConnectionType,
+} from '../../../shared/graphql/queries/user/getUserCommunityConnection';
+import type { NavigationProp } from 'react-navigation';
+
+type Props = {
+  ...$Exact<ViewNetworkHandlerProps>,
+  ...$Exact<WithCurrentUserProps>,
+  navigation: NavigationProp,
+  id: string,
+  dispatch: Function,
+  data: {
+    user?: GetUserCommunityConnectionType,
+  },
+};
+
+class UserDetail extends React.Component<Props> {
+  navigateToCommunity = (communityId: string) => () => {
+    this.props.navigation.navigate('Community', { id: communityId });
+  };
+
+  logout = () => {
+    this.props.dispatch(logout());
+  };
+
+  share = () => {
+    const { user } = this.props.data;
+
+    if (!user) return;
+
+    return Share.share(
+      {
+        url: `https://spectrum.chat/users/${user.username}`,
+        title: `${user.name} (@${user.username}) on Spectrum`,
+      },
+      {
+        subject: `${user.name} (@${user.username}) on Spectrum`,
+      }
+    );
+  };
+
+  render() {
+    const {
+      currentUser,
+      data: { user },
+      isLoading,
+      hasError,
+      navigation,
+    } = this.props;
+
+    if (user) {
+      return (
+        <Fragment>
+          <ListSectionDivider title="Member of" />
+          <ListSection>
+            {user.communityConnection.edges
+              .filter(Boolean)
+              .map(({ node: community }, index) => (
+                <CommunityListItem
+                  key={community.id}
+                  community={community}
+                  divider={index !== user.communityConnection.edges.length - 1}
+                  onPressHandler={() =>
+                    navigation.navigate({
+                      routeName: 'Community',
+                      key: community.id,
+                      params: { id: community.id },
+                    })
+                  }
+                />
+              ))}
+          </ListSection>
+
+          <ListSectionDivider />
+          <ListSection>
+            <ListItemWithButton title="Share" onPressHandler={this.share} />
+            {currentUser &&
+              currentUser.id === user.id && (
+                <ListItemWithButton
+                  type="destructive"
+                  title="Log Out"
+                  onPressHandler={this.logout}
+                />
+              )}
+          </ListSection>
+        </Fragment>
+      );
+    }
+
+    if (hasError) return <Text type="title1">Error!</Text>;
+
+    if (isLoading) return <Loading />;
+
+    return null;
+  }
+}
+
+export default compose(
+  connect(),
+  withCurrentUser,
+  getUserCommunityConnection,
+  viewNetworkHandler
+)(UserDetail);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- mobile

**Related issues (delete if you don't know of any)**
Closes #3346

Adds a `UserDetail` screen similar to what we have in the `CommunityDetail`/`ThreadDetail`/`ChannelDetail` screens. It shows a list of the communities a user is a member of, a "Share" button and, if it's your own detail screen, a "Logout" button!

I made it a `UserDetail` rather than `UserSettings` screen since the list of communities isn't really a setting and we do want to show that for all users. We could, in the future, show a `UserSettings` screen instead of the `UserDetail` screen if you're viewing your own profile, but let's tackle that when it's necessary.

<img width="539" alt="screen shot 2018-06-19 at 10 07 04" src="https://user-images.githubusercontent.com/7525670/41585892-9dde9dfa-73ab-11e8-9714-643a256a1888.png">
