### PR TITLE
Simplify path aliases

### DIFF
--- a/rules-alpha.json
+++ b/rules-alpha.json
@@ -1,12 +1,9 @@
 {
   "rules": [
     { "pathname": "/robots.txt", "dest": "robots.alpha.spectrum.chat" },
-    { "pathname": "/api", "dest": "api.alpha.spectrum.chat" },
-    { "pathname": "/api/**", "dest": "api.alpha.spectrum.chat" },
-    { "pathname": "/auth", "dest": "api.alpha.spectrum.chat" },
-    { "pathname": "/auth/**", "dest": "api.alpha.spectrum.chat" },
-    { "pathname": "/websocket", "dest": "api.alpha.spectrum.chat" },
-    { "pathname": "/websocket/**", "dest": "api.alpha.spectrum.chat" },
+    { "pathname": "/api**", "dest": "api.alpha.spectrum.chat" },
+    { "pathname": "/auth**", "dest": "api.alpha.spectrum.chat" },
+    { "pathname": "/websocket**", "dest": "api.alpha.spectrum.chat" },
     { "dest": "hyperion.alpha.spectrum.chat" }
   ]
 }

--- a/rules.json
+++ b/rules.json
@@ -1,11 +1,8 @@
 {
   "rules": [
-    { "pathname": "/api", "dest": "api.spectrum.chat" },
-    { "pathname": "/api/**", "dest": "api.spectrum.chat" },
-    { "pathname": "/auth", "dest": "api.spectrum.chat" },
-    { "pathname": "/auth/**", "dest": "api.spectrum.chat" },
-    { "pathname": "/websocket", "dest": "api.spectrum.chat" },
-    { "pathname": "/websocket/**", "dest": "api.spectrum.chat" },
+    { "pathname": "/api**", "dest": "api.spectrum.chat" },
+    { "pathname": "/auth**", "dest": "api.spectrum.chat" },
+    { "pathname": "/websocket**", "dest": "api.spectrum.chat" },
     { "dest": "hyperion.workers.spectrum.chat" }
   ]
 }


### PR DESCRIPTION
I'm just refactoring and simplifying the path aliases in `rules.json` and `rules-alpha.json` in this PR.

I already tested the use of `/folder**` in `rules.json` on my own projects, so it should be safe 🙂 

But it's better to not stick to my words and try it with `alpha`.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
No microservice need to be redeployed.

To deploy and test the new aliases on alpha :
```
now alias -r rules-alpha.json alpha.spectrum.chat
```

To deploy the new aliases on the main branch :
```
now alias -r rules.json spectrum.chat
```

UPDATE : I probably shouldn't have runned the test for that 😬 Sorry