### PR TITLE
Fix GraphQL getEverythingThreads error for userId BRIAN_ID in test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ There's a shortcut for dropping, migrating and seeding the database too:
 yarn run db:reset
 ```
 
+The `testing` database used in end to end tests is managed separately. It is built, migrated, and seeded when you run:
+
+```sh
+yarn run start:api:test
+```
+
+To drop the `testing` database, go to http://localhost:8080/#tables while `rethinkdb` is running, and click Delete Database on the appropriate database.
+
 #### Getting the secrets
 
 While the app will run without any secrets set up, you won't be able to sign in locally. To get that set up, copy the provided example secrets file to the real location:

--- a/api/migrations/seed/default/threads.js
+++ b/api/migrations/seed/default/threads.js
@@ -380,7 +380,7 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
-    // deletedAt is missing intentionally
+    deletedAt: new Date(DATE),
   },
 
   {

--- a/api/migrations/seed/default/usersChannels.js
+++ b/api/migrations/seed/default/usersChannels.js
@@ -13,7 +13,6 @@ const {
   PRIVATE_GENERAL_CHANNEL_ID,
   SPECTRUM_ARCHIVED_CHANNEL_ID,
   SPECTRUM_PRIVATE_CHANNEL_ID,
-  DELETED_COMMUNITY_DELETED_CHANNEL_ID,
   PAYMENTS_GENERAL_CHANNEL_ID,
   PAYMENTS_PRIVATE_CHANNEL_ID,
   MODERATOR_CREATED_CHANNEL_ID,
@@ -360,20 +359,9 @@ module.exports = [
     isPending: false,
     receiveNotifications: true,
   },
+
   {
     id: '29',
-    createdAt: new Date(DATE),
-    userId: BRIAN_ID,
-    channelId: DELETED_COMMUNITY_DELETED_CHANNEL_ID,
-    isOwner: false,
-    isModerator: false,
-    isMember: true,
-    isBlocked: false,
-    isPending: false,
-    receiveNotifications: true,
-  },
-  {
-    id: '30',
     createdAt: new Date(DATE),
     userId: PREVIOUS_MEMBER_USER_ID,
     channelId: SPECTRUM_GENERAL_CHANNEL_ID,
@@ -385,7 +373,7 @@ module.exports = [
     receiveNotifications: false,
   },
   {
-    id: '31',
+    id: '30',
     createdAt: new Date(DATE),
     userId: MAX_ID,
     channelId: PRIVATE_GENERAL_CHANNEL_ID,

--- a/api/migrations/seed/default/usersChannels.js
+++ b/api/migrations/seed/default/usersChannels.js
@@ -13,6 +13,7 @@ const {
   PRIVATE_GENERAL_CHANNEL_ID,
   SPECTRUM_ARCHIVED_CHANNEL_ID,
   SPECTRUM_PRIVATE_CHANNEL_ID,
+  DELETED_COMMUNITY_DELETED_CHANNEL_ID,
   PAYMENTS_GENERAL_CHANNEL_ID,
   PAYMENTS_PRIVATE_CHANNEL_ID,
   MODERATOR_CREATED_CHANNEL_ID,
@@ -359,9 +360,20 @@ module.exports = [
     isPending: false,
     receiveNotifications: true,
   },
-
   {
     id: '29',
+    createdAt: new Date(DATE),
+    userId: BRIAN_ID,
+    channelId: DELETED_COMMUNITY_DELETED_CHANNEL_ID,
+    isOwner: false,
+    isModerator: false,
+    isMember: true,
+    isBlocked: false,
+    isPending: false,
+    receiveNotifications: true,
+  },
+  {
+    id: '30',
     createdAt: new Date(DATE),
     userId: PREVIOUS_MEMBER_USER_ID,
     channelId: SPECTRUM_GENERAL_CHANNEL_ID,
@@ -373,7 +385,7 @@ module.exports = [
     receiveNotifications: false,
   },
   {
-    id: '30',
+    id: '31',
     createdAt: new Date(DATE),
     userId: MAX_ID,
     channelId: PRIVATE_GENERAL_CHANNEL_ID,


### PR DESCRIPTION
As discussed in #3229, there was a GraphQL error preventing usage of `BRIAN_ID` as a user in tests (`MAX_ID` and `BRYN_ID` work fine). Removing the `userChannel` entry that tied `BRIAN_ID` to `DELETED_COMMUNITY_DELETED_CHANNEL_ID` fixes the error.

Though I'll admit I don't think I understand the data model well enough to understand why this is (I assume that when a community is deleted, userChannel references should be cleaned up?). I didn't write any tests to verify the fix - not sure if that's expected for mock data integrity. Happy to do so if you'd like, e.g. a test that makes sure each user has the expected # of threads show up in their inbox.

Also left a note in the README on dropping the test DB. Was there a cleaner way to do that?

After resolving this, I'll go back to fixing #3229's rebase conflicts.

Easiest way to reproduce prior to the fix:
* Change `const user = data.users[0];` to `const user = data.users[1];` in `inbox_spec.js`
* Run that test; observe API debug log (will have the non-null error as described in more detail in #3229)

To verify fix:
* Change `const user = data.users[0];` to `const user = data.users[1];` in `inbox_spec.js`
* Run that test; no error shows up, and threads are now visible

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [X] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
N/A (only tests affected)

<!-- If there are UI changes please share mobile and desktop screenshots or recordings. -->

