### PR TITLE
Decrease message text size

### DIFF
--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -62,7 +62,7 @@ export const InputWrapper = styled(EditorWrapper)`
   flex-direction: column;
   align-items: stretch;
   flex: auto;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 500;
   line-height: 20px;
   min-height: 40px;
@@ -126,7 +126,7 @@ export const InputWrapper = styled(EditorWrapper)`
 
   pre {
     ${monoStack};
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 500;
     background-color: ${props => props.theme.bg.wash};
     border: 1px solid ${props => props.theme.bg.border};

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -62,7 +62,7 @@ export const InputWrapper = styled(EditorWrapper)`
   flex-direction: column;
   align-items: stretch;
   flex: auto;
-  font-size: 14px;
+  font-size: 15px;
   font-weight: 500;
   line-height: 20px;
   min-height: 40px;
@@ -126,7 +126,7 @@ export const InputWrapper = styled(EditorWrapper)`
 
   pre {
     ${monoStack};
-    font-size: 14px;
+    font-size: 15px;
     font-weight: 500;
     background-color: ${props => props.theme.bg.wash};
     border: 1px solid ${props => props.theme.bg.border};

--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -243,7 +243,7 @@ export const Time = styled.div`
 
 export const Text = styled(Bubble)`
   padding: 8px 16px;
-  font-size: 16px;
+  font-size: 14px;
   line-height: 1.4;
   background-color: ${props =>
     props.me ? props.theme.brand.default : props.theme.generic.default};

--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -243,7 +243,7 @@ export const Time = styled.div`
 
 export const Text = styled(Bubble)`
   padding: 8px 16px;
-  font-size: 14px;
+  font-size: 15px;
   line-height: 1.4;
   background-color: ${props =>
     props.me ? props.theme.brand.default : props.theme.generic.default};


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This moves our message and chat input text size to 15px. The bubbles
are waaaaay to big now in comparison to all the other UI and feel way
out of place.