### PR TITLE
Add sw.js to ServiceWorker external cache

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -96,6 +96,7 @@ module.exports = function override(config, env) {
   );
   // Get all public files so they're cached by the SW
   let externals = [
+    'sw.js',
     'https://www.google-analytics.com/analytics.js',
     'https://cdn.amplitude.com/libs/amplitude-4.2.1-min.gz.js',
   ];


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This should make it so that requesting https://spectrum.chat/sw.js doesn't return the app shell when cached locally. This doesn't fix anything, but it's a nice QoL change. Ref NekR/offline-plugin#400