### PR TITLE
FIx double hover profiles, small styling nits

### DIFF
--- a/src/components/badges/style.js
+++ b/src/components/badges/style.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Tooltip, Gradient } from '../globals';
 
 export const Span = styled.span`
-  display: inline;
+  display: flex;
   color: ${({ theme }) => theme.text.reverse};
   background-color: ${props => props.theme.text.alt};
   text-transform: uppercase;
@@ -16,6 +16,8 @@ export const Span = styled.span`
   letter-spacing: 0.6px;
   line-height: 1;
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.16);
+  align-items: center;
+  align-self: center;
 `;
 
 export const ProBadge = styled(Span)`

--- a/src/components/granularUserProfile/index.js
+++ b/src/components/granularUserProfile/index.js
@@ -107,7 +107,7 @@ class GranularUserProfile extends React.Component<Props> {
             user={userObject}
             size={avatarSize || 32}
             onlineSize={onlineSize || 'small'}
-            showHoverProfile={showHoverProfile}
+            showHoverProfile={!showHoverProfile}
           />
         )}
         <LinkHandler username={userObject.username}>
@@ -139,4 +139,7 @@ class GranularUserProfile extends React.Component<Props> {
   }
 }
 
-export default compose(connect(), withRouter)(GranularUserProfileHandler);
+export default compose(
+  connect(),
+  withRouter
+)(GranularUserProfileHandler);

--- a/src/components/granularUserProfile/style.js
+++ b/src/components/granularUserProfile/style.js
@@ -21,7 +21,6 @@ export const Row = styled.div`
       ? `'avatar name message' 'action action action' '. description .'`
       : `'avatar name action' '. description .'`};
   grid-column-gap: 16px;
-  grid-row-gap: 8px;
   padding: 12px 16px;
   width: 100%;
   background: ${props => props.theme.bg.default};
@@ -58,6 +57,7 @@ export const Name = styled.span`
   line-height: 1;
   vertical-align: middle;
   display: flex;
+  align-items: flex-end;
 
   &:hover {
     color: ${props => props.theme.brand.alt};


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Fixes some styling nits, as well as a bug where you could trigger two user hover profile cards on the team list when viewing a community/channel