### PR TITLE
Small thread card improvements

### DIFF
--- a/src/views/dashboard/components/inboxThread/index.js
+++ b/src/views/dashboard/components/inboxThread/index.js
@@ -63,6 +63,12 @@ class InboxThread extends React.Component<Props> {
       queryPrefix = '?thread';
     }
 
+    const newMessagesSinceLastViewed =
+      !active &&
+      thread.currentUserLastSeen &&
+      thread.lastActive &&
+      thread.currentUserLastSeen < thread.lastActive;
+
     return (
       <ErrorBoundary fallbackComponent={null}>
         <InboxThreadItem active={active}>
@@ -113,7 +119,7 @@ class InboxThread extends React.Component<Props> {
                 />
               </ErrorBoundary>
 
-              <ThreadTitle active={active}>
+              <ThreadTitle active={active} new={newMessagesSinceLastViewed}>
                 {truncate(thread.content.title, 80)}
               </ThreadTitle>
 

--- a/src/views/dashboard/components/inboxThread/index.js
+++ b/src/views/dashboard/components/inboxThread/index.js
@@ -81,6 +81,7 @@ class InboxThread extends React.Component<Props> {
                   <Avatar
                     user={thread.author.user}
                     src={`${thread.author.user.profilePhoto}`}
+                    isOnline={thread.author.user.isOnline}
                     size={'40'}
                     link={
                       thread.author.user.username &&

--- a/src/views/dashboard/components/inboxThread/style.js
+++ b/src/views/dashboard/components/inboxThread/style.js
@@ -63,7 +63,7 @@ export const Column = styled.div`
 
 export const ThreadTitle = styled.h3`
   font-size: 16px;
-  font-weight: 500;
+  font-weight: ${props => (props.new ? '600' : '400')};
   color: ${props =>
     props.active ? props.theme.text.reverse : props.theme.text.default};
   max-width: 100%;

--- a/src/views/dashboard/components/inboxThread/style.js
+++ b/src/views/dashboard/components/inboxThread/style.js
@@ -137,7 +137,6 @@ const avatarLinkStyles = css`
   margin-right: 12px;
   margin-top: 4px;
   pointer-events: auto;
-  overflow: hidden;
   max-width: 40px;
 `;
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

- Adds online indicators to user avatars in thread cards
- Adds a bold/regular weight text styling based on if the thread has new content inside it (cc @mxstbr, open to feedback here - maybe it's not needed, but it feels kinda nice in dev)