### PR TITLE
Restyling thread like button to be more clear

### DIFF
--- a/src/components/threadLikes/index.js
+++ b/src/components/threadLikes/index.js
@@ -7,8 +7,6 @@ import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
 import addThreadReactionMutation from 'shared/graphql/mutations/thread/addThreadReaction';
 import removeThreadReactionMutation from 'shared/graphql/mutations/thread/removeThreadReaction';
 import { openModal } from 'src/actions/modals';
-
-import { IconButton } from 'src/components/buttons';
 import Icon from 'src/components/icons';
 import { LikeButtonWrapper, LikeCountWrapper, CurrentCount } from './style';
 
@@ -17,7 +15,6 @@ type LikeButtonProps = {
   addThreadReaction: Function,
   removeThreadReaction: Function,
   currentUser: ?Object,
-  tipLocation?: string,
   dispatch: Dispatch<Object>,
 };
 
@@ -46,17 +43,16 @@ class LikeButtonPure extends React.Component<LikeButtonProps> {
   };
 
   render() {
-    const { thread, tipLocation = 'bottom-left' } = this.props;
+    const { thread } = this.props;
     const { hasReacted, count } = thread.reactions;
 
     return (
-      <LikeButtonWrapper hasReacted={hasReacted}>
-        <IconButton
-          glyph={'thumbsup'}
-          tipText={hasReacted ? 'Unlike thread' : 'Like thread'}
-          tipLocation={tipLocation}
-          onClick={this.handleClick}
-        />
+      <LikeButtonWrapper
+        hasReacted={hasReacted}
+        onClick={this.handleClick}
+        icon={'thumbsup'}
+      >
+        {hasReacted ? 'Liked' : 'Like'}
         <CurrentCount>{count}</CurrentCount>
       </LikeButtonWrapper>
     );

--- a/src/components/threadLikes/style.js
+++ b/src/components/threadLikes/style.js
@@ -1,43 +1,45 @@
 // @flow
 import styled from 'styled-components';
+import { Button } from 'src/components/buttons';
 
-export const CurrentCount = styled.span`
+export const CurrentCount = styled.b`
   font-size: 14px;
 `;
 
-const LikeWrapper = styled.div`
+export const LikeButtonWrapper = styled(Button)`
+  background: ${props => props.theme.bg.default};
+  border: 1px solid ${props => props.theme.bg.border};
+  color: ${props =>
+    props.hasReacted ? props.theme.brand.alt : props.theme.text.alt};
+  padding: 4px 0 4px 8px;
   display: flex;
-  flex: none;
   align-items: center;
-`;
+  overflow: hidden;
 
-export const LikeButtonWrapper = styled(LikeWrapper)`
-  min-width: 48px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  > button {
-    color: ${props =>
-      props.hasReacted ? props.theme.brand.alt : props.theme.text.alt};
-    transition: transform 0.2s ease-in-out;
-
-    &:hover {
-      color: ${props =>
-        props.hasReacted ? props.theme.warn.alt : props.theme.brand.alt};
-      transition: color 0.3s ease-in-out;
-    }
+  div + span {
+    margin: 0;
+    margin-left: 8px;
   }
 
   ${CurrentCount} {
-    margin-right: 8px;
-    margin-left: 4px;
-    font-weight: 600;
-    color: ${props => props.theme.text.alt};
+    background: ${props => props.theme.bg.wash};
+    border-left: 1px solid ${props => props.theme.bg.border};
+    padding: 12px;
+    margin-left: 12px;
+    border-top-right-radius: 8px;
+    border-bottom-right-radius: 8px;
+    color: ${props => props.theme.text.secondary};
+  }
+
+  &:hover {
+    background: ${props => props.theme.bg.default};
+    color: ${props => props.theme.text.default};
   }
 `;
 
-export const LikeCountWrapper = styled(LikeWrapper)`
+export const LikeCountWrapper = styled.div`
+  display: flex;
+  align-items: center;
   margin-right: 12px;
   color: ${props =>
     props.active ? props.theme.text.reverse : props.theme.text.alt};

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -406,6 +406,7 @@ export const ThreadDescription = {
 export const ShareButtons = styled.div`
   display: flex;
   align-items: center;
+  margin-left: 12px;
 `;
 
 export const ShareButton = styled.span`
@@ -592,7 +593,7 @@ export const ActionBarContainer = styled.div`
   background: ${props => props.theme.bg.wash};
   border: 1px solid ${props => props.theme.bg.border};
   border-radius: 6px;
-  padding: 6px 6px 6px 12px;
+  padding: 6px;
 
   @media (max-width: 768px) {
     margin: 0;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

We're seeing a relatively low-volume of thread likes. This restyles the button in the thread view to be more explicit (text label) and stand out like a button versus a static icon. We'll see if this moves metrics at all.