### PR TITLE
Fix dashboard SSR

### DIFF
--- a/shared/middlewares/thread-param.js
+++ b/shared/middlewares/thread-param.js
@@ -2,7 +2,7 @@
 
 const threadParamRedirect = (req, res, next) => {
   // Redirect /?t=asdf123 if the user isn't logged in
-  if (req.query.t) {
+  if (req.query.t && !req.user) {
     res.redirect(`/thread/${req.query.t}`);
     // Redirect /anything?thread=asdf123
   } else if (req.query.thread) {

--- a/src/index.js
+++ b/src/index.js
@@ -22,45 +22,32 @@ import { track, events } from './helpers/analytics';
 import { wsLink } from 'shared/graphql';
 import { subscribeToDesktopPush } from './subscribe-to-desktop-push';
 
-const { thread, t } = queryString.parse(history.location.search);
+const storedData: ?Object = getItemFromStorage('spectrum');
+const params = queryString.parse(history.location.search);
 
-const existingUser = getItemFromStorage('spectrum');
-let initialState;
-if (existingUser) {
-  initialState = {
+// Always redirect ?thread=asdfxyz to the thread view
+if (params.thread) history.replace(`/thread/${params.thread}`);
+
+// Redirect ?t=asdfxyz to the thread view only for anonymous users who wouldn't see it
+// in their inbox view (since they don't have an inbox view)
+if ((!storedData || !storedData.currentUser) && params.t)
+  history.replace(`/thread/${params.t}`);
+
+// If the server passes an initial redux state use that, otherwise construct our own
+const store = initStore(
+  window.__SERVER_STATE__ || {
     users: {
-      currentUser: existingUser.currentUser,
+      currentUser: storedData ? storedData.currentUser : null,
     },
     dashboardFeed: {
-      activeThread: t ? t : '',
-      mountedWithActiveThread: t ? t : '',
+      activeThread: params.t || '',
+      mountedWithActiveThread: params.t || '',
       search: {
         isOpen: false,
       },
     },
-  };
-} else {
-  initialState = {};
-}
-
-if (thread) {
-  const hash = window.location.hash.substr(1);
-  if (hash && hash.length > 1) {
-    history.replace(`/thread/${thread}#${hash}`);
-  } else {
-    history.replace(`/thread/${thread}`);
   }
-}
-if (t) {
-  const hash = window.location.hash.substr(1);
-  if (hash && hash.length > 1) {
-    history.replace(`/thread/${t}#${hash}`);
-  } else {
-    history.replace(`/thread/${t}`);
-  }
-}
-
-const store = initStore(window.__SERVER_STATE__ || initialState);
+);
 
 const App = hot(module)(() => {
   return (

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -13,10 +13,8 @@ import threadSlider from './threadSlider';
 import notifications from './notifications';
 import message from './message';
 import connectionStatus from './connectionStatus';
-import type { Reducer } from 'redux';
 
-// Allow dependency injection of extra reducers, we need this for SSR
-const getReducers = (extraReducers: { [key: string]: Reducer<*, *> }) => {
+const getReducers = () => {
   return combineReducers({
     users,
     modals,
@@ -31,7 +29,6 @@ const getReducers = (extraReducers: { [key: string]: Reducer<*, *> }) => {
     notifications,
     connectionStatus,
     message,
-    ...extraReducers,
   });
 };
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,3 +1,4 @@
+// @flow
 /* eslint-disable */
 import { createStore, compose, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
@@ -13,33 +14,17 @@ const composeEnhancers =
 
 // init the store with the thunkMiddleware which allows us to make async actions play nicely with the store
 // Allow dependency injection of extra reducers and middleware, we need this for SSR
-export const initStore = (
-  initialState,
-  { middleware = [], reducers = {} } = {}
-) => {
-  let store;
-  if (initialState) {
-    store = createStore(
-      getReducers(reducers),
-      initialState,
-      composeEnhancers(
-        applyMiddleware(...middleware, thunkMiddleware, crashReporter)
-      )
-    );
-  } else {
-    store = createStore(
-      getReducers(reducers),
-      {},
-      composeEnhancers(
-        applyMiddleware(...middleware, thunkMiddleware, crashReporter)
-      )
-    );
-  }
+export const initStore = (initialState?: Object) => {
+  let store = createStore(
+    getReducers(),
+    initialState || {},
+    composeEnhancers(applyMiddleware(thunkMiddleware, crashReporter))
+  );
 
-  if (module.hot) {
+  if (module.hot && typeof module.hot.accept === 'function') {
     module.hot.accept('../reducers', () => {
-      const nextRootReducer = require('../reducers/index');
-      store.replaceReducer(nextRootReducer);
+      const nextGetReducers = require('../reducers/index').default;
+      store.replaceReducer(nextGetReducers());
     });
   }
 

--- a/src/views/dashboard/components/threadFeed.js
+++ b/src/views/dashboard/components/threadFeed.js
@@ -118,8 +118,9 @@ class ThreadFeed extends React.Component<Props, State> {
     const hasThreadsButNoneSelected =
       this.props.data.threads && !this.props.selectedId;
     const justLoadedThreads =
-      (!prevProps.data.threads && this.props.data.threads) ||
-      (prevProps.data.loading && !this.props.data.loading);
+      !mountedWithActiveThread &&
+      ((!prevProps.data.threads && this.props.data.threads) ||
+        (prevProps.data.loading && !this.props.data.loading));
 
     if (
       isDesktop &&

--- a/src/views/dashboard/components/threadFeed.js
+++ b/src/views/dashboard/components/threadFeed.js
@@ -103,17 +103,12 @@ class ThreadFeed extends React.Component<Props, State> {
       return;
     }
 
-    // if the app loaded with a ?t query param, it means the user was linked to a thread from the inbox view and is already logged in. In this case we want to load the thread identified in the url and ignore the fact that a feed is loading in which auto-selects a different thread. If the user is on mobile, we should push them to the thread detail view
-    if (this.props.data.threads && mountedWithActiveThread) {
-      if (!isDesktop) {
-        this.props.history.replace(`/?thread=${mountedWithActiveThread}`);
-      }
+    // If we mount with ?t and are on mobile, we have to redirect to ?thread
+    if (!isDesktop && mountedWithActiveThread) {
+      this.props.history.replace(`/?thread=${mountedWithActiveThread}`);
       this.props.dispatch({ type: 'REMOVE_MOUNTED_THREAD_ID' });
       return;
     }
-
-    // don't select a thread if the composer is open
-    if (prevProps.selectedId === 'new') return;
 
     const hasThreadsButNoneSelected =
       this.props.data.threads && !this.props.selectedId;
@@ -121,6 +116,17 @@ class ThreadFeed extends React.Component<Props, State> {
       !mountedWithActiveThread &&
       ((!prevProps.data.threads && this.props.data.threads) ||
         (prevProps.data.loading && !this.props.data.loading));
+
+    // if the app loaded with a ?t query param, it means the user was linked to a thread from the inbox view and is already logged in. In this case we want to load the thread identified in the url and ignore the fact that a feed is loading in which auto-selects a different thread.
+    if (justLoadedThreads && mountedWithActiveThread) {
+      this.props.dispatch({ type: 'REMOVE_MOUNTED_THREAD_ID' });
+      return;
+    }
+
+    // don't select a thread if the composer is open
+    if (prevProps.selectedId === 'new') {
+      return;
+    }
 
     if (
       isDesktop &&

--- a/src/views/dashboard/index.js
+++ b/src/views/dashboard/index.js
@@ -52,7 +52,6 @@ const SearchThreadFeed = compose(connect(), searchThreadsQuery)(
 );
 
 type State = {
-  isHovered: boolean,
   activeChannelObject: ?Object,
 };
 
@@ -71,22 +70,7 @@ type Props = {
 
 class Dashboard extends React.Component<Props, State> {
   state = {
-    isHovered: false,
     activeChannelObject: null,
-  };
-
-  setHover = () => {
-    setTimeout(() => {
-      this.setState({
-        isHovered: true,
-      });
-    }, 1000);
-  };
-
-  removeHover = () => {
-    this.setState({
-      isHovered: false,
-    });
   };
 
   setActiveChannelObject = (channel: Object) => {
@@ -116,7 +100,7 @@ class Dashboard extends React.Component<Props, State> {
       everythingFeed: false,
       creatorId: null,
       channelId: activeChannel || null,
-      communityId: activeChannel ? null : activeCommunity || null
+      communityId: activeChannel ? null : activeCommunity || null,
     };
     const { title, description } = generateMetaInfo();
 
@@ -133,7 +117,9 @@ class Dashboard extends React.Component<Props, State> {
       }
 
       // at this point we have succesfully validated a user, and the user has both a username and joined communities - we can show their thread feed!
-      const communities = user.communityConnection.edges.map(c => c && c.node);
+      const communities = user.communityConnection.edges
+        .filter(Boolean)
+        .map(({ node: community }) => community);
       const activeCommunityObject = communities.find(
         c => c && c.id === activeCommunity
       );


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Ref #3303

@brianlovin 63ad628db _should_ fix the `?t` query param even when SSR'ing I think? I haven't been able to verify because I can't seem to log into the SSR'd site locally anymore. (not sure why) Further down below we check `(hasThreadsButNoneSelected || loadedNewThreads)` before selecting the first thread, which means even if one was selected as soon as new ones load in it would select the first one, right? So this new condition should make sure that doesn't happen if we mounted with that thread.