### PR TITLE
Fix alpha continuous deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,11 +130,11 @@ jobs:
           name: Deploy and alias API
           command: |
             cd build-api
-            npx now-cd --alias "alpha=api.alpha.spectrum.chat" --team spaceprogram
+            npx now-cd --alias "alpha=api.alpha.spectrum.chat" --team space-program
             cd ..
       - run:
           name: Deploy and alias Hyperion
-          command: npx now-cd --alias "alpha=hyperion.alpha.spectrum.chat" --team spaceprogram
+          command: npx now-cd --alias "alpha=hyperion.alpha.spectrum.chat" --team space-program
 
   # Run eslint, flow etc.
   test_static_js:


### PR DESCRIPTION
Zeit renamed our Zeit team from "spaceprogram" to "space-program", which
broke alpha CD.


<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing