### PR TITLE
Fix thread selected state in inbox on mobile

### DIFF
--- a/src/views/dashboard/components/inboxThread/index.js
+++ b/src/views/dashboard/components/inboxThread/index.js
@@ -49,15 +49,16 @@ class InboxThread extends React.Component<Props> {
       currentUser,
     } = this.props;
 
-    let queryPrefix;
-    if (
-      // TODO(@mxstbr): Fix this to not use window.innerWidth
-      // which breaks SSR rehydration on mobile devices
+    // TODO(@mxstbr): Fix this to not use window.innerWidth
+    // which breaks SSR rehydration on mobile devices
+    const isDesktopInbox =
       window.innerWidth > 768 &&
       (!viewContext ||
         viewContext === 'communityInbox' ||
-        viewContext === 'channelInbox')
-    ) {
+        viewContext === 'channelInbox');
+
+    let queryPrefix;
+    if (isDesktopInbox) {
       queryPrefix = '?t';
     } else {
       queryPrefix = '?thread';
@@ -71,7 +72,10 @@ class InboxThread extends React.Component<Props> {
               pathname: location.pathname,
               search: `${queryPrefix}=${thread.id}`,
             }}
-            onClick={() => this.props.dispatch(changeActiveThread(thread.id))}
+            onClick={() =>
+              isDesktopInbox &&
+              this.props.dispatch(changeActiveThread(thread.id))
+            }
           />
 
           <InboxThreadContent>


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Fixes a bug where on mobile threads in the inbox would have the purple selected background after navigating back to the feed from a thread view.