### PR TITLE
Fix notifications pagination

### DIFF
--- a/athena/queues/thread-notification.js
+++ b/athena/queues/thread-notification.js
@@ -4,17 +4,6 @@ import Raven from 'shared/raven';
 import axios from 'axios';
 import getMentions from 'shared/get-mentions';
 import { toPlainText, toState } from 'shared/draft-utils';
-import { fetchPayload, createPayload } from '../utils/payloads';
-import { getDistinctActors } from '../utils/actors';
-import {
-  storeNotification,
-  updateNotification,
-  checkForExistingNotification,
-} from '../models/notification';
-import {
-  storeUsersNotifications,
-  markUsersNotificationsAsNew,
-} from '../models/usersNotifications';
 import { getUserById, getUsers } from '../models/user';
 import { getCommunityById } from '../models/community';
 import { getMembersInChannelWithNotifications } from '../models/usersChannels';
@@ -34,63 +23,10 @@ export default async (job: Job<ThreadNotificationJobData>) => {
   const { thread: incomingThread } = job.data;
   debug(`new job for a thread by ${incomingThread.creatorId}`);
 
-  const [
-    actor,
-    context,
-    entity,
-    channelSlackSettings,
-    communitySlackSettings,
-  ] = await Promise.all([
-    fetchPayload('USER', incomingThread.creatorId),
-    fetchPayload('CHANNEL', incomingThread.channelId),
-    createPayload('THREAD', incomingThread),
+  const [channelSlackSettings, communitySlackSettings] = await Promise.all([
     getChannelSettings(incomingThread.channelId),
     getCommunitySettings(incomingThread.communityId),
   ]);
-  const eventType = 'THREAD_CREATED';
-
-  // determine if a notification already exists
-  const existing = await checkForExistingNotification(
-    eventType,
-    incomingThread.channelId
-  );
-
-  // handle the notification record in the db
-  // if it exists, we'll be updating it with new actors and entities
-  const handleNotificationRecord = existing
-    ? updateNotification
-    : storeNotification;
-
-  // handle the usersNotification record in the db
-  // if it exists, we'll mark it as new to trigger a badge in the app
-  const handleUsersNotificationRecord = existing
-    ? markUsersNotificationsAsNew
-    : storeUsersNotifications;
-
-  // actors should always be distinct to make client side rendering easier
-  const distinctActors = existing
-    ? getDistinctActors([...existing.actors, actor])
-    : [actor];
-
-  // append the new thread to the list of entities
-  const entities = existing ? [...existing.entities, entity] : [entity];
-
-  // construct a new notification record to either be updated or stored in the db
-  const nextNotificationRecord = Object.assign(
-    {},
-    {
-      ...existing,
-      event: eventType,
-      actors: distinctActors,
-      context,
-      entities,
-    }
-  );
-
-  // update or store a record in the notifications table, returns a notification
-  const updatedNotification = await handleNotificationRecord(
-    nextNotificationRecord
-  );
 
   // get the members in the channel who should receive notifications
   const recipients = await getMembersInChannelWithNotifications(
@@ -127,12 +63,6 @@ export default async (job: Job<ThreadNotificationJobData>) => {
   const recipientsWithoutMentions = filteredRecipients.filter(r => {
     return r.username && mentions.indexOf(r.username) < 0;
   });
-
-  // for each recipient that *wasn't* mentioned, create a notification in the db
-  const usersNotificationPromises = recipientsWithoutMentions.map(
-    async recipient =>
-      await handleUsersNotificationRecord(updatedNotification.id, recipient.id)
-  );
 
   let slackNotificationPromise;
   if (
@@ -217,7 +147,6 @@ export default async (job: Job<ThreadNotificationJobData>) => {
 
   return Promise.all([
     createThreadNotificationEmail(incomingThread, recipientsWithoutMentions), // handle emails separately
-    ...usersNotificationPromises, // update or store usersNotifications in-app
     slackNotificationPromise,
   ]).catch(err => {
     debug('❌ Error in job:\n');

--- a/shared/graphql/queries/notification/getNotifications.js
+++ b/shared/graphql/queries/notification/getNotifications.js
@@ -60,9 +60,6 @@ export const getNotificationsQuery = gql`
 `;
 
 export const getNotificationsOptions = {
-  options: () => ({
-    fetchPolicy: 'cache-and-network',
-  }),
   props: ({
     data: {
       fetchMore,

--- a/src/components/appViewWrapper/index.js
+++ b/src/components/appViewWrapper/index.js
@@ -1,8 +1,6 @@
 // @flow
 import React from 'react';
-// $FlowFixMe
 import compose from 'recompose/compose';
-// $FlowFixMe
 import { withRouter } from 'react-router';
 import { Wrapper } from './style';
 
@@ -14,5 +12,4 @@ const AppViewWrapperPure = (props: Object): React$Element<any> => (
   </Wrapper>
 );
 
-const AppViewWrapper = compose(withRouter)(AppViewWrapperPure);
-export default AppViewWrapper;
+export default compose(withRouter)(AppViewWrapperPure);

--- a/src/views/notifications/components/notificationDropdownList.js
+++ b/src/views/notifications/components/notificationDropdownList.js
@@ -8,7 +8,6 @@ import { MiniNewMessageNotification } from './newMessageNotification';
 import { MiniNewReactionNotification } from './newReactionNotification';
 import { MiniNewThreadReactionNotification } from './newThreadReactionNotification';
 import { MiniNewChannelNotification } from './newChannelNotification';
-import { MiniNewThreadNotification } from './newThreadNotification';
 import { MiniNewUserInCommunityNotification } from './newUserInCommunityNotification';
 import { MiniCommunityInviteNotification } from './communityInviteNotification';
 import { MiniMentionMessageNotification } from './mentionMessageNotification';
@@ -108,18 +107,8 @@ export class NotificationDropdownList extends React.Component<Props> {
               );
             }
             case 'THREAD_CREATED': {
-              return (
-                <ErrorBoundary fallbackComponent={null} key={notification.id}>
-                  <MiniNewThreadNotification
-                    notification={notification}
-                    currentUser={currentUser}
-                    history={history}
-                    markSingleNotificationAsSeenInState={
-                      markSingleNotificationAsSeenInState
-                    }
-                  />
-                </ErrorBoundary>
-              );
+              // deprecated - we no longer show this notification type in-app
+              return null;
             }
             case 'COMMUNITY_INVITE': {
               return (

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -309,17 +309,7 @@ class NotificationsPure extends React.Component<Props, State> {
                     );
                   }
                   case 'THREAD_CREATED': {
-                    return (
-                      <ErrorBoundary
-                        fallbackComponent={null}
-                        key={notification.id}
-                      >
-                        <NewThreadNotification
-                          notification={notification}
-                          currentUser={currentUser}
-                        />
-                      </ErrorBoundary>
-                    );
+                    return null;
                   }
                   case 'COMMUNITY_INVITE': {
                     return (

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -138,23 +138,23 @@ class NotificationsPure extends React.Component<Props, State> {
 
   subscribeToWebPush = () => {
     track(events.WEB_PUSH_NOTIFICATIONS_PROMPT_CLICKED);
-    // this.setState({
-    //   webPushPromptLoading: true,
-    // });
+    this.setState({
+      webPushPromptLoading: true,
+    });
     WebPushManager.subscribe()
       .then(subscription => {
         track(events.WEB_PUSH_NOTIFICATIONS_SUBSCRIBED);
-        // this.setState({
-        //   webPushPromptLoading: false,
-        //   showWebPushPrompt: false,
-        // });
+        this.setState({
+          webPushPromptLoading: false,
+          showWebPushPrompt: false,
+        });
         return this.props.subscribeToWebPush(subscription);
       })
       .catch(err => {
         track(events.WEB_PUSH_NOTIFICATIONS_BLOCKED);
-        // this.setState({
-        //   webPushPromptLoading: false,
-        // });
+        this.setState({
+          webPushPromptLoading: false,
+        });
         console.error(err);
         return this.props.dispatch(
           addToastWithTimeout(
@@ -166,9 +166,9 @@ class NotificationsPure extends React.Component<Props, State> {
   };
 
   dismissWebPushRequest = () => {
-    // this.setState({
-    //   showWebPushPrompt: false,
-    // });
+    this.setState({
+      showWebPushPrompt: false,
+    });
     track(events.WEB_PUSH_NOTIFICATIONS_PROMPT_DISMISSED);
   };
 

--- a/src/views/thread/components/threadCommunityBanner.js
+++ b/src/views/thread/components/threadCommunityBanner.js
@@ -134,7 +134,7 @@ class ThreadCommunityBanner extends React.Component<Props, State> {
                     {channel.name}
                   </Link>
                 )}
-                <span>{` · ${timestamp}`}</span>
+                <Link to={`/thread/${id}`}>&nbsp;{`· ${timestamp}`}</Link>
               </CommunityHeaderSubtitle>
             </CommunityHeaderMetaCol>
           </CommunityHeaderMeta>

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -800,7 +800,7 @@ export const AnimatedContainer = styled.div`
   top: 0;
   left: 0;
   right: 0;
-  z-index: ${zIndex.chrome + 10};
+  z-index: ${zIndex.composerToolbar + 1};
 
   @media (max-width: 768px) {
     display: none;

--- a/src/views/threadSlider/style.js
+++ b/src/views/threadSlider/style.js
@@ -38,7 +38,7 @@ export const Thread = styled.div`
   display: flex;
   position: absolute;
   right: 0;
-  top: 48px;
+  top: 0;
   bottom: 0;
   width: 650px;
   background: #fff;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)
- athena

cc @mxstbr 
This implements my suggestion to not show new thread notifications in-app anymore. Really we should just rely on the feed to keep people updated; notifications should be reserved for super high-signal events (thus, @ mentions in threads will still trigger in app notifs)

Also, the last commit where I removed the fetch policy magically fixed pagination being broken on the notifications view. Very weird.

Closes #3423 and #3425 
Also should close #2145 