### PR TITLE
Fix email validation email redirects for users without usernames

### DIFF
--- a/api/routes/api/email.js
+++ b/api/routes/api/email.js
@@ -193,16 +193,13 @@ emailRouter.get('/validate', (req, res) => {
 
   // and send a database request to update the user record with this email
   try {
-    return updateUserEmail(userId, email).then(
-      user =>
-        IS_PROD
-          ? res.redirect(
-              `https://spectrum.chat/users/${user.username}/settings`
-            )
-          : res.redirect(
-              `http://localhost:3000/users/${user.username}/settings`
-            )
-    );
+    return updateUserEmail(userId, email).then(user => {
+      const rootRedirect = IS_PROD
+        ? `https://spectrum.chat`
+        : `http://localhost:3000`;
+      if (!user.username) return res.redirect(rootRedirect);
+      return res.redirect(`${rootRedirect}/users/${user.username}/settings`);
+    });
   } catch (err) {
     console.error(err);
     return res


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

Closes https://sentry.io/space-program/spectrum/issues/561302243/

Not sure exactly the state that causes this, but my hunch is that it's people who have deleted an account who are clicking verification email links when their username no longer exists.