### PR TITLE
Fix thread message pagination in long threads

### DIFF
--- a/shared/graphql/queries/thread/getThreadMessageConnection.js
+++ b/shared/graphql/queries/thread/getThreadMessageConnection.js
@@ -53,7 +53,7 @@ export const getThreadMessageConnectionOptions = {
     };
 
     // Any thread with less than 50 messages just load all of 'em
-    if (props.threadMessageCount >= 50) {
+    if (props.thread.messageCount >= 50) {
       // If the thread was active after the user last saw it, only load the new messages
       if (props.lastSeen) {
         if (


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

For some reason we stopped passing the `threadMessageCount` prop, but never updated the query. This fixes long thread pagination where it would load the first 50 messages and then scroll to the bottom.