### PR TITLE
Custom ServiceWorker caching configuration

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -113,6 +113,7 @@ module.exports = function override(config, env) {
               additional: ['**/*.chunk.js'],
               optional: [':rest:', ':externals:'],
             },
+      safeToUseOptionalCaches: true,
       externals,
       autoUpdate: true,
       // NOTE(@mxstbr): Normally this is handled by setting


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Based on a recent error I happened to see in my browser console by chance, I think our ServiceWorker woes come from the fact that the `offline-plugin` aborts caching anything on install if downloading even a single asset fails: https://imgur.com/a/q4ut6xx (note how it says `if (failAll)`, which is true if an asset is in the `main` cache section—which all assets are by default)

> I _think_ this is due to us hitting the now DDOS protection, since the ServiceWorker fetches a large number of files in quick succession—I'm not certain that's the case, but the reason the fetches fail doesn't matter too much.

This patch changes that behavior by only failing caching entirely if either the app shell or the main JS bundles fails to download.  Everything else is downloaded too, but if it fails to download just isn't cached and instead requested from the server when it's used. (and then cached if it downloads fine)

Let's hope this fixes our SW woes!

Related to NekR/offline-plugin#400, potentially even resolves it.

/cc @NekR a review would be appreciated here!