### PR TITLE
Fix forwarding to newest version of JS bundle chunks

### DIFF
--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -145,7 +145,8 @@ app.get('/static/js/:name', (req: express$Request, res, next) => {
     return res.sendFile(
       path.resolve(__dirname, '..', 'build', 'static', 'js', req.params.name)
     );
-  const match = req.params.name.match(/(\w+?)\.(\w+?\.)?js/i);
+  // Match the first part of the file name, i.e. from "UserSettings.asdf123.chunk.js" match "UserSettings"
+  const match = req.params.name.match(/(\w+?)\..+js/i);
   if (!match) return next();
   const actualFilename = jsFiles.find(file => file.startsWith(match[1]));
   if (!actualFilename) return next();


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

ServiceWorker installs are failing because old ServiceWorkers are trying to cache old versions of the JavaScript chunks. Unfortunately, the bundle filenames change with each release so if the SW tries to cache `UserSettings.asdf123.chunk.js` and we've released a new verion, that file is called something entirely different like `UserSettings.lkjli53.chunk.js` instead!

This fixes the issue by forwarding old asset names to the new name, i.e.  if a user requests `UserSettings.asdf123.chunk.js` but the current name is `UserSettingsings.lkjli53.chunk.js` we forward them to the new version.

This should potentially fix some ServiceWorker problems!

Shoutout to @matheuss for pointing me in the right direction with his bug report.