### PR TITLE
Potentially fix perpetually being signed out

### DIFF
--- a/api/queries/channel/communityPermissions.js
+++ b/api/queries/channel/communityPermissions.js
@@ -2,17 +2,21 @@
 import type { GraphQLContext } from '../../';
 import type { DBChannel } from 'shared/types';
 
+const DEFAULT = {
+  isOwner: false,
+  isMember: false,
+  isModerator: false,
+  isBlocked: false,
+  isPending: false,
+  receiveNotifications: false,
+};
+
 export default (root: DBChannel, _: any, { user, loaders }: GraphQLContext) => {
   const communityId = root.id || root.communityId;
   if (!communityId || !user) {
-    return {
-      isOwner: false,
-      isMember: false,
-      isModerator: false,
-      isBlocked: false,
-      isPending: false,
-      receiveNotifications: false,
-    };
+    return DEFAULT;
   }
-  return loaders.userPermissionsInCommunity.load([user.id, communityId]);
+  return loaders.userPermissionsInCommunity
+    .load([user.id, communityId])
+    .then(res => res || DEFAULT);
 };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -14,10 +14,7 @@ const getUser = userId => data.users.find(user => user.id === userId);
 Cypress.Commands.add('auth', userId => {
   const user = getUser(userId);
 
-  localStorage.setItem(
-    'spectrum',
-    JSON.stringify({ currentUser: { id: user.id, username: user.username } })
-  );
+  localStorage.setItem('spectrum', JSON.stringify({ currentUser: user }));
   return cy.setCookie(
     'session',
     encode(JSON.stringify({ passport: { user: userId } })),

--- a/shared/truthy-values.js
+++ b/shared/truthy-values.js
@@ -1,4 +1,10 @@
 // @flow
-export const getTruthyValuesFromObject = (object: Object): Array<?string> => {
-  return Object.keys(object).filter(key => object[key] === true);
+export const getTruthyValuesFromObject = (object?: Object): Array<?string> => {
+  if (!object) return [];
+  return (
+    Object.keys(object)
+      .filter(Boolean)
+      // $FlowIssue
+      .filter(key => object[key] === true)
+  );
 };

--- a/src/helpers/signed-out-fallback.js
+++ b/src/helpers/signed-out-fallback.js
@@ -36,8 +36,8 @@ const ConnectedSwitch = compose(
 )(Switch);
 
 const signedOutFallback = (
-  Component: React$Component<*>,
-  FallbackComponent: React$Component<*>
+  Component: React$ComponentType<*>,
+  FallbackComponent: React$ComponentType<*>
 ) => {
   return (props: *) => (
     <ConnectedSwitch

--- a/src/helpers/signed-out-fallback.js
+++ b/src/helpers/signed-out-fallback.js
@@ -1,26 +1,45 @@
+// @flow
 // Render a component depending on a users authentication status
 import React from 'react';
 import { connect } from 'react-redux';
+import compose from 'recompose/compose';
 import queryString from 'query-string';
+import { getCurrentUser } from 'shared/graphql/queries/user/getUser';
+import { Loading } from 'src/components/loading';
 
 // This is the component that determines at render time what to do
 const Switch = props => {
   const { Component, FallbackComponent, currentUser, ...rest } = props;
   const { authed } = queryString.parse(props.location.search);
-  if ((!currentUser && !authed) || !Component) {
-    return <FallbackComponent {...rest} />;
-  } else {
-    return <Component {...rest} />;
-  }
+
+  if (!Component) return <FallbackComponent {...rest} />;
+
+  if (currentUser || authed) return <Component {...rest} />;
+
+  if (props.data.loading) return <Loading />;
+
+  if (props.data.user && props.data.user.id) return <Component {...rest} />;
+
+  return <FallbackComponent {...rest} />;
 };
 
-// Connect that component to the Redux state
-const ConnectedSwitch = connect(state => ({
+const mapStateToProps: (*) => * = state => ({
   currentUser: state.users.currentUser,
-}))(Switch);
+});
+// Connect that component to the Redux state and to the Apollo query for the current user
+// By default the data is injected into the Redux state at startup from local storage or from the SSR
+// But if it's not there we fall back to showing a global loading indicator and waiting for the Apollo
+// query to get the current user to complete
+const ConnectedSwitch = compose(
+  connect(mapStateToProps),
+  getCurrentUser
+)(Switch);
 
-const signedOutFallback = (Component, FallbackComponent) => {
-  return props => (
+const signedOutFallback = (
+  Component: React$Component<*>,
+  FallbackComponent: React$Component<*>
+) => {
+  return (props: *) => (
     <ConnectedSwitch
       {...props}
       FallbackComponent={FallbackComponent}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Fixed bug where you were perpetually signed out every time you re-opened Spectrum

**Related issues (delete if you don't know of any)**
https://spectrum.chat/?t=5d3c0ae2-d947-4bca-96c1-52dca4468143

Based on this production reproduction (https://i.imgur.com/gG9qJuI.gif) I think the issue is our `signedOutFallback` component not having the current user in the redux state from local storage for whatever reason.  (browser settings?)

This might fix it by falling back to the Apollo `getCurrentUser` query before declaring the user definitely logged in or out.