### PR TITLE
Enable Apollo Engine again and cache Community.metaData

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -94,25 +94,24 @@ import createSubscriptionsServer from './routes/create-subscription-server';
 const subscriptionsServer = createSubscriptionsServer(server, '/websocket');
 
 // Start API wrapped in Apollo Engine
-// const engine = new ApolloEngine({
-//   logging: {
-//     level: 'WARN',
-//   },
-//   apiKey: process.env.APOLLO_ENGINE_API_KEY,
-//   // Only send perf data to the remote server in production
-//   reporting: {
-//     disabled: process.env.NODE_ENV !== 'production',
-//     hostname: process.env.NOW_URL || undefined,
-//     privateHeaders: ['authorization', 'Authorization', 'AUTHORIZATION'],
-//   },
-// });
+const engine = new ApolloEngine({
+  logging: {
+    level: 'WARN',
+  },
+  apiKey: process.env.APOLLO_ENGINE_API_KEY,
+  // Only send perf data to the remote server in production
+  reporting: {
+    disabled: process.env.NODE_ENV !== 'production',
+    hostname: process.env.NOW_URL || undefined,
+    privateHeaders: ['authorization', 'Authorization', 'AUTHORIZATION'],
+  },
+});
 
-// engine.listen({
-//   port: PORT,
-//   httpServer: server,
-//   graphqlPaths: ['/api'],
-// });
-server.listen(PORT);
+engine.listen({
+  port: PORT,
+  httpServer: server,
+  graphqlPaths: ['/api'],
+});
 debug(`GraphQL server running at http://localhost:${PORT}/api`);
 
 process.on('unhandledRejection', async err => {

--- a/api/index.js
+++ b/api/index.js
@@ -105,6 +105,23 @@ const engine = new ApolloEngine({
     hostname: process.env.NOW_URL || undefined,
     privateHeaders: ['authorization', 'Authorization', 'AUTHORIZATION'],
   },
+  stores: [
+    {
+      name: 'InMemoryStore',
+      inMemory: {
+        cacheSize: 104857600, // 100 MB
+      },
+    },
+  ],
+  queryCache: {
+    // Don't cache logged-in user responses
+    privateFullQueryStore: 'disabled',
+  },
+  sessionAuth: {
+    cookie: 'session',
+    // TODO(@mxstbr): Ping Apollo to note that we need both of those
+    // header: 'Authorization'
+  },
 });
 
 engine.listen({

--- a/api/index.js
+++ b/api/index.js
@@ -105,14 +105,6 @@ const engine = new ApolloEngine({
     hostname: process.env.NOW_URL || undefined,
     privateHeaders: ['authorization', 'Authorization', 'AUTHORIZATION'],
   },
-  stores: [
-    {
-      name: 'InMemoryStore',
-      inMemory: {
-        cacheSize: 104857600, // 100 MB
-      },
-    },
-  ],
   queryCache: {
     // Don't cache logged-in user responses
     privateFullQueryStore: 'disabled',

--- a/api/queries/community/metaData.js
+++ b/api/queries/community/metaData.js
@@ -11,6 +11,7 @@ export default async (root: DBCommunity, _: any, ctx: GraphQLContext) => {
     return {
       channels: 0,
       members: 0,
+      onlineMembers: 0,
     };
   }
 

--- a/api/routes/api/graphql.js
+++ b/api/routes/api/graphql.js
@@ -15,6 +15,9 @@ export default graphqlExpress(req => {
   return {
     schema,
     formatError: createErrorFormatter(req),
+    tracing: true,
+    cacheControl: true,
+    engine: false,
     context: {
       loaders,
       user: currentUser,

--- a/api/types/Community.js
+++ b/api/types/Community.js
@@ -41,7 +41,7 @@ const Community = /* GraphQL */ `
     node: Thread!
   }
 
-  type CommunityMetaData {
+  type CommunityMetaData @cacheControl(maxAge: 1800) {
     members: Int
     channels: Int
     onlineMembers: Int


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api


This sets Apollo Engine up again and makes it cache public responses in the server memory.This is obviously not optimal as we want the cached result to be returned by all servers, not every server having to cache! Not sure yet what to do about that because they don't support Redis, only memcached...

It also sets up the cache directive for Community.metaData, which should theoretically mean we only recompute that every 30 mins or so.