### PR TITLE
Frecency thread feeds

### DIFF
--- a/api/loaders/index.js
+++ b/api/loaders/index.js
@@ -12,7 +12,6 @@ import {
 import {
   __createThreadLoader,
   __createThreadParticipantsLoader,
-  __createThreadMessageCountLoader,
 } from './thread';
 import { __createNotificationLoader } from './notification';
 import {
@@ -58,7 +57,6 @@ const createLoaders = (options?: DataLoaderOptions) => ({
   ),
   thread: __createThreadLoader(options),
   threadParticipants: __createThreadParticipantsLoader(options),
-  threadMessageCount: __createThreadMessageCountLoader(options),
   notification: __createNotificationLoader(options),
   channel: __createChannelLoader(options),
   channelMemberCount: __createChannelMemberCountLoader(options),

--- a/api/loaders/thread.js
+++ b/api/loaders/thread.js
@@ -14,11 +14,6 @@ export const __createThreadParticipantsLoader = createLoader(
   'group'
 );
 
-export const __createThreadMessageCountLoader = createLoader(
-  threadIds => getMessageCountInThreads(threadIds),
-  'group'
-);
-
 export default () => {
   throw new Error(
     '⚠️ Do not import loaders directly, get them from the GraphQL context instead! ⚠️'

--- a/api/migrations/20180807060551-thread-metadata-denormalization.js
+++ b/api/migrations/20180807060551-thread-metadata-denormalization.js
@@ -1,0 +1,57 @@
+exports.up = function(r, conn) {
+  return r
+    .table('threads')
+    .update(
+      {
+        messageCount: r
+          .table('messages')
+          .getAll(r.row('id'), { index: 'threadId' })
+          .count()
+          .default(0),
+        reactionCount: r
+          .table('threadReactions')
+          .getAll(r.row('id'), { index: 'threadId' })
+          .count()
+          .default(0),
+      },
+      {
+        nonAtomic: true,
+      }
+    )
+    .run(conn)
+    .then(() => {
+      return Promise.all([
+        r
+          .table('threads')
+          .indexCreate('messageCount')
+          .run(conn),
+        r
+          .table('threads')
+          .indexCreate('reactionCount')
+          .run(conn),
+      ]);
+    })
+    .catch(err => console.error(err));
+};
+
+exports.down = function(r, conn) {
+  return r
+    .table('threads')
+    .update({
+      messageCount: r.literal(),
+      reactionCount: r.literal(),
+    })
+    .run(conn)
+    .then(() => {
+      return Promise.all([
+        r
+          .table('threads')
+          .indexDrop('messageCount')
+          .run(conn),
+        r
+          .table('threads')
+          .indexDrop('reactionCount')
+          .run(conn),
+      ]);
+    });
+};

--- a/api/migrations/20180807072706-thread-frecency-scores.js
+++ b/api/migrations/20180807072706-thread-frecency-scores.js
@@ -1,0 +1,49 @@
+const FRECENCY_WEIGHTS = {
+  messageWeight: 1,
+  reactionWeight: 0.2,
+  ageWeight: 0.25,
+  lastActiveWeight: 0.5,
+};
+
+exports.up = function(r, conn) {
+  return r
+    .table('threads')
+    .indexCreate('frecency_score', thread => {
+      return thread('messageCount')
+        .default(0)
+        .mul(FRECENCY_WEIGHTS.messageWeight)
+        .add(
+          thread('reactionCount')
+            .default(0)
+            .mul(FRECENCY_WEIGHTS.reactionWeight)
+        )
+        .sub(
+          r
+            .round(
+              r
+                .now()
+                .sub(thread('createdAt'))
+                .div(86400)
+            )
+            .mul(FRECENCY_WEIGHTS.ageWeight)
+        )
+        .sub(
+          r
+            .round(
+              r
+                .now()
+                .sub(thread('lastActive').default(thread('createdAt')))
+                .div(86400)
+            )
+            .mul(FRECENCY_WEIGHTS.lastActiveWeight)
+        );
+    })
+    .run(conn);
+};
+
+exports.down = function(r, conn) {
+  return r
+    .table('threads')
+    .indexDrop('frecency_score')
+    .run(conn);
+};

--- a/api/migrations/seed/default/threads.js
+++ b/api/migrations/seed/default/threads.js
@@ -47,6 +47,8 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE),
     lastActive: new Date(DATE),
+    messageCount: 4,
+    reactionCount: 0,
   },
   {
     id: 'thread-2',
@@ -77,6 +79,8 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE + 1),
     lastActive: new Date(DATE + 1),
+    messageCount: 4,
+    reactionCount: 0,
   },
   {
     id: 'thread-3',
@@ -107,6 +111,8 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
+    messageCount: 0,
+    reactionCount: 0,
   },
 
   {
@@ -138,6 +144,8 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE),
     lastActive: new Date(DATE),
+    messageCount: 0,
+    reactionCount: 0,
   },
   {
     id: 'thread-5',
@@ -168,6 +176,8 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE + 1),
     lastActive: new Date(DATE + 1),
+    messageCount: 0,
+    reactionCount: 0,
   },
   {
     id: 'thread-6',
@@ -198,6 +208,8 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
+    messageCount: 0,
+    reactionCount: 0,
   },
   {
     id: 'thread-7',
@@ -229,6 +241,8 @@ module.exports = [
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
     deletedAt: new Date(DATE + 3),
+    messageCount: 0,
+    reactionCount: 0,
   },
   {
     id: 'thread-8',
@@ -259,6 +273,8 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
+    messageCount: 0,
+    reactionCount: 0,
   },
   {
     id: 'thread-9',
@@ -320,6 +336,8 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
+    messageCount: 0,
+    reactionCount: 0,
   },
   {
     id: 'thread-11',
@@ -349,6 +367,8 @@ module.exports = [
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
     deletedAt: new Date(DATE + 3),
+    messageCount: 0,
+    reactionCount: 0,
   },
 
   {
@@ -381,6 +401,8 @@ module.exports = [
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
     deletedAt: new Date(DATE),
+    messageCount: 0,
+    reactionCount: 0,
   },
 
   {
@@ -412,5 +434,7 @@ module.exports = [
     ],
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
+    messageCount: 0,
+    reactionCount: 0,
   },
 ];

--- a/api/models/thread.js
+++ b/api/models/thread.js
@@ -73,7 +73,7 @@ export const getThreadsByChannel = (channelId: string, options: PaginationOption
 // prettier-ignore
 export const getThreadsByChannels = (channelIds: Array<string>, options: PaginationOptions): Promise<Array<DBThread>> => {
   const { first, after } = options
-  
+
   return db
     .table('threads')
     .getAll(...channelIds, { index: 'channelId' })
@@ -447,10 +447,10 @@ export const setThreadLock = (threadId: string, value: boolean, userId: string, 
       .run()
       .then(async () => {
         const thread = await getThreadById(threadId)
-        
-        const event = value 
-          ? byModerator 
-            ? events.THREAD_LOCKED_BY_MODERATOR 
+
+        const event = value
+          ? byModerator
+            ? events.THREAD_LOCKED_BY_MODERATOR
             : events.THREAD_LOCKED
           : byModerator
             ? events.THREAD_UNLOCKED_BY_MODERATOR
@@ -645,6 +645,58 @@ export const moveThread = (id: string, channelId: string, userId: string) => {
 
       return null;
     });
+};
+
+export const incrementMessageCount = (threadId: string) => {
+  return db
+    .table('threads')
+    .get(threadId)
+    .update({
+      messageCount: db
+        .row('messageCount')
+        .default(0)
+        .add(1),
+    })
+    .run();
+};
+
+export const decrementMessageCount = (threadId: string) => {
+  return db
+    .table('threads')
+    .get(threadId)
+    .update({
+      messageCount: db
+        .row('messageCount')
+        .default(1)
+        .sub(1),
+    })
+    .run();
+};
+
+export const incrementReactionCount = (threadId: string) => {
+  return db
+    .table('threads')
+    .get(threadId)
+    .update({
+      reactionCount: db
+        .row('reactionCount')
+        .default(0)
+        .add(1),
+    })
+    .run();
+};
+
+export const decrementReactionCount = (threadId: string) => {
+  return db
+    .table('threads')
+    .get(threadId)
+    .update({
+      reactionCount: db
+        .row('reactionCount')
+        .default(1)
+        .sub(1),
+    })
+    .run();
 };
 
 const hasChanged = (field: string) =>

--- a/api/models/thread.js
+++ b/api/models/thread.js
@@ -71,14 +71,15 @@ export const getThreadsByChannel = (channelId: string, options: PaginationOption
 };
 
 // prettier-ignore
-export const getThreadsByChannels = (channelIds: Array<string>, options: PaginationOptions): Promise<Array<DBThread>> => {
-  const { first, after } = options
+export const getThreadsByChannels = (channelIds: Array<string>, options: { ...PaginationOptions, sort: 'NEW' | 'TOP' }): Promise<Array<DBThread>> => {
+  const { first, after, sort } = options
 
+  const order = sort === 'NEW' ? db.desc('lastActive') : db.desc('frecency_score');
   return db
     .table('threads')
     .getAll(...channelIds, { index: 'channelId' })
     .filter(thread => db.not(thread.hasFields('deletedAt')))
-    .orderBy(db.desc('lastActive'), db.desc('createdAt'))
+    .orderBy(order)
     .skip(after || 0)
     .limit(first || 999999)
     .run();

--- a/api/models/thread.js
+++ b/api/models/thread.js
@@ -50,9 +50,10 @@ export const getThreadsByChannelToDelete = (channelId: string) => {
 };
 
 // prettier-ignore
-export const getThreadsByChannel = (channelId: string, options: PaginationOptions): Promise<Array<DBThread>> => {
-  const { first, after } = options
+export const getThreadsByChannel = (channelId: string, options: { ...PaginationOptions, sort: 'NEW' | 'TOP' }): Promise<Array<DBThread>> => {
+  const { first, after, sort } = options
 
+  const order = sort === 'NEW' ? { index: db.desc('channelIdAndLastActive') } : db.desc('frecency_score');
   return db
     .table('threads')
     .between(
@@ -64,7 +65,7 @@ export const getThreadsByChannel = (channelId: string, options: PaginationOption
         rightBound: 'open',
       }
     )
-    .orderBy({ index: db.desc('channelIdAndLastActive') })
+    .orderBy(order)
     .filter(thread => db.not(thread.hasFields('deletedAt')))
     .limit(first)
     .run();

--- a/api/queries/channel/threadConnection.js
+++ b/api/queries/channel/threadConnection.js
@@ -5,12 +5,13 @@ import { encode, decode } from '../../utils/base64';
 
 export default (
   { id }: { id: string },
-  { first, after }: PaginationOptions
+  { first, after, sort }: { ...$Exact<PaginationOptions>, sort: 'NEW' | 'TOP' }
 ) => {
   // $FlowFixMe
   return getThreadsByChannel(id, {
     first,
     after: after && parseInt(decode(after), 10),
+    sort: sort || 'NEW',
   }).then(threads => ({
     pageInfo: {
       hasNextPage: threads.length >= first,

--- a/api/queries/community/threadConnection.js
+++ b/api/queries/community/threadConnection.js
@@ -11,8 +11,8 @@ import { getThreadsByChannels } from '../../models/thread';
 import { canViewCommunity } from '../../utils/permissions';
 
 // prettier-ignore
-export default async (root: DBCommunity, args: PaginationOptions, ctx: GraphQLContext) => {
-  const { first = 10, after } = args
+export default async (root: DBCommunity, args: { ...PaginationOptions, sort: 'NEW' | 'TOP' }, ctx: GraphQLContext) => {
+  const { first = 10, after, sort = 'NEW' } = args
   const { user, loaders } = ctx
   const { id } = root
 
@@ -48,6 +48,7 @@ export default async (root: DBCommunity, args: PaginationOptions, ctx: GraphQLCo
   const threads = await getThreadsByChannels(channels, {
     first,
     after: lastThreadIndex,
+    sort,
   });
 
   return {

--- a/api/queries/thread/index.js
+++ b/api/queries/thread/index.js
@@ -12,7 +12,6 @@ import receiveNotifications from './receiveNotifications';
 import messageConnection from './messageConnection';
 import author from './author';
 import creator from './creator';
-import messageCount from './messageCount';
 import currentUserLastSeen from './currentUserLastSeen';
 import content from './content';
 import reactions from './reactions';
@@ -33,7 +32,6 @@ module.exports = {
     messageConnection,
     author,
     creator, // deprecated
-    messageCount,
     currentUserLastSeen,
     content,
     reactions,

--- a/api/queries/thread/messageCount.js
+++ b/api/queries/thread/messageCount.js
@@ -1,9 +1,0 @@
-// @flow
-import type { GraphQLContext } from '../../';
-import type { DBThread } from 'shared/types';
-
-export default ({ id }: DBThread, __: any, { loaders }: GraphQLContext) => {
-  return loaders.threadMessageCount
-    .load(id)
-    .then(messageCount => (messageCount ? messageCount.reduction : 0));
-};

--- a/api/types/Channel.js
+++ b/api/types/Channel.js
@@ -58,6 +58,11 @@ const Channel = /* GraphQL */ `
     userId: ID!
   }
 
+  enum ChannelThreadConnectionSort {
+    NEW
+    TOP
+  }
+
   type Channel {
     id: ID!
     createdAt: Date!
@@ -71,20 +76,29 @@ const Channel = /* GraphQL */ `
     channelPermissions: ChannelPermissions! @cost(complexity: 1)
     communityPermissions: CommunityPermissions!
     community: Community! @cost(complexity: 1)
-    threadConnection(first: Int = 10, after: String): ChannelThreadsConnection! @cost(complexity: 1, multiplier: "first")
-    memberConnection(first: Int = 10, after: String): ChannelMembersConnection! @cost(complexity: 1, multiplier: "first")
+    threadConnection(
+      first: Int = 10
+      after: String
+      sort: ChannelThreadConnectionSort = NEW
+    ): ChannelThreadsConnection! @cost(complexity: 1, multiplier: "first")
+    memberConnection(first: Int = 10, after: String): ChannelMembersConnection!
+      @cost(complexity: 1, multiplier: "first")
     memberCount: Int!
     metaData: ChannelMetaData @cost(complexity: 1)
     pendingUsers: [User] @cost(complexity: 3)
     blockedUsers: [User] @cost(complexity: 3)
     moderators: [User] @cost(complexity: 3)
     owners: [User] @cost(complexity: 3)
-    joinSettings: JoinSettings 
+    joinSettings: JoinSettings
     slackSettings: ChannelSlackSettings
   }
 
   extend type Query {
-    channel(id: ID, channelSlug: LowercaseString, communitySlug: LowercaseString): Channel @cost(complexity: 1)
+    channel(
+      id: ID
+      channelSlug: LowercaseString
+      communitySlug: LowercaseString
+    ): Channel @cost(complexity: 1)
   }
 
   input ArchiveChannelInput {

--- a/api/types/Community.js
+++ b/api/types/Community.js
@@ -1,318 +1,362 @@
 // @flow
 const Community = /* GraphQL */ `
-	type CommunityChannelsConnection {
-		pageInfo: PageInfo!
-		edges: [CommunityChannelEdge!]
-	}
+  type CommunityChannelsConnection {
+    pageInfo: PageInfo!
+    edges: [CommunityChannelEdge!]
+  }
 
-	type CommunityChannelEdge {
-		node: Channel!
-	}
+  type CommunityChannelEdge {
+    node: Channel!
+  }
 
-	type CommunityMembersConnection @deprecated(reason:"Use the new Community.members type") {
-		pageInfo: PageInfo!
-		edges: [CommunityMemberEdge!]
-	}
+  type CommunityMembersConnection
+    @deprecated(reason: "Use the new Community.members type") {
+    pageInfo: PageInfo!
+    edges: [CommunityMemberEdge!]
+  }
 
-	type CommunityMemberEdge @deprecated(reason:"Use the new Community.members type") {
-		cursor: String!
-		node: User!
-	}
+  type CommunityMemberEdge
+    @deprecated(reason: "Use the new Community.members type") {
+    cursor: String!
+    node: User!
+  }
 
-	type CommunityMembers {
-		pageInfo: PageInfo!
-		edges: [CommunityMembersEdge!]
-	}
+  type CommunityMembers {
+    pageInfo: PageInfo!
+    edges: [CommunityMembersEdge!]
+  }
 
-	type CommunityMembersEdge {
-		cursor: String!
-		node: CommunityMember!
-	}
+  type CommunityMembersEdge {
+    cursor: String!
+    node: CommunityMember!
+  }
 
-	type CommunityThreadsConnection {
-		pageInfo: PageInfo!
-		edges: [CommunityThreadEdge!]
-	}
+  type CommunityThreadsConnection {
+    pageInfo: PageInfo!
+    edges: [CommunityThreadEdge!]
+  }
 
-	type CommunityThreadEdge {
-		cursor: String!
-		node: Thread!
-	}
+  type CommunityThreadEdge {
+    cursor: String!
+    node: Thread!
+  }
 
-	type CommunityMetaData {
-		members: Int
-		channels: Int
-	}
+  type CommunityMetaData {
+    members: Int
+    channels: Int
+  }
 
-	type SlackImport @deprecated(reason: "Use the slack settings field instead") {
-		members: String
-		teamName: String
-		sent: Date
-	}
+  type SlackImport @deprecated(reason: "Use the slack settings field instead") {
+    members: String
+    teamName: String
+    sent: Date
+  }
 
-	type TopAndNewThreads {
-		topThreads: [Thread]
-		newThreads: [Thread]
-	}
+  type TopAndNewThreads {
+    topThreads: [Thread]
+    newThreads: [Thread]
+  }
 
-	type StripeCard {
-		brand: String
-		exp_month: Int
-		exp_year: Int
-		last4: String
-	}
+  type StripeCard {
+    brand: String
+    exp_month: Int
+    exp_year: Int
+    last4: String
+  }
 
-	type StripeSource {
-		id: ID
-		card: StripeCard
-		isDefault: Boolean
-	}
+  type StripeSource {
+    id: ID
+    card: StripeCard
+    isDefault: Boolean
+  }
 
-	type StripeItem {
-		id: ID
-		amount: Int
-		quantity: Int
-		planId: String
-		planName: String
-	}
+  type StripeItem {
+    id: ID
+    amount: Int
+    quantity: Int
+    planId: String
+    planName: String
+  }
 
-	type StripeSubscriptionItem {
-		created: Int
-		planId: String
-		planName: String
-		amount: Int
-		quantity: Int
-		id: String
-	}
+  type StripeSubscriptionItem {
+    created: Int
+    planId: String
+    planName: String
+    amount: Int
+    quantity: Int
+    id: String
+  }
 
-	type StripeDiscount {
-		amount_off: Int
-		percent_off: Int
-		id: String
-	}
+  type StripeDiscount {
+    amount_off: Int
+    percent_off: Int
+    id: String
+  }
 
-	type StripeSubscription {
-		id: ID
-		created: Int
-		discount: StripeDiscount
-		billing_cycle_anchor: Int
-		current_period_end: Int
-		canceled_at: Int
-		items: [StripeSubscriptionItem]
-		status: String
-	}
+  type StripeSubscription {
+    id: ID
+    created: Int
+    discount: StripeDiscount
+    billing_cycle_anchor: Int
+    current_period_end: Int
+    canceled_at: Int
+    items: [StripeSubscriptionItem]
+    status: String
+  }
 
-	type StripeInvoice {
-		id: ID
-		date: Int
-		items: [StripeItem]
-		total: Int
-	}
+  type StripeInvoice {
+    id: ID
+    date: Int
+    items: [StripeItem]
+    total: Int
+  }
 
-	type CommunityBillingSettings {
-		pendingAdministratorEmail: LowercaseString
-		administratorEmail: LowercaseString
-		sources: [StripeSource]
-		invoices: [StripeInvoice]
-		subscriptions: [StripeSubscription]
-	}
+  type CommunityBillingSettings {
+    pendingAdministratorEmail: LowercaseString
+    administratorEmail: LowercaseString
+    sources: [StripeSource]
+    invoices: [StripeInvoice]
+    subscriptions: [StripeSubscription]
+  }
 
-	type Features {
-		analytics: Boolean
-		prioritySupport: Boolean
-	}
-	
-	type BrandedLogin {
-		isEnabled: Boolean
-		message: String
-	}
+  type Features {
+    analytics: Boolean
+    prioritySupport: Boolean
+  }
 
-	type Community {
-		id: ID!
-		createdAt: Date
-		name: String!
-		slug: LowercaseString!
-		description: String
-		website: String
-		profilePhoto: String
-		coverPhoto: String
-		reputation: Int
-		pinnedThreadId: String
-		pinnedThread: Thread
-		isPrivate: Boolean
+  type BrandedLogin {
+    isEnabled: Boolean
+    message: String
+  }
+
+  enum CommunityThreadConnectionSort {
+    NEW
+    TOP
+  }
+
+  type Community {
+    id: ID!
+    createdAt: Date
+    name: String!
+    slug: LowercaseString!
+    description: String
+    website: String
+    profilePhoto: String
+    coverPhoto: String
+    reputation: Int
+    pinnedThreadId: String
+    pinnedThread: Thread
+    isPrivate: Boolean
     communityPermissions: CommunityPermissions @cost(complexity: 1)
     channelConnection: CommunityChannelsConnection @cost(complexity: 1)
-    members(first: Int = 10, after: String, filter: MembersFilter): CommunityMembers @cost(complexity: 5, multiplier: "first")
-    threadConnection(first: Int = 10, after: String): CommunityThreadsConnection @cost(complexity: 2, multiplier: "first")
+    members(
+      first: Int = 10
+      after: String
+      filter: MembersFilter
+    ): CommunityMembers @cost(complexity: 5, multiplier: "first")
+    threadConnection(
+      first: Int = 10
+      after: String
+      sort: CommunityThreadConnectionSort = "NEW"
+    ): CommunityThreadsConnection @cost(complexity: 2, multiplier: "first")
     metaData: CommunityMetaData @cost(complexity: 10)
     invoices: [Invoice] @cost(complexity: 1)
-		recurringPayments: [RecurringPayment]
+    recurringPayments: [RecurringPayment]
     isPro: Boolean @cost(complexity: 1)
     memberGrowth: GrowthData @cost(complexity: 10)
     conversationGrowth: GrowthData @cost(complexity: 3)
     topMembers: [CommunityMember] @cost(complexity: 10)
     topAndNewThreads: TopAndNewThreads @cost(complexity: 4)
-		watercooler: Thread
-		brandedLogin: BrandedLogin
-		joinSettings: JoinSettings
-		slackSettings: CommunitySlackSettings @cost(complexity: 2)
+    watercooler: Thread
+    brandedLogin: BrandedLogin
+    joinSettings: JoinSettings
+    slackSettings: CommunitySlackSettings @cost(complexity: 2)
 
-		hasFeatures: Features
-		hasChargeableSource: Boolean
-		billingSettings: CommunityBillingSettings
+    hasFeatures: Features
+    hasChargeableSource: Boolean
+    billingSettings: CommunityBillingSettings
 
-		slackImport: SlackImport @cost(complexity: 2) @deprecated(reason: "Use slack settings field instead")
-		memberConnection(first: Int = 10, after: String, filter: MemberConnectionFilter): CommunityMembersConnection! @deprecated(reason:"Use the new Community.members type")
-		contextPermissions: ContextPermissions @deprecated(reason:"Use the new CommunityMember type to get permissions")
-	}
+    slackImport: SlackImport
+      @cost(complexity: 2)
+      @deprecated(reason: "Use slack settings field instead")
+    memberConnection(
+      first: Int = 10
+      after: String
+      filter: MemberConnectionFilter
+    ): CommunityMembersConnection!
+      @deprecated(reason: "Use the new Community.members type")
+    contextPermissions: ContextPermissions
+      @deprecated(reason: "Use the new CommunityMember type to get permissions")
+  }
 
-	extend type Query {
-		community(id: ID, slug: LowercaseString): Community
-		communities(slugs: [LowercaseString], ids: [ID], curatedContentType: String): [Community]
-		communityMember(userId: String, communityId: String): CommunityMember
-    topCommunities(amount: Int = 20): [Community!] @cost(complexity: 4, multiplier: "amount")
-		recentCommunities: [Community!]
+  extend type Query {
+    community(id: ID, slug: LowercaseString): Community
+    communities(
+      slugs: [LowercaseString]
+      ids: [ID]
+      curatedContentType: String
+    ): [Community]
+    communityMember(userId: String, communityId: String): CommunityMember
+    topCommunities(amount: Int = 20): [Community!]
+      @cost(complexity: 4, multiplier: "amount")
+    recentCommunities: [Community!]
 
-		searchCommunities(string: String, amount: Int = 20): [Community] @deprecated(reason:"Use the new Search query endpoint")
-		searchCommunityThreads(communityId: ID!, searchString: String): [Thread] @deprecated(reason:"Use the new Search query endpoint")
-	}
+    searchCommunities(string: String, amount: Int = 20): [Community]
+      @deprecated(reason: "Use the new Search query endpoint")
+    searchCommunityThreads(communityId: ID!, searchString: String): [Thread]
+      @deprecated(reason: "Use the new Search query endpoint")
+  }
 
-	input MembersFilter {
-		isOwner: Boolean
-		isMember: Boolean
-		isBlocked: Boolean
-		isPending: Boolean
-		isModerator: Boolean
-	}
+  input MembersFilter {
+    isOwner: Boolean
+    isMember: Boolean
+    isBlocked: Boolean
+    isPending: Boolean
+    isModerator: Boolean
+  }
 
-	input MemberConnectionFilter @deprecated(reason: "Use the new MembersFilter input type") {
-		isOwner: Boolean
-		isMember: Boolean
-		isBlocked: Boolean
-		isPending: Boolean
-		isModerator: Boolean
-	}
+  input MemberConnectionFilter
+    @deprecated(reason: "Use the new MembersFilter input type") {
+    isOwner: Boolean
+    isMember: Boolean
+    isBlocked: Boolean
+    isPending: Boolean
+    isModerator: Boolean
+  }
 
-	input CreateCommunityInput {
-		name: String!
-		slug: LowercaseString!
-		description: String!
-		website: String
-		file: Upload
-		coverFile: Upload
-		isPrivate: Boolean
-	}
+  input CreateCommunityInput {
+    name: String!
+    slug: LowercaseString!
+    description: String!
+    website: String
+    file: Upload
+    coverFile: Upload
+    isPrivate: Boolean
+  }
 
-	input EditCommunityInput {
-		name: String
-		description: String
-		website: String
-		file: Upload
-		coverFile: Upload
-		communityId: ID!
-	}
+  input EditCommunityInput {
+    name: String
+    description: String
+    website: String
+    file: Upload
+    coverFile: Upload
+    communityId: ID!
+  }
 
-	input UpgradeCommunityInput {
-		plan: String!
-		token: String!
-		communityId: String!
-	}
+  input UpgradeCommunityInput {
+    plan: String!
+    token: String!
+    communityId: String!
+  }
 
-	input DowngradeCommunityInput {
-		id: String!
-	}
-
-	input UpdateAdministratorEmailInput {
-		id: ID!
-		email: LowercaseString!
-	}
-
-	input AddPaymentSourceInput {
-		sourceId: String!
-		communityId: ID!
-	}
-
-	input RemovePaymentSourceInput {
-		sourceId: String!
-		communityId: ID!
-	}
-
-	input MakePaymentSourceDefaultInput {
-		sourceId: String!
-		communityId: ID!
-	}
-
-	input CancelSubscriptionInput {
-		communityId: ID!
-	}
-
-	input EnableCommunityAnalyticsInput {
-		communityId: ID!
-	}
-
-	input DisableCommunityAnalyticsInput {
-		communityId: ID!
-	}
-	
-	input EnableBrandedLoginInput {
-		id: String!
-	}
-
-	input DisableBrandedLoginInput {
-		id: String!
-	}
-
-	input SaveBrandedLoginSettingsInput {
-		id: String!
-		message: String
-	}
-
-	input ImportSlackMembersInput @deprecated(reason: "Slack imports are no longer used, invites sent directly with sendSlackInvites") {
+  input DowngradeCommunityInput {
     id: String!
   }
 
-	input SendSlackInvitesInput {
-		id: ID!
-		customMessage: String
-	}
+  input UpdateAdministratorEmailInput {
+    id: ID!
+    email: LowercaseString!
+  }
 
-	input EnableCommunityTokenJoinInput {
-		id: ID!
-	}
+  input AddPaymentSourceInput {
+    sourceId: String!
+    communityId: ID!
+  }
 
-	input DisableCommunityTokenJoinInput {
-		id: ID!
-	}
+  input RemovePaymentSourceInput {
+    sourceId: String!
+    communityId: ID!
+  }
 
-	input ResetCommunityJoinTokenInput {
-		id: ID!
-	}
+  input MakePaymentSourceDefaultInput {
+    sourceId: String!
+    communityId: ID!
+  }
 
-	extend type Mutation {
-		createCommunity(input: CreateCommunityInput!): Community
-		editCommunity(input: EditCommunityInput!): Community
-		deleteCommunity(communityId: ID!): Boolean
-		toggleCommunityMembership(communityId: ID!): Community @deprecated(reason:"Use the new addCommunityMember or removeCommunityMember mutations")
-		sendSlackInvites(input: SendSlackInvitesInput!): Community
-		importSlackMembers(input: ImportSlackMembersInput!): Boolean @deprecated(reason:"Importing slack members is deprecated")
-		sendEmailInvites(input: EmailInvitesInput!): Boolean
-		pinThread(threadId: ID!, communityId: ID!, value: String): Community
-		upgradeCommunity(input: UpgradeCommunityInput!): Community @deprecated(reason:"Use feature level upgrade mutations like enableCommunityAnalytics")
-		downgradeCommunity(input: DowngradeCommunityInput!): Community @deprecated(reason:"Use feature level downgrade mutations like disableCommunityAnalytics")
-		updateAdministratorEmail(input: UpdateAdministratorEmailInput!): Community
-		addPaymentSource(input: AddPaymentSourceInput!): Community
-		removePaymentSource(input: RemovePaymentSourceInput!): Community
-		makePaymentSourceDefault(input: MakePaymentSourceDefaultInput!): Community
-		cancelSubscription(input: CancelSubscriptionInput!): Community
-		enableCommunityAnalytics(input: EnableCommunityAnalyticsInput!): Community
-		disableCommunityAnalytics(input: DisableCommunityAnalyticsInput!): Community
-		enableBrandedLogin(input: EnableBrandedLoginInput!): Community
-		disableBrandedLogin(input: DisableBrandedLoginInput!): Community
-		saveBrandedLoginSettings(input: SaveBrandedLoginSettingsInput!): Community
-		enableCommunityTokenJoin(input: EnableCommunityTokenJoinInput!): Community
-		disableCommunityTokenJoin(input: DisableCommunityTokenJoinInput!): Community
-		resetCommunityJoinToken(input: ResetCommunityJoinTokenInput!): Community
-	}
+  input CancelSubscriptionInput {
+    communityId: ID!
+  }
+
+  input EnableCommunityAnalyticsInput {
+    communityId: ID!
+  }
+
+  input DisableCommunityAnalyticsInput {
+    communityId: ID!
+  }
+
+  input EnableBrandedLoginInput {
+    id: String!
+  }
+
+  input DisableBrandedLoginInput {
+    id: String!
+  }
+
+  input SaveBrandedLoginSettingsInput {
+    id: String!
+    message: String
+  }
+
+  input ImportSlackMembersInput
+    @deprecated(
+      reason: "Slack imports are no longer used, invites sent directly with sendSlackInvites"
+    ) {
+    id: String!
+  }
+
+  input SendSlackInvitesInput {
+    id: ID!
+    customMessage: String
+  }
+
+  input EnableCommunityTokenJoinInput {
+    id: ID!
+  }
+
+  input DisableCommunityTokenJoinInput {
+    id: ID!
+  }
+
+  input ResetCommunityJoinTokenInput {
+    id: ID!
+  }
+
+  extend type Mutation {
+    createCommunity(input: CreateCommunityInput!): Community
+    editCommunity(input: EditCommunityInput!): Community
+    deleteCommunity(communityId: ID!): Boolean
+    toggleCommunityMembership(communityId: ID!): Community
+      @deprecated(
+        reason: "Use the new addCommunityMember or removeCommunityMember mutations"
+      )
+    sendSlackInvites(input: SendSlackInvitesInput!): Community
+    importSlackMembers(input: ImportSlackMembersInput!): Boolean
+      @deprecated(reason: "Importing slack members is deprecated")
+    sendEmailInvites(input: EmailInvitesInput!): Boolean
+    pinThread(threadId: ID!, communityId: ID!, value: String): Community
+    upgradeCommunity(input: UpgradeCommunityInput!): Community
+      @deprecated(
+        reason: "Use feature level upgrade mutations like enableCommunityAnalytics"
+      )
+    downgradeCommunity(input: DowngradeCommunityInput!): Community
+      @deprecated(
+        reason: "Use feature level downgrade mutations like disableCommunityAnalytics"
+      )
+    updateAdministratorEmail(input: UpdateAdministratorEmailInput!): Community
+    addPaymentSource(input: AddPaymentSourceInput!): Community
+    removePaymentSource(input: RemovePaymentSourceInput!): Community
+    makePaymentSourceDefault(input: MakePaymentSourceDefaultInput!): Community
+    cancelSubscription(input: CancelSubscriptionInput!): Community
+    enableCommunityAnalytics(input: EnableCommunityAnalyticsInput!): Community
+    disableCommunityAnalytics(input: DisableCommunityAnalyticsInput!): Community
+    enableBrandedLogin(input: EnableBrandedLoginInput!): Community
+    disableBrandedLogin(input: DisableBrandedLoginInput!): Community
+    saveBrandedLoginSettings(input: SaveBrandedLoginSettingsInput!): Community
+    enableCommunityTokenJoin(input: EnableCommunityTokenJoinInput!): Community
+    disableCommunityTokenJoin(input: DisableCommunityTokenJoinInput!): Community
+    resetCommunityJoinToken(input: ResetCommunityJoinTokenInput!): Community
+  }
 `;
 
 module.exports = Community;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] WIP
- [ ] Ready for review
- [x] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

**Run database migrations (delete if no migration was added)**
YES

**Related issues (delete if you don't know of any)**
Closes #3718
Based on #3726 (until that's merged you'll also see those changes here)

----

- [x] Add `frecency_score` index to threads
- [ ] Figure out how to sort results by calculation
- [x] Implement in GraphQL API
  - [x] `Community.threadConnection`
  - [x] `Channel.threadConnection`
  - [ ] Others?
- [ ] Implement in old community and channel views?
