### PR TITLE
Support blockquotes in messages

### DIFF
--- a/api/mutations/message/addMessage.js
+++ b/api/mutations/message/addMessage.js
@@ -107,7 +107,11 @@ export default requireAuth(async (_: any, args: Input, ctx: GraphQLContext) => {
     }
     if (
       body.blocks.some(
-        ({ type }) => !type || (type !== 'unstyled' && type !== 'code-block')
+        ({ type }) =>
+          !type ||
+          (type !== 'unstyled' &&
+            type !== 'code-block' &&
+            type !== 'blockquote')
       )
     ) {
       trackQueue.add({

--- a/shared/clients/draft-js/message/renderer.web.js
+++ b/shared/clients/draft-js/message/renderer.web.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import mentionsDecorator from '../mentions-decorator/index.web';
 import linksDecorator from '../links-decorator/index.web';
-import { Line, Paragraph } from 'src/components/message/style';
+import { Line, Paragraph, BlockQuote } from 'src/components/message/style';
 import type { Node } from 'react';
 import type { KeyObj, KeysObj } from './types';
 
@@ -30,6 +30,10 @@ const messageRenderer = {
         {children.map((child, i) => [child, <br key={i} />])}
       </Line>
     ),
+    blockquote: (children: Array<Node>, { keys }: KeysObj) =>
+      children.map((child, index) => (
+        <BlockQuote key={keys[index] || index}>{child}</BlockQuote>
+      )),
   },
   decorators: [mentionsDecorator, linksDecorator],
 };

--- a/shared/clients/draft-js/message/test/__snapshots__/renderer.test.js.snap
+++ b/shared/clients/draft-js/message/test/__snapshots__/renderer.test.js.snap
@@ -4,5 +4,6 @@ exports[`messageRenderer should render certain blocks 1`] = `
 Array [
   "unstyled",
   "code-block",
+  "blockquote",
 ]
 `;

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -60,7 +60,7 @@ class Input extends React.Component<Props, State> {
         createMarkdownPlugin({
           features: {
             inline: ['BOLD', 'ITALIC', 'CODE'],
-            block: ['CODE'],
+            block: ['CODE', 'blockquote'],
           },
           renderLanguageSelect: () => null,
         }),

--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -358,6 +358,14 @@ export const Paragraph = styled.p`
   }
 `;
 
+export const BlockQuote = styled.p`
+  line-height: 1.5;
+
+  &:not(:empty) ~ &:not(:empty) {
+    margin-top: 1em;
+  }
+`;
+
 export const QuotedParagraph = Paragraph.withComponent('div').extend`
   padding-left: 12px;
   border-left: 4px solid ${props => props.theme.bg.border};


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

Fixes #3517 

@mxstbr this lets people send blockquotes and not have them be lost forever because of a draftjs error. This is a temporary solution for the general problem: we should never let a message get lost because of a draftjs error. I went ahead and created a separate `BlockQuote` component that I will re-styled as soon as we ship the messages redesign branch.