### PR TITLE
Fix mobile menu gap

### DIFF
--- a/src/components/menu/style.js
+++ b/src/components/menu/style.js
@@ -35,12 +35,16 @@ export const Absolute = styled.div`
   min-height: 100%;
   z-index: 1;
 
-  > button {
+  button {
     color: ${props => props.theme.text.reverse};
     z-index: 2;
     align-self: flex-start;
     margin-top: ${props => (props.hasNavBar ? '56px' : '8px')};
     margin-left: 8px;
+  }
+
+  button:hover {
+    color: ${props => props.theme.text.reverse};
   }
 `;
 
@@ -53,8 +57,7 @@ export const MenuContainer = styled.div`
   left: 0;
   top: 0;
   bottom: 0;
-  height: ${props =>
-    props.hasTabBar ? (isDesktopApp() ? '100%' : 'calc(100% - 48px)') : '100%'};
+  height: 100%;
   width: 300px;
   color: ${props => props.theme.brand.alt};
   background-color: ${props => props.theme.bg.wash};

--- a/src/views/thread/components/messages.js
+++ b/src/views/thread/components/messages.js
@@ -8,7 +8,6 @@ import idx from 'idx';
 import InfiniteList from 'src/components/infiniteScroll';
 import { deduplicateChildren } from 'src/components/infiniteScroll/deduplicateChildren';
 import { sortAndGroupMessages } from 'shared/clients/group-messages';
-import type { ThreadInfoType } from 'shared/graphql/fragments/thread/threadInfo';
 import ChatMessages from '../../../components/messageGroup';
 import { Loading } from '../../../components/loading';
 import { Button } from '../../../components/buttons';
@@ -21,8 +20,6 @@ import {
   ChatWrapper,
   NullMessagesWrapper,
   NullCopy,
-  EmptyThreadHeading,
-  EmptyThreadDescription,
   SocialShareWrapper,
   A,
 } from '../style';

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -1,22 +1,20 @@
 // @flow
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
-import { UserAvatar, CommunityAvatar } from '../../components/avatar';
-import { Button } from '../../components/buttons';
-import Column from '../../components/column';
+import { UserAvatar, CommunityAvatar } from 'src/components/avatar';
+import { Button } from 'src/components/buttons';
+import Column from 'src/components/column';
 import {
   FlexCol,
   FlexRow,
   H1,
-  H2,
   H3,
   Transition,
-  P,
   zIndex,
   Tooltip,
   Shadow,
   hexa,
-} from '../../components/globals';
+} from 'src/components/globals';
 
 export const ThreadViewContainer = styled.div`
   display: flex;
@@ -164,22 +162,6 @@ export const ThreadHeading = styled(H1)`
   @media (max-width: 768px) {
     margin-top: 8px;
   }
-`;
-
-export const EmptyThreadHeading = styled(H2)`
-  font-size: 32px;
-  font-weight: 800;
-
-  @media (max-width: 768px) {
-    margin-top: 8px;
-  }
-`;
-
-export const EmptyThreadDescription = styled(P)`
-  margin-top: 8px;
-  font-size: 24px;
-  font-weight: 600;
-  color: ${({ theme }) => theme.text.alt};
 `;
 
 export const A = styled.a`


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Makes the mobile slideout community navigation take the full height of the viewport. Fixed some eslint warnings.