### PR TITLE
Revert image plugin version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "draft-js-drag-n-drop-plugin": "^2.0.3",
     "draft-js-embed-plugin": "^1.2.0",
     "draft-js-focus-plugin": "2.0.0-rc2",
-    "draft-js-image-plugin": "^2.0.5",
+    "draft-js-image-plugin": "2.0.0-rc8",
     "draft-js-import-markdown": "^1.2.1",
     "draft-js-linkify-plugin": "^2.0.0-beta1",
     "draft-js-markdown-plugin": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3791,12 +3791,12 @@ draft-js-focus-plugin@2.0.0-rc2:
     prop-types "^15.5.8"
     union-class-names "^1.0.0"
 
-draft-js-image-plugin@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/draft-js-image-plugin/-/draft-js-image-plugin-2.0.5.tgz#17c7218019877d9643a2f379635df11428e68a7f"
+draft-js-image-plugin@2.0.0-rc8:
+  version "2.0.0-rc8"
+  resolved "https://registry.yarnpkg.com/draft-js-image-plugin/-/draft-js-image-plugin-2.0.0-rc8.tgz#9ccd0d83c84f53dceefcd3c72f944e26ef9e2db5"
   dependencies:
     decorate-component-with-props "^1.0.2"
-    find-with-regex "^1.1.3"
+    find-with-regex "^1.0.2"
     immutable "~3.7.4"
     prop-types "^15.5.8"
     union-class-names "^1.0.0"


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This dependency bump broke images in all previously published threads. My notes in #3496. Let's get this into alpha asap so we don't accidentally do a prod cut and break all images.