### PR TITLE
Fix API logging undefined over and over

### DIFF
--- a/api/routes/create-subscription-server.js
+++ b/api/routes/create-subscription-server.js
@@ -25,19 +25,17 @@ const createSubscriptionsServer = (server: any, path: string) => {
       },
       onDisconnect: rawSocket => {
         return getUserIdFromReq(rawSocket.upgradeReq)
-          .then(id => {
-            return setUserOnline(id, false);
-          })
+          .then(id => id && setUserOnline(id, false))
           .catch(err => {
             console.error(err);
           });
       },
       onConnect: (connectionParams, rawSocket) =>
         getUserIdFromReq(rawSocket.upgradeReq)
-          .then(id => setUserOnline(id, true))
+          .then(id => (id ? setUserOnline(id, true) : null))
           .then(user => {
             return {
-              user,
+              user: user || null,
               loaders: createLoaders({ cache: false }),
             };
           })

--- a/api/utils/session-store.js
+++ b/api/utils/session-store.js
@@ -7,12 +7,15 @@ const ONE_DAY = 86400000;
 /**
  * Get the sessions' users' ID of a req manually, needed for websocket authentication
  */
-export const getUserIdFromReq = (req: any): Promise<string> =>
+export const getUserIdFromReq = (req: any): Promise<?string> =>
   new Promise((res, rej) => {
     session(req, {}, err => {
-      if (err) return rej(err);
-      if (!req.session || !req.session.passport || !req.session.passport.user)
-        return rej();
+      if (err) {
+        return rej(err);
+      }
+      if (!req.session || !req.session.passport || !req.session.passport.user) {
+        return res(null);
+      }
 
       return res(req.session.passport.user);
     });


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

It turns out I'm a dummy and did Promise.reject(undefined) when a user wasn't authenticated, which was constantly logged with `console.error` :facepalm:

This fixes #3746