### PR TITLE
Stop ServiceWorker from returning app shell for /auth and /api

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -108,6 +108,16 @@ module.exports = function override(config, env) {
       caches: process.env.NODE_ENV === 'development' ? {} : 'all',
       externals,
       autoUpdate: true,
+      cacheMaps: [
+        {
+          match(url) {
+            const EXTERNAL_PATHS = ['/api', '/auth'];
+            if (EXTERNAL_PATHS.some(path => url.pathname.indexOf(path) === 0))
+              return false;
+            return url;
+          },
+        },
+      ],
       rewrites: arg => arg,
       ServiceWorker: {
         entry: './public/push-sw.js',

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -110,9 +110,13 @@ module.exports = function override(config, env) {
       autoUpdate: true,
       cacheMaps: [
         {
-          match(url) {
-            const EXTERNAL_PATHS = ['/api', '/auth'];
-            if (EXTERNAL_PATHS.some(path => url.pathname.indexOf(path) === 0))
+          match: function(url) {
+            var EXTERNAL_PATHS = ['/api', '/auth'];
+            if (
+              EXTERNAL_PATHS.some(function(path) {
+                return url.pathname.indexOf(path) === 0;
+              })
+            )
               return false;
             return url;
           },


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

People couldn't authenticate because the ServiceWorker would return the app shell for the `/api` and `/auth` routes, when we really want it to go to the server for those.

This _should_ remedy that broken behavior—let's get it on alpha and test?