### PR TITLE
Fix moderator list not updating moderators

### DIFF
--- a/src/views/community/components/moderatorList.js
+++ b/src/views/community/components/moderatorList.js
@@ -38,9 +38,10 @@ class CommunityModeratorList extends React.Component<Props> {
     if (
       this.props.data &&
       this.props.data.community &&
-      this.props.data.community.id === nextProps.data.community.id
+      nextProps.data.community
     ) {
-      return false;
+      if (this.props.data.community.id === nextProps.data.community.id)
+        return false;
     }
     return true;
   }

--- a/src/views/community/components/moderatorList.js
+++ b/src/views/community/components/moderatorList.js
@@ -30,12 +30,18 @@ type Props = {
 };
 
 class CommunityModeratorList extends React.Component<Props> {
-  shouldComponentUpdate() {
+  shouldComponentUpdate(nextProps) {
     // NOTE(@brian) This is needed to avoid conflicting the the members tab in
     // the community view. See https://github.com/withspectrum/spectrum/pull/2613#pullrequestreview-105861623
     // for discussion
     // never update once we have the list of team members
-    if (this.props.data && this.props.data.community) return false;
+    if (
+      this.props.data &&
+      this.props.data.community &&
+      this.props.data.community.id === nextProps.data.community.id
+    ) {
+      return false;
+    }
     return true;
   }
 
@@ -45,7 +51,11 @@ class CommunityModeratorList extends React.Component<Props> {
   };
 
   render() {
-    const { data: { community }, isLoading, currentUser } = this.props;
+    const {
+      data: { community },
+      isLoading,
+      currentUser,
+    } = this.props;
 
     if (community && community.members) {
       const { edges: members } = community.members;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- athena

(not sure if they need deploying, per se, but these were the two services I had running during development)

**Related issues (delete if you don't know of any)**
Closes #3606 

This is a small, simple fix that sets the correct moderatorList members when switching directly between community views (eg. via notifications). It just adds another extra equality check to make sure that `this.props.data.community.id === nextProps.data.community.id` in the `shouldComponentUpdate`. If it is the same `community.id`, it won't re-render, otherwise, if it detects a change in `community.id` it will trigger a re-render and cause the current & updated moderatorList to render.

<!-- If there are UI changes please share mobile and desktop screenshots or recordings. -->

