### PR TITLE
Fix ServiceWorker caching

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -108,6 +108,7 @@ module.exports = function override(config, env) {
       caches: process.env.NODE_ENV === 'development' ? {} : 'all',
       externals,
       autoUpdate: true,
+      rewrites: arg => arg,
       ServiceWorker: {
         entry: './public/push-sw.js',
         events: true,


### PR DESCRIPTION
> Note: This is cherry-picked from #3334 since that's not quite done yet, but this should go live asap.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This might fix both the ServiceWorker error we've been getting in prod a ton and the stale notifications stuff. I can't for sure say that it will (:fingers_crossed:) but this definitely fixes our ServiceWorker caching.

Previously, we were (accidentally) caching the homepage as the app shell, which means we'd serve the SSR'd homepage (or dashboard if you were signed in) on every subsequent pageload. This fixes it by not caching `/`, but caching `/index.html`, the app shell, as intended. (offline-plugin by default rewrites `xyz/index.html` to `xyz/`; this disables that automatic rewrite)