### PR TITLE
Fix broken authentication

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -121,10 +121,10 @@ module.exports = function override(config, env) {
               })
             )
               return false;
-            // This function will be stringified and injected into the client, where
-            // window.location will be a thing
+            // This function will be stringified and injected into the ServiceWorker on the client, where
+            // location will be a thing
             // eslint-disable-next-line no-restricted-globals
-            return new URL('./index.html', window.location);
+            return new URL('./index.html', location);
           },
           requestTypes: ['navigate'],
         },

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -104,10 +104,13 @@ module.exports = function override(config, env) {
   });
   config.plugins.push(
     new OfflinePlugin({
-      appShell: '/index.html',
       caches: process.env.NODE_ENV === 'development' ? {} : 'all',
       externals,
       autoUpdate: true,
+      // NOTE(@mxstbr): Normally this is handled by setting
+      // appShell: './index.html'
+      // but we don't want to serve the app shell for the `/api` and `/auth` routes
+      // which means we have to manually do this and filter any of those routes out
       cacheMaps: [
         {
           match: function(url) {
@@ -118,8 +121,12 @@ module.exports = function override(config, env) {
               })
             )
               return false;
-            return url;
+            // This function will be stringified and injected into the client, where
+            // window.location will be a thing
+            // eslint-disable-next-line no-restricted-globals
+            return new URL('./index.html', window.location);
           },
+          requestTypes: ['navigate'],
         },
       ],
       rewrites: arg => arg,


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

The ServiceWorker would automatically return our app shell for all navigation requests, including to `/auth/xyz`—which meant that users were served the app instead of getting redirected to their auth provider of choice.

This fixes it by disabling the built-in `appShell` option and then copying exactly what it does BUT filtering out the `/auth` route first. (and the `/api` route for good measure)

> /cc @NekR it would be nice if there was a built-in option for this behavior (excluding certain routes from the app shell) or if the default `appShell` cache map would be added as the first cache map , not as the last cache map, so it can be overridden.
> https://github.com/NekR/offline-plugin/blob/ddec2aa93a7ea1cf8f0338518f96cf9f521607c9/src/index.js#L130-L140 It says here that it's added before the custom ones, but it's actually added after them as far as I can tell