### PR TITLE
Rework mobile type system

### DIFF
--- a/mobile/components/Message/index.js
+++ b/mobile/components/Message/index.js
@@ -169,7 +169,7 @@ class Message extends React.Component<Props, State> {
             )}
           >
             <Text
-              color={me ? '#FFFFFF' : '#000000'}
+              color={theme => (me ? theme.text.reverse : theme.text.default)}
               fontSize={emojiOnly ? 24 : undefined}
               style={{ marginTop: 0, marginBottom: 0 }}
             >

--- a/mobile/components/Text/getTypeConfigFromType.js
+++ b/mobile/components/Text/getTypeConfigFromType.js
@@ -1,0 +1,81 @@
+// @flow
+import type { TextTypes } from './';
+
+export default (type: TextTypes) => {
+  const defaultConfig = {
+    size: 17,
+    leading: 22,
+  };
+
+  switch (type) {
+    case 'largeTitle': {
+      return {
+        size: 36,
+        leading: 41,
+      };
+    }
+    case 'title1': {
+      return {
+        size: 32,
+        leading: 34,
+      };
+    }
+    case 'title2': {
+      return {
+        size: 24,
+        leading: 28,
+      };
+    }
+    case 'title3': {
+      return {
+        size: 20,
+        leading: 25,
+      };
+    }
+    case 'headline': {
+      return {
+        size: 18,
+        leading: 22,
+      };
+    }
+    case 'body': {
+      return {
+        size: 16,
+        leading: 22,
+      };
+    }
+    case 'callout': {
+      return {
+        size: 15,
+        leading: 21,
+      };
+    }
+    case 'subhead': {
+      return {
+        size: 14,
+        leading: 20,
+      };
+    }
+    case 'footnote': {
+      return {
+        size: 13,
+        leading: 18,
+      };
+    }
+    case 'caption1': {
+      return {
+        size: 12,
+        leading: 16,
+      };
+    }
+    case 'caption2': {
+      return {
+        size: 11,
+        leading: 13,
+      };
+    }
+    default: {
+      return defaultConfig;
+    }
+  }
+};

--- a/mobile/components/Text/getWeightFromType.js
+++ b/mobile/components/Text/getWeightFromType.js
@@ -1,0 +1,27 @@
+// @flow
+import type { WeightTypes } from './';
+
+export default (type: WeightTypes) => {
+  switch (type) {
+    case 'thin':
+      return '100';
+    case 'ultraLight':
+      return '200';
+    case 'light':
+      return '300';
+    case 'regular':
+      return '400';
+    case 'medium':
+      return '500';
+    case 'semibold':
+      return '600';
+    case 'bold':
+      return '700';
+    case 'heavy':
+      return '800';
+    case 'black':
+      return '900';
+    default:
+      return '400';
+  }
+};

--- a/mobile/components/Text/index.js
+++ b/mobile/components/Text/index.js
@@ -1,11 +1,12 @@
 // @flow
 import type { Node } from 'react';
 import { Platform } from 'react-native';
-import styled, { css } from 'styled-components/native';
-import { human } from 'react-native-typography';
+import styled from 'styled-components/native';
 import type { ComponentType } from 'react';
+import getTypeConfigFromType from './getTypeConfigFromType';
+import getWeightFromType from './getWeightFromType';
 
-type TextTypes =
+export type TextTypes =
   | 'largeTitle'
   | 'title1'
   | 'title2'
@@ -18,34 +19,44 @@ type TextTypes =
   | 'caption1'
   | 'caption2';
 
+export type WeightTypes =
+  | 'thin'
+  | 'ultraLight'
+  | 'light'
+  | 'regular'
+  | 'medium'
+  | 'semibold'
+  | 'bold'
+  | 'heavy'
+  | 'black';
+
 export type Props = {
   type?: TextTypes,
-  bold?: boolean,
+  weight?: WeightTypes,
   italic?: boolean,
   underline?: boolean,
   fontFamily?: 'monospace',
-  color?: string | Function,
+  color?: Function,
   children: Node,
 };
 
 const monospaceFont = Platform.OS === 'android' ? 'monospace' : 'Menlo';
 
 const Text: ComponentType<Props> = styled.Text`
-  ${(props: Props) => props.type && human[`${props.type}Object`]}
-  ${(props: Props) => {
-    const type = props.type || 'body';
-    return `margin-top: ${human[`${type}Object`].lineHeight * 0.35};`;
-  }}
-  ${(props: Props) => props.bold && 'font-weight: bold;'}
-  ${(props: Props) => props.italic && 'font-style: italic;'}
-  ${(props: Props) => props.underline && 'text-decoration-line: underline;'}
+  font-weight: ${props =>
+    props.weight ? `${getWeightFromType(props.weight)}` : '400'};
+  font-size: ${props => getTypeConfigFromType(props.type).size}px;
+  line-height: ${props => getTypeConfigFromType(props.type).leading}px;
+  color: ${props =>
+    props.color ? props.color(props.theme) : props.theme.text.default};
+
+  ${(props: Props) => props.italic && 'font-style: italic;'} ${(props: Props) =>
+    props.underline &&
+    'text-decoration-line: underline;'}
+
+  font-family: 'System';
   ${(props: Props) =>
-    props.color &&
-    css`
-      color: ${props.color};
-    `}
-  ${(props: Props) =>
-    props.fontFamily === 'monospace' && `font-family: ${monospaceFont};`}
+    props.fontFamily === 'monospace' && `font-family: ${monospaceFont};`};
 `;
 
 export default Text;

--- a/mobile/views/UserOnboarding/ExploreCommunities/CommunityProfileCard/style.js
+++ b/mobile/views/UserOnboarding/ExploreCommunities/CommunityProfileCard/style.js
@@ -1,7 +1,9 @@
 // @flow
+import * as React from 'react';
 import styled from 'styled-components/native';
 import { Dimensions } from 'react-native';
 import { Row } from '../../../../components/Flex';
+import Text from '../../../../components/Text';
 
 const { width } = Dimensions.get('window');
 
@@ -32,28 +34,50 @@ export const CommunityProfilePhoto = styled.Image`
   border-radius: 8px;
 `;
 
-export const CommunityProfileName = styled.Text`
-  font-size: 18px;
-  font-weight: 800;
-  color: ${props => props.theme.text.default};
-  margin-top: 16px;
-`;
+export const CommunityProfileName = ({ children }: any) => {
+  const customStyles = {
+    marginTop: 16,
+  };
 
-export const CommunityProfileDescription = styled.Text`
-  margin-top: 12px;
-  font-size: 16px;
-  font-weight: 500;
-  color: ${props => props.theme.text.secondary};
-  line-height: 22;
-`;
+  return (
+    <Text type="headline" weight={'heavy'} style={customStyles}>
+      {children}
+    </Text>
+  );
+};
 
-export const CommunityProfileMemberCount = styled.Text`
-  margin-top: 8px;
-  font-size: 14px;
-  font-weight: 600;
-  letter-spacing: 0.3px;
-  color: ${props => props.theme.text.alt};
-`;
+export const CommunityProfileDescription = ({ children }: any) => {
+  const customStyles = {
+    marginTop: 12,
+  };
+
+  return (
+    <Text
+      type="body"
+      color={theme => theme.text.secondary}
+      style={customStyles}
+    >
+      {children}
+    </Text>
+  );
+};
+
+export const CommunityProfileMemberCount = ({ children }: any) => {
+  const customStyles = {
+    marginTop: 8,
+  };
+
+  return (
+    <Text
+      type="subhead"
+      weight={'semibold'}
+      color={theme => theme.text.alt}
+      style={customStyles}
+    >
+      {children}
+    </Text>
+  );
+};
 
 export const CommunityProfileHeader = styled(Row)`
   justify-content: space-between;

--- a/mobile/views/UserOnboarding/ExploreCommunities/style.js
+++ b/mobile/views/UserOnboarding/ExploreCommunities/style.js
@@ -1,7 +1,8 @@
 // @flow
+import * as React from 'react';
 import styled from 'styled-components/native';
 import { ScrollView } from 'react-native';
-import { ViewSubtitle } from '../style';
+import Text from '../../../components/Text';
 import { BlurView } from 'expo';
 import { isIPhoneX } from '../../../utils/platform';
 
@@ -18,20 +19,6 @@ export const CommunityCardListScrollView = styled(ScrollView)`
   padding: 32px 0;
 `;
 
-export const ExploreSectionHeader = styled.Text`
-  font-size: 28px;
-  font-weight: 800;
-  color: ${props => props.theme.text.default};
-  margin-top: 32px;
-  letter-spacing: -0.3;
-`;
-
-export const ExploreSectionSubheader = styled(ViewSubtitle)`
-  font-size: 18px;
-  line-height: 24;
-  margin-bottom: 0;
-`;
-
 export const ContinueButtonContainer = styled(BlurView)`
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
@@ -46,3 +33,31 @@ export const ContinueButtonContainer = styled(BlurView)`
   shadow-opacity: 0.1;
   shadow-radius: 8;
 `;
+
+export const ExploreSectionHeader = ({ children }: any) => {
+  const customStyles = {
+    marginTop: 32,
+  };
+
+  return (
+    <Text type={'title2'} weight={'heavy'} style={customStyles}>
+      {children}
+    </Text>
+  );
+};
+
+export const ExploreSectionSubheader = ({ children }: any) => {
+  const customStyles = {
+    marginTop: 8,
+  };
+
+  return (
+    <Text
+      type={'headline'}
+      color={theme => theme.text.alt}
+      style={customStyles}
+    >
+      {children}
+    </Text>
+  );
+};

--- a/mobile/views/UserOnboarding/style.js
+++ b/mobile/views/UserOnboarding/style.js
@@ -1,6 +1,8 @@
 // @flow
+import * as React from 'react';
 import styled from 'styled-components/native';
 import { ScrollView } from 'react-native';
+import Text from '../../components/Text';
 
 export const UserOnboardingWrapper = styled.View`
   flex: 1;
@@ -41,26 +43,30 @@ export const UsernameInput = styled.TextInput.attrs({
   font-size: 18px;
 `;
 
-export const ViewTitle = styled.Text`
-  font-size: 34px;
-  letter-spacing: -0.3;
-  line-height: 40;
-  font-weight: 800;
-  color: ${props => props.theme.text.default};
-  max-width: 100%;
-  margin-bottom: 8px;
-`;
+export const ViewTitle = ({ children }: any) => {
+  const customStyles = {
+    marginBottom: 8,
+  };
 
-export const ViewSubtitle = styled.Text`
-  font-size: 20px;
-  width: 100%;
-  max-width: 100%;
-  line-height: 28;
-  font-weight: 500;
-  color: ${props => props.theme.text.alt};
-  margin-bottom: 16px;
-  margin-top: 8px;
-`;
+  return (
+    <Text type={'largeTitle'} weight={'heavy'} style={customStyles}>
+      {children}
+    </Text>
+  );
+};
+
+export const ViewSubtitle = ({ children }: any) => {
+  const customStyles = {
+    marginTop: 8,
+    marginBottom: 16,
+  };
+
+  return (
+    <Text type={'title3'} color={theme => theme.text.alt} style={customStyles}>
+      {children}
+    </Text>
+  );
+};
 
 export const SaveButtonWrapper = styled.View`
   margin-bottom: 16px;
@@ -83,17 +89,4 @@ export const CommunityCardListScrollView = styled(ScrollView)`
   margin-left: -16px;
   margin-right: -16px;
   padding: 32px 0;
-`;
-
-export const ExploreSectionHeader = styled.Text`
-  font-size: 24px;
-  font-weight: 700;
-  color: ${props => props.theme.text.default};
-  margin-top: 32px;
-`;
-
-export const ExploreSectionSubheader = styled(ViewSubtitle)`
-  font-size: 16px;
-  line-height: 20;
-  margin-bottom: 0;
 `;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- mobile

kk @mxstbr made some tweaks to the type system to move back to having a centralized `Text` component which we can use to maintain consistent type sizes and weights across the board; things are overrideable at the instance level, which you can see in the second commit here.

Would love your feedback - if this feels good I'll go through and migrate the rest of our custom `styled.Text` instances over to the new component.