### PR TITLE
Fix flex on short dm snippets

### DIFF
--- a/src/views/directMessages/components/style.js
+++ b/src/views/directMessages/components/style.js
@@ -58,7 +58,7 @@ export const Col = styled(FlexCol)`
 `;
 
 export const Row = styled(FlexRow)`
-  flex: 0 0 auto;
+  flex: 1 0 auto;
   align-items: center;
   max-width: 100%;
   padding-right: 16px;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Super small fix where direct messages weren't filling the container, so short snippet messages wouldn't have the timestamp right aligned.