### PR TITLE
[PoC] Better thread scrolling on web

### DIFF
--- a/src/hot-routes.js
+++ b/src/hot-routes.js
@@ -1,0 +1,7 @@
+// @flow
+// This takes the ./routes.js file and makes it hot reload.
+// This should only be used on the client, not on the server!
+import { hot } from 'react-hot-loader';
+import Routes from './routes';
+
+export default hot(module)(Routes);

--- a/src/index.js
+++ b/src/index.js
@@ -11,13 +11,12 @@ import queryString from 'query-string';
 import Loadable from 'react-loadable';
 import * as OfflinePluginRuntime from 'offline-plugin/runtime';
 import { HelmetProvider } from 'react-helmet-async';
-import { hot } from 'react-hot-loader';
 import webPushManager from './helpers/web-push-manager';
 import { history } from './helpers/history';
 import { client } from 'shared/graphql';
 import { initStore } from './store';
 import { getItemFromStorage } from './helpers/localStorage';
-import Routes from './routes';
+import Routes from './hot-routes';
 import { track, events } from './helpers/analytics';
 import { wsLink } from 'shared/graphql';
 import { subscribeToDesktopPush } from './subscribe-to-desktop-push';
@@ -49,7 +48,7 @@ const store = initStore(
   }
 );
 
-const App = hot(module)(() => {
+const App = () => {
   return (
     <Provider store={store}>
       <HelmetProvider>
@@ -61,7 +60,7 @@ const App = hot(module)(() => {
       </HelmetProvider>
     </Provider>
   );
-});
+};
 
 const renderMethod = !!window.__SERVER_STATE__
   ? // $FlowIssue

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -62,6 +62,7 @@ type State = {
   // while looking at a live thread
   lastSeen: ?number | ?string,
   bannerIsVisible: boolean,
+  stickToBottom: boolean,
 };
 
 class ThreadContainer extends React.Component<Props, State> {
@@ -79,6 +80,7 @@ class ThreadContainer extends React.Component<Props, State> {
     lastSeen: null,
     bannerIsVisible: false,
     scrollOffset: 0,
+    stickToBottom: false,
   };
 
   componentWillReceiveProps(next: Props) {
@@ -90,10 +92,20 @@ class ThreadContainer extends React.Component<Props, State> {
       curr.data.thread.id !== next.data.thread.id;
     // Update the cached lastSeen value when switching threads
     if (newThread || threadChanged) {
+      const stickToBottom =
+        !!next.data.thread.watercooler ||
+        !next.currentUser ||
+        next.data.thread.isAuthor ||
+        !next.data.thread.currentUserLastSeen ||
+        next.data.thread.participants
+          .filter(Boolean)
+          .some(user => user.id === next.currentUser.id);
+
       this.setState({
         lastSeen: next.data.thread.currentUserLastSeen
           ? next.data.thread.currentUserLastSeen
           : null,
+        stickToBottom,
       });
     }
   }
@@ -165,20 +177,37 @@ class ThreadContainer extends React.Component<Props, State> {
     const scrollOffset = e.target.scrollTop;
     try {
       const threadDetail = ReactDOM.findDOMNode(this.threadDetailElem);
+      const messagesContainer = ReactDOM.findDOMNode(
+        this.state.messagesContainer
+      );
       if (!threadDetail) return;
 
-      const {
-        height: threadDetailHeight,
+      requestAnimationFrame(() => {
+        const {
+          height: threadDetailHeight,
+          // $FlowFixMe
+        } = threadDetail.getBoundingClientRect();
+        const {
+          height: messagesContainerHeight,
+          // $FlowFixMe
+        } = messagesContainer.getBoundingClientRect();
         // $FlowFixMe
-      } = threadDetail.getBoundingClientRect();
-      const bannerShouldBeVisible = scrollOffset > threadDetailHeight;
-      if (bannerShouldBeVisible !== this.state.bannerIsVisible) {
-        this.setState({
-          bannerIsVisible: bannerShouldBeVisible,
-        });
-      }
+        const messagesContainerScrollHeight = messagesContainer.scrollHeight;
+        // To stick to the bottom we invert the scroll container, so we have to adjust our calculation of the scroll position
+        const bannerShouldBeVisible = this.state.stickToBottom
+          ? messagesContainerScrollHeight - messagesContainerHeight >
+            scrollOffset + threadDetailHeight
+          : scrollOffset > threadDetailHeight;
+        if (bannerShouldBeVisible !== this.state.bannerIsVisible) {
+          this.setState({
+            bannerIsVisible: bannerShouldBeVisible,
+          });
+        }
+      });
     } catch (err) {
-      // no need to do anything here
+      if (process.env.NODE_ENV === 'development') {
+        console.error(err);
+      }
     }
   };
 
@@ -203,7 +232,6 @@ class ThreadContainer extends React.Component<Props, State> {
       if (prevProps.threadId) {
         this.updateThreadLastSeen(prevProps.threadId);
       }
-      this.forceScrollToTop();
     }
 
     // we never autofocus on mobile
@@ -399,15 +427,7 @@ class ThreadContainer extends React.Component<Props, State> {
       const headDescription = isWatercooler
         ? `Watercooler chat for the ${thread.community.name} community`
         : description;
-
-      const stickToBottom =
-        isWatercooler ||
-        !currentUser ||
-        thread.isAuthor ||
-        !thread.currentUserLastSeen ||
-        thread.participants
-          .filter(Boolean)
-          .some(user => user.id === currentUser.id);
+      const { stickToBottom } = this.state;
 
       return (
         <ErrorBoundary>

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -236,10 +236,7 @@ class ThreadContainer extends React.Component<Props, State> {
   };
 
   forceScrollToBottom = () => {
-    const { messagesContainer } = this.state;
-    if (!messagesContainer) return;
-    const node = messagesContainer;
-    node.scrollTop = node.scrollHeight - node.clientHeight;
+    return;
   };
 
   contextualScrollToBottom = () => {
@@ -403,6 +400,15 @@ class ThreadContainer extends React.Component<Props, State> {
         ? `Watercooler chat for the ${thread.community.name} community`
         : description;
 
+      const stickToBottom =
+        isWatercooler ||
+        !currentUser ||
+        thread.isAuthor ||
+        !thread.currentUserLastSeen ||
+        thread.participants
+          .filter(Boolean)
+          .some(user => user.id === currentUser.id);
+
       return (
         <ErrorBoundary>
           <ThreadViewContainer
@@ -443,8 +449,11 @@ class ThreadContainer extends React.Component<Props, State> {
                 isVisible={this.state.bannerIsVisible}
               />
 
-              <Content innerRef={this.setMessagesContainer}>
-                <Detail type={slider ? '' : 'only'}>
+              <Content
+                invert={stickToBottom}
+                innerRef={this.setMessagesContainer}
+              >
+                <Detail invert={stickToBottom} type={slider ? '' : 'only'}>
                   {this.renderPost()}
 
                   {!isEditing && (

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -83,6 +83,11 @@ export const Content = styled(FlexRow)`
   max-width: 1024px;
   margin: 0 auto;
   background: ${props => props.theme.bg.default};
+  ${props =>
+    props.invert &&
+    css`
+      transform: scale(1, -1);
+    `};
 `;
 
 export const Input = styled(FlexRow)`
@@ -102,6 +107,11 @@ export const Detail = styled(Column)`
   flex: auto;
   margin: 0;
   max-width: 100%;
+  ${props =>
+    props.invert &&
+    css`
+      transform: scale(1, -1);
+    `};
 `;
 
 export const ChatInputWrapper = styled(FlexCol)`

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -75,7 +75,7 @@ export const ThreadSidebarView = styled(FlexCol)`
 
 export const Content = styled(FlexRow)`
   justify-content: center;
-  align-items: flex-start;
+  align-items: ${props => (props.invert ? 'flex-end' : 'flex-start')};
   flex: auto;
   overflow-y: auto;
   grid-area: body;

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -75,7 +75,7 @@ export const ThreadSidebarView = styled(FlexCol)`
 
 export const Content = styled(FlexRow)`
   justify-content: center;
-  align-items: ${props => (props.invert ? 'flex-end' : 'flex-start')};
+  align-items: flex-start;
   flex: auto;
   overflow-y: auto;
   grid-area: body;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] WIP
- [ ] Ready for review
- [x] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Instead of using a ton of custom code to scroll to the bottom of threads at the right time, we smartly invert the thread content container with a `transform`. This makes the browser automatically stick to the bottom of the scroll, no matter if the images load in slowly afterwards or not.

This is a proof of concept because, while the scrolling already works better than before, this has tons of bugs to iron out and lots of testing needed before it's anywere near production-ready.

- [x] Sticky thread header shows at wrong time
- [x] Fix space above thread title
- [ ] Figure out all edge cases
- [ ] Remove all custom `forceScrollToBottom` logic
- [ ] Make sure `forceScrollToTop` is actually needed
- [ ] Make sure the `contextualScrollToBottom` method is used in the right places at the right time
- [ ] Bonus: Figure out why the thread message connection sometimes doesn't get the right pagination arguments