### PR TITLE
Hide pricing link on signed out navbar

### DIFF
--- a/cypress/integration/navbar_spec.js
+++ b/cypress/integration/navbar_spec.js
@@ -48,8 +48,6 @@ const checkSignedOutNavbarRenders = () => {
   cy.get('[data-cy="navbar-explore"]').should('be.visible');
 
   cy.get('[data-cy="navbar-support"]').should('be.visible');
-
-  cy.get('[data-cy="navbar-pricing"]').should('be.visible');
 };
 
 const checkSignedOutSplashNavbarRenders = () => {
@@ -65,9 +63,6 @@ const checkSignedOutSplashNavbarRenders = () => {
 
 const checkSignedInSplashNavbarRenders = () => {
   cy.visit('/about');
-  checkSignedInSplashNavbarLinksRender();
-
-  cy.visit('/pricing');
   checkSignedInSplashNavbarLinksRender();
 
   cy.visit('/features');

--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -16,7 +16,6 @@ import {
   ProfileDrop,
   ProfileTab,
   SupportTab,
-  PricingTab,
   Tab,
   Label,
   Navatar,
@@ -297,14 +296,6 @@ class Navbar extends React.Component<Props, State> {
             <Icon glyph="like" />
             <Label>Support</Label>
           </SupportTab>
-          <PricingTab
-            {...this.getTabProps(history.location.pathname === '/pricing')}
-            to="/pricing"
-            data-cy="navbar-pricing"
-          >
-            <Icon glyph="payment" />
-            <Label>Pricing</Label>
-          </PricingTab>
           <SigninLink to="/login">Sign In</SigninLink>
         </Nav>
       );

--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -49,12 +49,12 @@ export const Nav = styled.nav`
   ${props =>
     props.loggedOut &&
     css`
-      grid-template-columns: repeat(4, auto) 1fr auto;
-      grid-template-areas: 'logo explore support pricing . signin';
+      grid-template-columns: repeat(3, auto) 1fr auto;
+      grid-template-areas: 'logo explore support . signin';
 
       @media (max-width: 768px) {
-        grid-template-columns: auto auto auto auto;
-        grid-template-areas: 'home explore support pricing';
+        grid-template-columns: repeat(3, 1fr);
+        grid-template-areas: 'home explore support';
       }
     `} ${props =>
   props.hideOnMobile &&
@@ -275,10 +275,6 @@ export const ExploreTab = styled(Tab)`
 
 export const SupportTab = styled(Tab)`
   grid-area: support;
-`;
-
-export const PricingTab = styled(MessageTab)`
-  grid-area: pricing;
 `;
 
 export const NotificationTab = styled(DropTab)`


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Had feedback that people were getting confused by the 'pricing' link in the navbar when viewing a community profile while signed out. It felt like the community itself was paid, and wasn't clear that the navbar was for Spectrum and not the community. This is a confusing paradigm in general, and should be considered with our community profile redesign cc @mxstbr @uberbryn 

I've gone ahead and removed it, since we should realistically only expect people to dig into the pricing page when they are approaching Spectrum from one of our marketing pages.