### PR TITLE
Better thread meta images

### DIFF
--- a/src/helpers/generate-image-from-text.js
+++ b/src/helpers/generate-image-from-text.js
@@ -1,7 +1,7 @@
 // @flow
 // Generates a meta image which shows a title and a footer text on a nice Spectrum background.
 import theme from 'shared/theme';
-import { bota } from 'abab';
+import { btoa } from 'abab';
 import { stringify } from 'query-string';
 
 // NOTES(@mxstbr):

--- a/src/helpers/generate-image-from-text.js
+++ b/src/helpers/generate-image-from-text.js
@@ -1,0 +1,60 @@
+// @flow
+// Generates a meta image which shows a title and a footer text on a nice Spectrum background.
+import theme from 'shared/theme';
+import { bota } from 'abab';
+import { stringify } from 'query-string';
+
+// NOTES(@mxstbr):
+// Imgix has a useful ~text endpoint that allows us to add text to any image, but unfortunately that endpoint only allows us to add one piece of text to an image—but we need two!
+// We work around this by generating two images that only contain the text of the title and the footer respectively, nothing else, and then using the blend option to blend the background image with the title image (which only has the title text) and used the mark option to add our footer text as a "watermark" to the footer.
+
+const WIDTH = 1500;
+const IMGIX_TEXT_ENDPOINT = 'https://assets.imgix.net/~text';
+
+const TITLE_PARAMS = {
+  w: WIDTH * 0.8, // 10% padding on each side
+  h: 350, // Magic number, clips text after four lines
+  txtsize: 56,
+  txtfont: 'Helvetica,Bold',
+  txtalign: 'center,middle', // Center the text on both axis
+  txtcolor: 'ffffff',
+  // NOTE(@mxstbr): txtclip (i.e. ellipsis on overflowing text) only works with single-line text, which titles aren't, so this doesn't do anything rn
+  txtclip: 'end,ellipsis',
+};
+
+const FOOTER_PARAMS = {
+  h: 64,
+  txtsize: 32,
+  txtcolor: theme.brand.default.replace('#', ''),
+  txtalign: 'right,middle',
+  txtfont: 'Helvetica,Bold',
+};
+
+const BACKGROUND_URL = `http://spectrum.imgix.net/default_images/twitter-share-card.png`;
+
+type GetMetaImageInput = {
+  title: string,
+  footer: string,
+};
+
+const generateImageFromText = ({ title, footer }: GetMetaImageInput) => {
+  const titleUrl = `${IMGIX_TEXT_ENDPOINT}?${stringify(
+    { ...TITLE_PARAMS, txt: title },
+    { encode: false }
+  )}`;
+  const footerUrl = `${IMGIX_TEXT_ENDPOINT}?${stringify(
+    { ...FOOTER_PARAMS, txt: footer },
+    { encode: false }
+  )}`;
+
+  const BACKGROUND_PARAMS = {
+    w: WIDTH,
+    bm: 'normal', // Blend the title normally, don't change opacity or color or anything, just overlay it
+    blend64: btoa(titleUrl),
+    mark64: btoa(footerUrl),
+  };
+
+  return `${BACKGROUND_URL}?${stringify(BACKGROUND_PARAMS, { encode: false })}`;
+};
+
+export default generateImageFromText;

--- a/src/helpers/generate-image-from-text.js
+++ b/src/helpers/generate-image-from-text.js
@@ -39,14 +39,23 @@ type GetMetaImageInput = {
 };
 
 const generateImageFromText = ({ title, footer }: GetMetaImageInput) => {
+  const base64title = btoa(title);
+  const base64footer = btoa(footer);
+  if (!base64title || !base64footer) return;
+
   const titleUrl = `${IMGIX_TEXT_ENDPOINT}?${stringify(
-    { ...TITLE_PARAMS, txt64: btoa(title).replace('=', '') },
+    { ...TITLE_PARAMS, txt64: base64title.replace('=', '') },
     { encode: false }
   )}`;
   const footerUrl = `${IMGIX_TEXT_ENDPOINT}?${stringify(
-    { ...FOOTER_PARAMS, txt64: btoa(footer).replace(/=/g, '') },
+    { ...FOOTER_PARAMS, txt64: base64footer.replace(/=/g, '') },
     { encode: false }
   )}`;
+
+  const base64titleurl = btoa(titleUrl);
+  const base64footerurl = btoa(footerUrl);
+
+  if (!base64titleurl || !base64footerurl) return;
 
   const BACKGROUND_PARAMS = {
     w: WIDTH,

--- a/src/helpers/generate-image-from-text.js
+++ b/src/helpers/generate-image-from-text.js
@@ -63,7 +63,7 @@ const generateImageFromText = ({ title, footer }: GetMetaImageInput) => {
     by: 170, // Magic numbers that get the position right
     bx: 180,
     markalign: 'left,bottom', // Show the footer on the left side
-    markpad: 12, // We overwrite the X pos, so the padding only applies on the y-axis
+    markpad: 24, // We overwrite the X pos, so the padding only applies on the y-axis
     markx: 100,
     blend64: btoa(titleUrl).replace(/=/g, ''),
     mark64: btoa(footerUrl).replace(/=/g, ''),

--- a/src/helpers/generate-image-from-text.js
+++ b/src/helpers/generate-image-from-text.js
@@ -13,9 +13,9 @@ const IMGIX_TEXT_ENDPOINT = 'https://assets.imgix.net/~text';
 
 const TITLE_PARAMS = {
   w: WIDTH * 0.8, // 10% padding on each side
-  h: 300, // Magic number, clips text after four lines
+  h: 270, // Magic number, clips text after three lines
   txtsize: 56,
-  txtlead: 4,
+  txtlead: 16,
   txtfont: 'Helvetica,Bold',
   txtalign: 'left,middle',
   txtcolor: 'ffffff',

--- a/src/helpers/generate-image-from-text.js
+++ b/src/helpers/generate-image-from-text.js
@@ -40,11 +40,11 @@ type GetMetaImageInput = {
 
 const generateImageFromText = ({ title, footer }: GetMetaImageInput) => {
   const titleUrl = `${IMGIX_TEXT_ENDPOINT}?${stringify(
-    { ...TITLE_PARAMS, txt: title },
+    { ...TITLE_PARAMS, txt64: btoa(title).replace('=', '') },
     { encode: false }
   )}`;
   const footerUrl = `${IMGIX_TEXT_ENDPOINT}?${stringify(
-    { ...FOOTER_PARAMS, txt: footer },
+    { ...FOOTER_PARAMS, txt64: btoa(footer).replace(/=/g, '') },
     { encode: false }
   )}`;
 
@@ -56,8 +56,8 @@ const generateImageFromText = ({ title, footer }: GetMetaImageInput) => {
     markalign: 'left,bottom', // Show the footer on the left side
     markpad: 12, // We overwrite the X pos, so the padding only applies on the y-axis
     markx: 100,
-    blend64: btoa(titleUrl),
-    mark64: btoa(footerUrl),
+    blend64: btoa(titleUrl).replace(/=/g, ''),
+    mark64: btoa(footerUrl).replace(/=/g, ''),
   };
 
   return `${BACKGROUND_URL}?${stringify(BACKGROUND_PARAMS, { encode: false })}`;

--- a/src/helpers/generate-image-from-text.js
+++ b/src/helpers/generate-image-from-text.js
@@ -25,7 +25,7 @@ const TITLE_PARAMS = {
 
 const FOOTER_PARAMS = {
   h: 64,
-  txtsize: 32,
+  txtsize: 36,
   txtcolor: theme.brand.default.replace('#', ''),
   txtalign: 'right,middle',
   txtfont: 'Helvetica,Bold',
@@ -54,7 +54,7 @@ const generateImageFromText = ({ title, footer }: GetMetaImageInput) => {
     by: 170, // Magic numbers that get the position right
     bx: 180,
     markalign: 'left,bottom', // Show the footer on the left side
-    markpad: 15, // We overwrite the X pos, so the padding only applies on the y-axis
+    markpad: 12, // We overwrite the X pos, so the padding only applies on the y-axis
     markx: 100,
     blend64: btoa(titleUrl),
     mark64: btoa(footerUrl),

--- a/src/helpers/generate-image-from-text.js
+++ b/src/helpers/generate-image-from-text.js
@@ -13,10 +13,11 @@ const IMGIX_TEXT_ENDPOINT = 'https://assets.imgix.net/~text';
 
 const TITLE_PARAMS = {
   w: WIDTH * 0.8, // 10% padding on each side
-  h: 350, // Magic number, clips text after four lines
+  h: 300, // Magic number, clips text after four lines
   txtsize: 56,
+  txtlead: 4,
   txtfont: 'Helvetica,Bold',
-  txtalign: 'center,middle', // Center the text on both axis
+  txtalign: 'left,middle',
   txtcolor: 'ffffff',
   // NOTE(@mxstbr): txtclip (i.e. ellipsis on overflowing text) only works with single-line text, which titles aren't, so this doesn't do anything rn
   txtclip: 'end,ellipsis',
@@ -30,7 +31,7 @@ const FOOTER_PARAMS = {
   txtfont: 'Helvetica,Bold',
 };
 
-const BACKGROUND_URL = `http://spectrum.imgix.net/default_images/twitter-share-card.png`;
+const BACKGROUND_URL = `https://spectrum.imgix.net/default_images/twitter-share-card.png`;
 
 type GetMetaImageInput = {
   title: string,
@@ -50,6 +51,11 @@ const generateImageFromText = ({ title, footer }: GetMetaImageInput) => {
   const BACKGROUND_PARAMS = {
     w: WIDTH,
     bm: 'normal', // Blend the title normally, don't change opacity or color or anything, just overlay it
+    by: 170, // Magic numbers that get the position right
+    bx: 180,
+    markalign: 'left,bottom', // Show the footer on the left side
+    markpad: 15, // We overwrite the X pos, so the padding only applies on the y-axis
+    markx: 100,
     blend64: btoa(titleUrl),
     mark64: btoa(footerUrl),
   };

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -39,6 +39,7 @@ import {
 } from './style';
 import WatercoolerActionBar from './components/watercoolerActionBar';
 import { ErrorBoundary } from 'src/components/error';
+import generateImageFromText from 'src/helpers/generate-image-from-text';
 
 type Props = {
   data: {
@@ -226,7 +227,11 @@ class ThreadContainer extends React.Component<Props, State> {
     // we never autofocus on mobile
     if (window && window.innerWidth < 768) return;
 
-    const { currentUser, data: { thread }, threadSliderIsOpen } = this.props;
+    const {
+      currentUser,
+      data: { thread },
+      threadSliderIsOpen,
+    } = this.props;
 
     // if no thread has been returned yet from the query, we don't know whether or not to focus yet
     if (!thread) return;
@@ -270,7 +275,10 @@ class ThreadContainer extends React.Component<Props, State> {
 
   renderChatInputOrUpsell = () => {
     const { isEditing } = this.state;
-    const { data: { thread }, currentUser } = this.props;
+    const {
+      data: { thread },
+      currentUser,
+    } = this.props;
 
     if (!thread) return null;
     if (thread.isLocked) return null;
@@ -319,7 +327,11 @@ class ThreadContainer extends React.Component<Props, State> {
   };
 
   renderPost = () => {
-    const { data: { thread }, slider, currentUser } = this.props;
+    const {
+      data: { thread },
+      slider,
+      currentUser,
+    } = this.props;
     if (!thread || !thread.id) return null;
 
     if (thread.watercooler) {
@@ -445,7 +457,10 @@ class ThreadContainer extends React.Component<Props, State> {
               <Head
                 title={headTitle}
                 description={headDescription}
-                image={thread.community.profilePhoto}
+                image={generateImageFromText({
+                  title: thread.content.title,
+                  footer: `spectrum.chat/${thread.community.slug}`,
+                })}
               />
               <Titlebar
                 title={thread.content.title}

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -461,7 +461,9 @@ class ThreadContainer extends React.Component<Props, State> {
                   title: thread.content.title,
                   footer: `spectrum.chat/${thread.community.slug}`,
                 })}
-              />
+              >
+                <meta name="twitter:card" content="summary_large_image" />
+              </Head>
               <Titlebar
                 title={thread.content.title}
                 subtitle={`${thread.community.name} / ${thread.channel.name}`}

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -458,7 +458,7 @@ class ThreadContainer extends React.Component<Props, State> {
                 title={headTitle}
                 description={headDescription}
                 image={generateImageFromText({
-                  title: thread.content.title,
+                  title: headTitle,
                   footer: `spectrum.chat/${thread.community.slug}`,
                 })}
               >


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Based on and closes #2910

This improves our thread meta images by generating an image from the title and community slug, instead of showing the community profile photo. Examples:

Normal title, long community slug:

![](http://spectrum.imgix.net/default_images/twitter-share-card.png?blend64=aHR0cHM6Ly9hc3NldHMuaW1naXgubmV0L350ZXh0P2g9MzUwJnR4dD1Ib3cgZG8gSSBzZXQgaG92ZXIgc3R5bGVzPyZ0eHRhbGlnbj1jZW50ZXIsbWlkZGxlJnR4dGNsaXA9ZW5kLGVsbGlwc2lzJnR4dGNvbG9yPWZmZmZmZiZ0eHRmb250PUhlbHZldGljYSxCb2xkJnR4dHNpemU9NTYmdz0xMjAw&bm=normal&mark64=aHR0cHM6Ly9hc3NldHMuaW1naXgubmV0L350ZXh0P2g9NjQmdHh0PXNwZWN0cnVtLmNoYXQvc3R5bGVkLWNvbXBvbmVudHMmdHh0YWxpZ249cmlnaHQsbWlkZGxlJnR4dGNvbG9yPTQ0MDBDQyZ0eHRmb250PUhlbHZldGljYSxCb2xkJnR4dHNpemU9MzI=&w=1500)

Extremely long title, normal community slug:

![](http://spectrum.imgix.net/default_images/twitter-share-card.png?blend64=aHR0cHM6Ly9hc3NldHMuaW1naXgubmV0L350ZXh0P2g9MzUwJnR4dD1OZWVkIHN3aXBlIHRvIG1vdmUgYmV0d2VlbiBmcmFtZXMgaW4gRmlnbWEgTWlycm9yLCBJIHdhbnQgZGVzaWduIHRvIGZpdCBpbiBteSBtb2JpbGUgc2NyZWVuIHdoaWxlIHZpZXdpbmcgb24gYW55IG1vYmlsZSBkZXZpY2UsIGFuZCBsYXllcnMgbmVlZCB0byBzdGFjayBhbmQgcmVhcnJhbmdlIGJhc2VkIG9uIEZsZXhib3ggbGlrZSBGcmFtZXIgWCB3aGljaCBpcyBtdWNoIGJldHRlciB0aGFuIEZpZ21hIGFuZCB0aGlzIHRpdGxlIGlzIGdldHRpbmcgcmlkaWN1bG91c2x5IGxvbmcgYW5kIEkgZG8gbm90IGtub3cgaWYgaXQgd2lsbCBwcm9wZXJseSBjbGlwIG9yIG5vdCBvbWcgcGxlYXNlIGNsaXAgd2l0aCBhbiBlbGxpcHNpcyBJIHdvdWxkIGxvdmUgeW91IGZvcmV2ZXIgYW5kIGV2ZXIgYW5kIGV2ZXIgYW5kIGV2ZXImdHh0YWxpZ249Y2VudGVyLG1pZGRsZSZ0eHRjbGlwPWVuZCxlbGxpcHNpcyZ0eHRjb2xvcj1mZmZmZmYmdHh0Zm9udD1IZWx2ZXRpY2EsQm9sZCZ0eHRzaXplPTU2Jnc9MTIwMA==&bm=normal&mark64=aHR0cHM6Ly9hc3NldHMuaW1naXgubmV0L350ZXh0P2g9NjQmdHh0PXNwZWN0cnVtLmNoYXQvZmlnbWEmdHh0YWxpZ249cmlnaHQsbWlkZGxlJnR4dGNvbG9yPTQ0MDBDQyZ0eHRmb250PUhlbHZldGljYSxCb2xkJnR4dHNpemU9MzI=&w=1500)

> Note: This isn't perfect yet, ideally it would show an ellipsis, but unfortunately the imgix text API only allows us to automatically add an ellipsis on one-line text 🙄 Good enough for now though