### PR TITLE
Fix emoji message replies

### DIFF
--- a/src/components/message/view.js
+++ b/src/components/message/view.js
@@ -30,10 +30,6 @@ export const Body = (props: BodyProps) => {
   const emojiOnly =
     message.messageType === 'draftjs' &&
     draftOnlyContainsEmoji(JSON.parse(message.content.body));
-  if (emojiOnly)
-    return (
-      <Emoji>{toPlainText(toState(JSON.parse(message.content.body)))}</Emoji>
-    );
   const WrapperComponent = bubble ? Text : QuotedParagraph;
   switch (message.messageType) {
     case 'text':
@@ -55,7 +51,13 @@ export const Body = (props: BodyProps) => {
               // $FlowIssue
               <QuotedMessage message={message.parent} />
             )}
-          {redraft(JSON.parse(message.content.body), messageRenderer)}
+          {emojiOnly ? (
+            <Emoji>
+              {toPlainText(toState(JSON.parse(message.content.body)))}
+            </Emoji>
+          ) : (
+            redraft(JSON.parse(message.content.body), messageRenderer)
+          )}
         </WrapperComponent>
       );
     }


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Fixed replying to a message with only emojis not showing the reply

**Related issues (delete if you don't know of any)**
Closes #3114

<!-- If there are UI changes please share mobile and desktop screenshots or recordings. -->

Now when you reply, even when it's only with a single emoji, we'll show your reply! Demo:

![screen shot 2018-08-10 at 14 08 10](https://user-images.githubusercontent.com/7525670/43957113-f8337c52-9ca6-11e8-94d5-fc4a7979a435.png)

/cc @ryota-murakami 