### PR TITLE
Fix inconsistency between thread like and comment counts

### DIFF
--- a/src/components/threadLikes/style.js
+++ b/src/components/threadLikes/style.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Button } from 'src/components/buttons';
 
 export const CurrentCount = styled.b`
-  font-size: 14px;
+  font-size: 13px;
 `;
 
 export const LikeButtonWrapper = styled(Button)`
@@ -45,7 +45,7 @@ export const LikeCountWrapper = styled.div`
   color: ${props =>
     props.active ? props.theme.text.reverse : props.theme.text.alt};
 
-  span {
+  b {
     margin-left: 4px;
     font-weight: 600;
   }

--- a/src/components/threadLikes/style.js
+++ b/src/components/threadLikes/style.js
@@ -46,7 +46,7 @@ export const LikeCountWrapper = styled.div`
   color: ${props =>
     props.active ? props.theme.text.reverse : props.theme.text.alt};
 
-  b {
+  ${CurrentCount} {
     margin-left: 4px;
     font-weight: 600;
   }

--- a/src/components/threadLikes/style.js
+++ b/src/components/threadLikes/style.js
@@ -29,6 +29,7 @@ export const LikeButtonWrapper = styled(Button)`
     border-top-right-radius: 8px;
     border-bottom-right-radius: 8px;
     color: ${props => props.theme.text.secondary};
+    font-size: 14px;
   }
 
   &:hover {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Fixes inconsistency between the thread comment and like counts.

**Before**
<img width="647" alt="threads-before" src="https://user-images.githubusercontent.com/944061/42891812-27e5ec7a-8aa8-11e8-981c-48c3fc6a9b73.png">

**After**
<img width="645" alt="threads-after" src="https://user-images.githubusercontent.com/944061/42891820-2af6245c-8aa8-11e8-983f-d89dee43970f.png">