### PR TITLE
Add type ahead to mentions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+- [x] figure out how to position suggestions where the cursor is
+- [ ] fix mention decorator conflict
+- [ ] how to render thread messages
+      redraft
+
+* [ ] make sure mentions still trigger appropriate serverside actions
+* [ ] disable sending post when hitting enter in input

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,0 @@
-- [x] figure out how to position suggestions where the cursor is
-- [x] fix mention decorator conflict
-- [ ] clean up old mention decorator code
-- [ ] how to render thread messages
-- [ ] fix links from mention components
-- [ ] make sure mentions still trigger appropriate serverside actions
-- [ ] disable sending post when hitting enter in input

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 - [x] figure out how to position suggestions where the cursor is
-- [ ] fix mention decorator conflict
+- [x] fix mention decorator conflict
+- [ ] clean up old mention decorator code
 - [ ] how to render thread messages
-      redraft
-
-* [ ] make sure mentions still trigger appropriate serverside actions
-* [ ] disable sending post when hitting enter in input
+- [ ] fix links from mention components
+- [ ] make sure mentions still trigger appropriate serverside actions
+- [ ] disable sending post when hitting enter in input

--- a/api/queries/search/searchUsers.js
+++ b/api/queries/search/searchUsers.js
@@ -7,36 +7,38 @@ import { trackQueue } from 'shared/bull/queues';
 import { events } from 'shared/analytics';
 
 export default (args: Args, { loaders, user }: GraphQLContext) => {
-  const { queryString, filter } = args;
-  const searchFilter = filter;
+  // const { queryString, filter } = args;
+  // const searchFilter = filter;
 
-  // if we are searching for community members, find *everyone*
-  const hitsPerPage = searchFilter && searchFilter.communityId ? 100000 : 20;
+  // // if we are searching for community members, find *everyone*
+  // const hitsPerPage = searchFilter && searchFilter.communityId ? 100000 : 20;
 
-  return usersSearchIndex
-    .search({ query: queryString, hitsPerPage })
-    .then(content => {
-      const event =
-        searchFilter && searchFilter.communityId
-          ? events.SEARCHED_COMMUNITY_MEMBERS
-          : events.SEARCHED_USERS;
+  // return usersSearchIndex
+  //   .search({ query: queryString, hitsPerPage })
+  //   .then(content => {
+  //     const event =
+  //       searchFilter && searchFilter.communityId
+  //         ? events.SEARCHED_COMMUNITY_MEMBERS
+  //         : events.SEARCHED_USERS;
 
-      if (user && user.id) {
-        trackQueue.add({
-          userId: user.id,
-          event,
-          properties: {
-            queryString,
-            hitsCount: content.hits ? content.hits.length : 0,
-          },
-        });
-      }
+  //     if (user && user.id) {
+  //       trackQueue.add({
+  //         userId: user.id,
+  //         event,
+  //         properties: {
+  //           queryString,
+  //           hitsCount: content.hits ? content.hits.length : 0,
+  //         },
+  //       });
+  //     }
 
-      if (!content.hits || content.hits.length === 0) return [];
+  //     if (!content.hits || content.hits.length === 0) return [];
 
-      const userIds = content.hits.map(o => o.objectID);
-      return loaders.user.loadMany(userIds);
-    })
+  //     const userIds = content.hits.map(o => o.objectID);
+  //   })
+  return Promise.resolve(
+    loaders.user.loadMany(['95de9ec4-924d-4d3d-b1bf-b56c2a3116a9'])
+  )
     .then(data => data.filter(Boolean))
     .catch(err => {
       console.error('err', err);

--- a/api/queries/search/searchUsers.js
+++ b/api/queries/search/searchUsers.js
@@ -36,9 +36,8 @@ export default (args: Args, { loaders, user }: GraphQLContext) => {
 
   //     const userIds = content.hits.map(o => o.objectID);
   //   })
-  return Promise.resolve(
-    loaders.user.loadMany(['95de9ec4-924d-4d3d-b1bf-b56c2a3116a9'])
-  )
+  // TODO: revert entire file.  Mocking this out to return two known users in the test fixtures right now
+  return Promise.resolve(loaders.user.loadMany(['2', '3']))
     .then(data => data.filter(Boolean))
     .catch(err => {
       console.error('err', err);

--- a/api/queries/search/searchUsers.js
+++ b/api/queries/search/searchUsers.js
@@ -37,7 +37,8 @@ export default (args: Args, { loaders, user }: GraphQLContext) => {
   //     const userIds = content.hits.map(o => o.objectID);
   //   })
   // TODO: revert entire file.  Mocking this out to return two known users in the test fixtures right now
-  return Promise.resolve(loaders.user.loadMany(['2', '3']))
+  return loaders.user
+    .loadMany(['2', '3', '4', '5', '6'])
     .then(data => data.filter(Boolean))
     .catch(err => {
       console.error('err', err);

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "draft-js-import-markdown": "^1.2.1",
     "draft-js-linkify-plugin": "^2.0.0-beta1",
     "draft-js-markdown-plugin": "^3.0.1",
+    "draft-js-mention-plugin": "^3.0.4",
     "draft-js-plugins-editor": "^2.1.1",
     "draft-js-prism-plugin": "0.1.3",
     "draftjs-to-markdown": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "draft-js-import-markdown": "^1.2.1",
     "draft-js-linkify-plugin": "^2.0.0-beta1",
     "draft-js-markdown-plugin": "^3.0.1",
-    "draft-js-mention-plugin": "^3.0.4",
+    "draft-js-mention-plugin": "^3.1.0",
     "draft-js-plugins-editor": "^2.1.1",
     "draft-js-prism-plugin": "0.1.3",
     "draftjs-to-markdown": "^0.5.1",

--- a/shared/clients/draft-js/mentionEntry/index.js
+++ b/shared/clients/draft-js/mentionEntry/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { UserAvatar } from 'src/components/avatar/userAvatar';
+import Img from 'react-image';
+
+const MentionEntry = props => {
+  const {
+    mention,
+    theme,
+    isFocused, // eslint-disable-line no-unused-vars
+    searchValue, // eslint-disable-line no-unused-vars
+    ...parentProps
+  } = props;
+
+  return (
+    <div {...parentProps}>
+      <Img
+        src={[mention.avatar, '/img/default_avatar.svg']}
+        className={theme.mentionSuggestionsEntryAvatar}
+        role="presentation"
+      />
+      <span className={theme.mentionSuggestionsEntryText}>{mention.name}</span>
+    </div>
+  );
+};
+
+export { MentionEntry };

--- a/shared/clients/draft-js/mentions-decorator/core.js
+++ b/shared/clients/draft-js/mentions-decorator/core.js
@@ -39,10 +39,12 @@ const createMentionsDecorator = (
 ) => ({
   strategy: (
     contentBlock: ContentBlock,
-    callback: (...args?: Array<any>) => any
+    callback: (...args?: Array<any>) => any,
+    contentState: any
   ) => {
     // This prevents the search for mentions when we're inside of a code-block
     if (contentBlock.type === 'code-block') return;
+    if (!contentState) return;
 
     // -> "@brian_lovin, what's up with @mxstbr?"
     const text = contentBlock.getText();
@@ -57,7 +59,15 @@ const createMentionsDecorator = (
 
     const mentionCoordinates = getMentionsPositionsFromMessage(text);
 
+    const selectionKeyOffset = contentState
+      .getSelectionAfter()
+      .getStartOffset();
+
     mentionCoordinates.forEach(({ startPos, endPos }) => {
+      // if cursor is currently on a mention, don't match
+      // this is so that the decorator doesn't conflict with the
+      // decorator from draft-js-mention-plugin that renders the suggestions portal
+      if (startPos < selectionKeyOffset && selectionKeyOffset < endPos) return;
       callback(startPos, endPos);
     });
   },

--- a/shared/clients/draft-js/message/renderer.web.js
+++ b/shared/clients/draft-js/message/renderer.web.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import mentionsDecorator from '../mentions-decorator/index.web';
 import linksDecorator from '../links-decorator/index.web';
+import { Mention } from 'src/components/rich-text-editor/style.js';
 import { Line, Paragraph, BlockQuote } from 'src/components/message/style';
 import type { Node } from 'react';
 import type { KeyObj, KeysObj } from './types';
@@ -20,6 +21,13 @@ const messageRenderer = {
       <code key={key}>{children}</code>
     ),
   },
+  entities: {
+    mention: (children: string, { mention: { name } }: any) => (
+      <Mention username={name} key={name}>
+        {children}
+      </Mention>
+    ),
+  },
   blocks: {
     unstyled: (children: Array<Node>, { keys }: KeysObj) =>
       children.map((child, index) => (
@@ -35,7 +43,7 @@ const messageRenderer = {
         <BlockQuote key={keys[index] || index}>{child}</BlockQuote>
       )),
   },
-  decorators: [mentionsDecorator, linksDecorator],
+  decorators: [linksDecorator],
 };
 
 export { messageRenderer };

--- a/shared/clients/draft-js/message/renderer.web.js
+++ b/shared/clients/draft-js/message/renderer.web.js
@@ -21,13 +21,6 @@ const messageRenderer = {
       <code key={key}>{children}</code>
     ),
   },
-  entities: {
-    mention: (children: string, { mention: { name } }: any) => (
-      <Mention username={name} key={name}>
-        {children}
-      </Mention>
-    ),
-  },
   blocks: {
     unstyled: (children: Array<Node>, { keys }: KeysObj) =>
       children.map((child, index) => (
@@ -43,7 +36,7 @@ const messageRenderer = {
         <BlockQuote key={keys[index] || index}>{child}</BlockQuote>
       )),
   },
-  decorators: [linksDecorator],
+  decorators: [mentionsDecorator, linksDecorator],
 };
 
 export { messageRenderer };

--- a/shared/regexps.js
+++ b/shared/regexps.js
@@ -1,5 +1,5 @@
 // @flow
 
-module.exports.MENTIONS = /\/?\B@[a-z0-9_-]+/gi;
+module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+/gi;
 module.exports.URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/gi;
 module.exports.RELATIVE_URL = /^\/([^\/].*|$)/g;

--- a/src/components/chatInput/MentionSuggestions/Entry/Avatar/index.js
+++ b/src/components/chatInput/MentionSuggestions/Entry/Avatar/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const Avatar = ({ mention, theme = {} }) => {
+  if (mention.avatar) {
+    return (
+      <img
+        src={mention.avatar}
+        className={theme.mentionSuggestionsEntryAvatar}
+        role="presentation"
+      />
+    );
+  }
+
+  return null;
+};
+
+export default Avatar;

--- a/src/components/chatInput/MentionSuggestions/Entry/defaultEntryComponent.js
+++ b/src/components/chatInput/MentionSuggestions/Entry/defaultEntryComponent.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Avatar from './Avatar';
+
+const defaultEntryComponent = props => {
+  const {
+    mention,
+    theme,
+    isFocused, // eslint-disable-line no-unused-vars
+    searchValue, // eslint-disable-line no-unused-vars
+    ...parentProps
+  } = props;
+
+  return (
+    <div {...parentProps}>
+      <Avatar mention={mention} theme={theme} />
+      <span className={theme.mentionSuggestionsEntryText}>{mention.name}</span>
+    </div>
+  );
+};
+
+export default defaultEntryComponent;

--- a/src/components/chatInput/MentionSuggestions/Entry/index.js
+++ b/src/components/chatInput/MentionSuggestions/Entry/index.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+export default class Entry extends Component {
+  static propTypes = {
+    entryComponent: PropTypes.any.isRequired,
+    searchValue: PropTypes.string,
+    onMentionSelect: PropTypes.func,
+  };
+
+  constructor(props) {
+    super(props);
+    this.mouseDown = false;
+  }
+
+  componentDidUpdate() {
+    this.mouseDown = false;
+  }
+
+  onMouseUp = () => {
+    if (this.mouseDown) {
+      this.props.onMentionSelect(this.props.mention);
+      this.mouseDown = false;
+    }
+  };
+
+  onMouseDown = event => {
+    // Note: important to avoid a content edit change
+    event.preventDefault();
+
+    this.mouseDown = true;
+  };
+
+  onMouseEnter = () => {
+    this.props.onMentionFocus(this.props.index);
+  };
+
+  render() {
+    const { theme = {}, mention, searchValue, isFocused, id } = this.props;
+    const className = isFocused
+      ? theme.mentionSuggestionsEntryFocused
+      : theme.mentionSuggestionsEntry;
+    const EntryComponent = this.props.entryComponent;
+    return (
+      <EntryComponent
+        className={className}
+        onMouseDown={this.onMouseDown}
+        onMouseUp={this.onMouseUp}
+        onMouseEnter={this.onMouseEnter}
+        role="option"
+        id={id}
+        aria-selected={isFocused ? 'true' : null}
+        theme={theme}
+        mention={mention}
+        isFocused={isFocused}
+        searchValue={searchValue}
+      />
+    );
+  }
+}

--- a/src/components/chatInput/MentionSuggestions/index.js
+++ b/src/components/chatInput/MentionSuggestions/index.js
@@ -1,0 +1,478 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Modifier, EditorState, genKey } from 'draft-js';
+import escapeRegExp from 'lodash.escaperegexp';
+import Entry from './Entry';
+import defaultEntryComponent from './Entry/defaultEntryComponent';
+
+export class MentionSuggestions extends Component {
+  static propTypes = {
+    entityMutability: PropTypes.oneOf(['SEGMENTED', 'IMMUTABLE', 'MUTABLE']),
+    entryComponent: PropTypes.func,
+    onAddMention: PropTypes.func,
+    suggestions: PropTypes.array,
+  };
+
+  state = {
+    isActive: false,
+    focusedOptionIndex: 0,
+  };
+
+  componentWillMount() {
+    this.key = genKey();
+    this.props.callbacks.onChange = this.onEditorStateChange;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.suggestions.length === 0 && this.state.isActive) {
+      this.closeDropdown();
+    } else if (
+      nextProps.suggestions.length > 0 &&
+      nextProps.suggestions !== this.props.suggestions &&
+      !this.state.isActive
+    ) {
+      this.openDropdown();
+    }
+  }
+
+  componentDidUpdate = (prevProps, prevState) => {
+    if (this.popover) {
+      // In case the list shrinks there should be still an option focused.
+      // Note: this might run multiple times and deduct 1 until the condition is
+      // not fullfilled anymore.
+      const size = this.props.suggestions.length;
+      if (size > 0 && this.state.focusedOptionIndex >= size) {
+        this.setState({
+          focusedOptionIndex: size - 1,
+        });
+      }
+
+      // Note: this is a simple protection for the error when componentDidUpdate
+      // try to get new getPortalClientRect, but the key already was deleted by
+      // previous action. (right now, it only can happened when set the mention
+      // trigger to be multi-characters which not supported anyway!)
+      if (!this.props.store.getAllSearches().has(this.activeOffsetKey)) {
+        return;
+      }
+
+      const decoratorRect = this.props.store.getPortalClientRect(
+        this.activeOffsetKey
+      );
+      const newStyles = this.props.positionSuggestions({
+        decoratorRect,
+        prevProps,
+        prevState,
+        props: this.props,
+        state: this.state,
+        popover: this.popover,
+      });
+      Object.keys(newStyles).forEach(key => {
+        this.popover.style[key] = newStyles[key];
+      });
+    }
+  };
+
+  componentWillUnmount = () => {
+    this.props.callbacks.onChange = undefined;
+  };
+
+  onEditorStateChange = editorState => {
+    const searches = this.props.store.getAllSearches();
+
+    // if no search portal is active there is no need to show the popover
+    if (searches.size === 0) {
+      return editorState;
+    }
+
+    const removeList = () => {
+      this.props.store.resetEscapedSearch();
+      this.closeDropdown();
+      return editorState;
+    };
+
+    // get the current selection
+    const selection = editorState.getSelection();
+    const anchorKey = selection.getAnchorKey();
+    const anchorOffset = selection.getAnchorOffset();
+
+    // the list should not be visible if a range is selected or the editor has no focus
+    if (!selection.isCollapsed() || !selection.getHasFocus())
+      return removeList();
+
+    // identify the start & end positon of each search-text
+    const offsetDetails = searches.map(offsetKey => decodeOffsetKey(offsetKey));
+
+    // a leave can be empty when it is removed due e.g. using backspace
+    // do not check leaves, use full decorated portal text
+    const leaves = offsetDetails
+      .filter(({ blockKey }) => blockKey === anchorKey)
+      .map(({ blockKey, decoratorKey }) =>
+        editorState.getBlockTree(blockKey).getIn([decoratorKey])
+      );
+
+    // if all leaves are undefined the popover should be removed
+    if (leaves.every(leave => leave === undefined)) {
+      return removeList();
+    }
+
+    // Checks that the cursor is after the @ character but still somewhere in
+    // the word (search term). Setting it to allow the cursor to be left of
+    // the @ causes troubles due selection confusion.
+    const plainText = editorState.getCurrentContent().getPlainText();
+    const selectionIsInsideWord = leaves
+      .filter(leave => leave !== undefined)
+      .map(
+        ({ start, end }) =>
+          (start === 0 &&
+            anchorOffset === this.props.mentionTrigger.length &&
+            plainText.charAt(anchorOffset) !== this.props.mentionTrigger &&
+            new RegExp(
+              String.raw({ raw: `${escapeRegExp(this.props.mentionTrigger)}` }),
+              'g'
+            ).test(plainText) &&
+            anchorOffset <= end) || // @ is the first character
+          (anchorOffset > start + this.props.mentionTrigger.length &&
+            anchorOffset <= end) // @ is in the text or at the end
+      );
+
+    if (selectionIsInsideWord.every(isInside => isInside === false))
+      return removeList();
+
+    const lastActiveOffsetKey = this.activeOffsetKey;
+    this.activeOffsetKey = selectionIsInsideWord
+      .filter(value => value === true)
+      .keySeq()
+      .first();
+
+    this.onSearchChange(
+      editorState,
+      selection,
+      this.activeOffsetKey,
+      lastActiveOffsetKey
+    );
+
+    // make sure the escaped search is reseted in the cursor since the user
+    // already switched to another mention search
+    if (!this.props.store.isEscaped(this.activeOffsetKey)) {
+      this.props.store.resetEscapedSearch();
+    }
+
+    // If none of the above triggered to close the window, it's safe to assume
+    // the dropdown should be open. This is useful when a user focuses on another
+    // input field and then comes back: the dropdown will show again.
+    if (
+      !this.state.isActive &&
+      !this.props.store.isEscaped(this.activeOffsetKey) &&
+      this.props.suggestions.length > 0
+    ) {
+      this.openDropdown();
+    }
+
+    // makes sure the focused index is reseted every time a new selection opens
+    // or the selection was moved to another mention search
+    if (
+      this.lastSelectionIsInsideWord === undefined ||
+      !selectionIsInsideWord.equals(this.lastSelectionIsInsideWord)
+    ) {
+      this.setState({
+        focusedOptionIndex: 0,
+      });
+    }
+
+    this.lastSelectionIsInsideWord = selectionIsInsideWord;
+
+    return editorState;
+  };
+
+  onSearchChange = (
+    editorState,
+    selection,
+    activeOffsetKey,
+    lastActiveOffsetKey
+  ) => {
+    const { matchingString: searchValue } = getSearchText(
+      editorState,
+      selection,
+      this.props.mentionTrigger
+    );
+
+    if (
+      this.lastSearchValue !== searchValue ||
+      activeOffsetKey !== lastActiveOffsetKey
+    ) {
+      this.lastSearchValue = searchValue;
+      this.props.onSearchChange({ value: searchValue });
+    }
+  };
+
+  onDownArrow = keyboardEvent => {
+    keyboardEvent.preventDefault();
+    const newIndex = this.state.focusedOptionIndex + 1;
+    this.onMentionFocus(
+      newIndex >= this.props.suggestions.length ? 0 : newIndex
+    );
+  };
+
+  onTab = keyboardEvent => {
+    keyboardEvent.preventDefault();
+    this.commitSelection();
+  };
+
+  onUpArrow = keyboardEvent => {
+    keyboardEvent.preventDefault();
+    if (this.props.suggestions.length > 0) {
+      const newIndex = this.state.focusedOptionIndex - 1;
+      this.onMentionFocus(
+        newIndex < 0 ? this.props.suggestions.length - 1 : newIndex
+      );
+    }
+  };
+
+  onEscape = keyboardEvent => {
+    keyboardEvent.preventDefault();
+
+    const activeOffsetKey = this.lastSelectionIsInsideWord
+      .filter(value => value === true)
+      .keySeq()
+      .first();
+    this.props.store.escapeSearch(activeOffsetKey);
+    this.closeDropdown();
+
+    // to force a re-render of the outer component to change the aria props
+    this.props.store.setEditorState(this.props.store.getEditorState());
+  };
+
+  onMentionSelect = mention => {
+    // Note: This can happen in case a user typed @xxx (invalid mention) and
+    // then hit Enter. Then the mention will be undefined.
+    if (!mention) {
+      return;
+    }
+
+    if (this.props.onAddMention) {
+      this.props.onAddMention(mention);
+    }
+
+    this.closeDropdown();
+    const newEditorState = addMention(
+      this.props.store.getEditorState(),
+      mention,
+      this.props.mentionPrefix,
+      this.props.mentionTrigger,
+      this.props.entityMutability
+    );
+    this.props.store.setEditorState(newEditorState);
+  };
+
+  onMentionFocus = index => {
+    const descendant = `mention-option-${this.key}-${index}`;
+    this.props.ariaProps.ariaActiveDescendantID = descendant;
+    this.setState({
+      focusedOptionIndex: index,
+    });
+
+    // to force a re-render of the outer component to change the aria props
+    this.props.store.setEditorState(this.props.store.getEditorState());
+  };
+
+  commitSelection = () => {
+    if (!this.props.store.getIsOpened()) {
+      return 'not-handled';
+    }
+
+    this.onMentionSelect(this.props.suggestions[this.state.focusedOptionIndex]);
+    return 'handled';
+  };
+
+  openDropdown = () => {
+    // This is a really nasty way of attaching & releasing the key related functions.
+    // It assumes that the keyFunctions object will not loose its reference and
+    // by this we can replace inner parameters spread over different modules.
+    // This better be some registering & unregistering logic. PRs are welcome :)
+    this.props.callbacks.onDownArrow = this.onDownArrow;
+    this.props.callbacks.onUpArrow = this.onUpArrow;
+    this.props.callbacks.onEscape = this.onEscape;
+    this.props.callbacks.handleReturn = this.commitSelection;
+    this.props.callbacks.onTab = this.onTab;
+
+    const descendant = `mention-option-${this.key}-${
+      this.state.focusedOptionIndex
+    }`;
+    this.props.ariaProps.ariaActiveDescendantID = descendant;
+    this.props.ariaProps.ariaOwneeID = `mentions-list-${this.key}`;
+    this.props.ariaProps.ariaHasPopup = 'true';
+    this.props.ariaProps.ariaExpanded = true;
+    this.setState({
+      isActive: true,
+    });
+
+    if (this.props.onOpen) {
+      this.props.onOpen();
+    }
+  };
+
+  closeDropdown = () => {
+    // make sure none of these callbacks are triggered
+    this.props.callbacks.onDownArrow = undefined;
+    this.props.callbacks.onUpArrow = undefined;
+    this.props.callbacks.onTab = undefined;
+    this.props.callbacks.onEscape = undefined;
+    this.props.callbacks.handleReturn = undefined;
+    this.props.ariaProps.ariaHasPopup = 'false';
+    this.props.ariaProps.ariaExpanded = false;
+    this.props.ariaProps.ariaActiveDescendantID = undefined;
+    this.props.ariaProps.ariaOwneeID = undefined;
+    this.setState({
+      isActive: false,
+    });
+
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
+  };
+
+  render() {
+    if (!this.state.isActive) {
+      return null;
+    }
+
+    const {
+      entryComponent,
+      popoverComponent = <div />,
+      onClose, // eslint-disable-line no-unused-vars
+      onOpen, // eslint-disable-line no-unused-vars
+      onAddMention, // eslint-disable-line no-unused-vars, no-shadow
+      onSearchChange, // eslint-disable-line no-unused-vars, no-shadow
+      suggestions, // eslint-disable-line no-unused-vars
+      ariaProps, // eslint-disable-line no-unused-vars
+      callbacks, // eslint-disable-line no-unused-vars
+      theme = {},
+      store, // eslint-disable-line no-unused-vars
+      entityMutability, // eslint-disable-line no-unused-vars
+      positionSuggestions, // eslint-disable-line no-unused-vars
+      mentionTrigger, // eslint-disable-line no-unused-vars
+      mentionPrefix, // eslint-disable-line no-unused-vars
+      ...elementProps
+    } = this.props;
+
+    return React.cloneElement(
+      popoverComponent,
+      {
+        ...elementProps,
+        className: theme.mentionSuggestions,
+        role: 'listbox',
+        id: `mentions-list-${this.key}`,
+        ref: element => {
+          this.popover = element;
+        },
+      },
+      this.props.suggestions.map((mention, index) => (
+        <Entry
+          key={mention.id != null ? mention.id : mention.name}
+          onMentionSelect={this.onMentionSelect}
+          onMentionFocus={this.onMentionFocus}
+          isFocused={this.state.focusedOptionIndex === index}
+          mention={mention}
+          index={index}
+          id={`mention-option-${this.key}-${index}`}
+          theme={theme}
+          searchValue={this.lastSearchValue}
+          entryComponent={entryComponent || defaultEntryComponent}
+        />
+      ))
+    );
+  }
+}
+
+export default MentionSuggestions;
+
+const decodeOffsetKey = offsetKey => {
+  const [blockKey, decoratorKey, leafKey] = offsetKey.split('-');
+  return {
+    blockKey,
+    decoratorKey: parseInt(decoratorKey, 10),
+    leafKey: parseInt(leafKey, 10),
+  };
+};
+
+const getSearchTextAt = (
+  blockText: string,
+  position: number,
+  trigger: string
+) => {
+  const str = blockText.substr(0, position);
+  const begin = str.lastIndexOf(trigger);
+  const matchingString = str.slice(begin + trigger.length);
+  const end = str.length;
+
+  return {
+    begin,
+    end,
+    matchingString,
+  };
+};
+
+const getSearchText = (editorState, selection, trigger) => {
+  const anchorKey = selection.getAnchorKey();
+  const anchorOffset = selection.getAnchorOffset();
+  const currentContent = editorState.getCurrentContent();
+  const currentBlock = currentContent.getBlockForKey(anchorKey);
+  const blockText = currentBlock.getText();
+  return getSearchTextAt(blockText, anchorOffset, trigger);
+};
+
+const getTypeByTrigger = trigger =>
+  trigger === '@' ? 'mention' : `${trigger}mention`;
+
+const addMention = (
+  editorState,
+  mention,
+  mentionPrefix,
+  mentionTrigger,
+  entityMutability
+) => {
+  const currentSelectionState = editorState.getSelection();
+  const { begin, end } = getSearchText(
+    editorState,
+    currentSelectionState,
+    mentionTrigger
+  );
+
+  // get selection of the @mention search text
+  const mentionTextSelection = currentSelectionState.merge({
+    anchorOffset: begin,
+    focusOffset: end,
+  });
+
+  let mentionReplacedContent = Modifier.replaceText(
+    editorState.getCurrentContent(),
+    mentionTextSelection,
+    `${mentionPrefix}${mention.name}`,
+    null // no inline style needed
+  );
+
+  // If the mention is inserted at the end, a space is appended right after for
+  // a smooth writing experience.
+  const blockKey = mentionTextSelection.getAnchorKey();
+  const blockSize = editorState
+    .getCurrentContent()
+    .getBlockForKey(blockKey)
+    .getLength();
+  if (blockSize === end) {
+    mentionReplacedContent = Modifier.insertText(
+      mentionReplacedContent,
+      mentionReplacedContent.getSelectionAfter(),
+      ' '
+    );
+  }
+
+  const newEditorState = EditorState.push(
+    editorState,
+    mentionReplacedContent,
+    'insert-mention'
+  );
+  return EditorState.forceSelection(
+    newEditorState,
+    mentionReplacedContent.getSelectionAfter()
+  );
+};

--- a/src/components/chatInput/hoc/withUserSearch.js
+++ b/src/components/chatInput/hoc/withUserSearch.js
@@ -1,0 +1,34 @@
+import { withStateHandlers, compose, withProps } from 'recompose';
+import searchUsers from 'shared/graphql/queries/search/searchUsers';
+import { flatMap, map } from 'lodash';
+
+const withUserSearch = withStateHandlers(
+  {
+    queryString: '',
+  },
+  {
+    search: prev => value => {
+      return {
+        queryString: value,
+      };
+    },
+  }
+);
+
+const mapUserProps = withProps(({ data, error, loading, queryString }) => {
+  const users = data.search
+    ? map(data.search.searchResultsConnection.edges, edge => {
+        return edge.node;
+      })
+    : [];
+  return {
+    users,
+    loading,
+    error,
+  };
+});
+export default compose(
+  withUserSearch,
+  searchUsers,
+  mapUserProps
+);

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -690,7 +690,7 @@ class ChatInput extends React.Component<Props, State> {
                 code={false}
                 editorRef={editor => (this.editor = editor)}
                 editorKey="chat-input"
-                decorators={[linksDecorator]}
+                decorators={[mentionsDecorator, linksDecorator]}
                 networkDisabled={networkDisabled}
                 hasAttachment={!!mediaPreview || !!quotedMessage}
               >

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -37,6 +37,8 @@ import { getMessageById } from 'shared/graphql/queries/message/getMessage';
 import MediaUploader from './components/mediaUploader';
 import { QuotedMessage as QuotedMessageComponent } from '../message/view';
 import type { Dispatch } from 'redux';
+import withUserSearch from './hoc/withUserSearch';
+import { consolidateStreamedStyles } from 'styled-components';
 
 const QuotedMessage = connect()(
   getMessageById(props => {
@@ -90,6 +92,8 @@ type Props = {
   threadData?: Object,
   refetchThread?: Function,
   quotedMessage: ?{ messageId: string, threadId: string },
+  search: Function,
+  users: Array<any>,
 };
 
 const LS_KEY = 'last-chat-input-content';
@@ -624,6 +628,7 @@ class ChatInput extends React.Component<Props, State> {
       websocketConnection,
       quotedMessage,
       thread,
+      users,
     } = this.props;
     const {
       isFocused,
@@ -671,6 +676,10 @@ class ChatInput extends React.Component<Props, State> {
             )}
             <Form focus={isFocused}>
               <Input
+                onMentionChange={({ value }) => {
+                  this.props.search(value);
+                }}
+                mentionSuggestions={users.map(userNodeToMention)}
                 focus={isFocused}
                 placeholder={`Your message here...`}
                 editorState={state}
@@ -681,7 +690,7 @@ class ChatInput extends React.Component<Props, State> {
                 code={false}
                 editorRef={editor => (this.editor = editor)}
                 editorKey="chat-input"
-                decorators={[mentionsDecorator, linksDecorator]}
+                decorators={[linksDecorator]}
                 networkDisabled={networkDisabled}
                 hasAttachment={!!mediaPreview || !!quotedMessage}
               >
@@ -742,5 +751,12 @@ export default compose(
   withHandlers({
     onChange: ({ changeState }) => state => changeState(state),
     clear: ({ changeState }) => () => changeState(fromPlainText('')),
-  })
+  }),
+  withUserSearch
 )(ChatInput);
+
+const userNodeToMention = ({ username, profilePhoto }) => ({
+  name: username,
+  avatar: profilePhoto,
+  link: 'https://twitter.com/mrussell247',
+});

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -69,41 +69,6 @@ type State = {
 //     transition,
 //   };
 // };
-const mentions = [
-  {
-    name: 'Matthew Russell',
-    link: 'https://twitter.com/mrussell247',
-    avatar:
-      'https://pbs.twimg.com/profile_images/517863945/mattsailing_400x400.jpg',
-  },
-  {
-    name: 'Julian Krispel-Samsel',
-    link: 'https://twitter.com/juliandoesstuff',
-    avatar: 'https://avatars2.githubusercontent.com/u/1188186?v=3&s=400',
-  },
-  {
-    name: 'Jyoti Puri',
-    link: 'https://twitter.com/jyopur',
-    avatar: 'https://avatars0.githubusercontent.com/u/2182307?v=3&s=400',
-  },
-  {
-    name: 'Max Stoiber',
-    link: 'https://twitter.com/mxstbr',
-    avatar:
-      'https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg',
-  },
-  {
-    name: 'Nik Graf',
-    link: 'https://twitter.com/nikgraf',
-    avatar: 'https://avatars0.githubusercontent.com/u/223045?v=3&s=400',
-  },
-  {
-    name: 'Pascal Brandt',
-    link: 'https://twitter.com/psbrandt',
-    avatar:
-      'https://pbs.twimg.com/profile_images/688487813025640448/E6O6I011_400x400.png',
-  },
-];
 
 /*
  * NOTE(@mxstbr): DraftJS has huge troubles on Android, it's basically unusable
@@ -150,12 +115,6 @@ class Input extends React.Component<Props, State> {
     if (editorRef && typeof editorRef === 'function') editorRef(editor);
   };
 
-  onMentionSearchChange = ({ value }: any) => {
-    this.setState({
-      mentionSuggestions: defaultSuggestionsFilter(value, mentions),
-    });
-  };
-
   onAddMention = () => {
     //TODO
   };
@@ -177,9 +136,6 @@ class Input extends React.Component<Props, State> {
     } = this.props;
     const { plugins } = this.state;
     const { MentionSuggestions } = this.mentionPlugin;
-
-    console.log('MENTION SUGGESTIONS----');
-    console.log(mentionSuggestions);
 
     return (
       <InputWrapper
@@ -204,19 +160,12 @@ class Input extends React.Component<Props, State> {
           {...rest}
         />
         <MentionSuggestions
-          // onSearchChange={args => {
-          //   console.log('onsearch change');
-          //   this.onMentionSearchChange(args);
-          // }}
           onSearchChange={({ value }) => {
-            console.log('----------On SearchChange');
-            console.log(value);
             this.props.onMentionChange({ value });
           }}
           suggestions={
             console.log(mentionSuggestions, 'mentions') || mentionSuggestions
           }
-          // suggestions={this.state.mentionSuggestions}
         />
       </InputWrapper>
     );

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -19,6 +19,10 @@ import 'prismjs/components/prism-swift';
 import createPrismPlugin from 'draft-js-prism-plugin';
 import { customStyleMap } from 'src/components/rich-text-editor/style';
 import type { DraftEditorState } from 'draft-js/lib/EditorState';
+import createMentionPlugin, {
+  defaultSuggestionsFilter,
+} from 'draft-js-mention-plugin';
+import mentionPositionSuggestion from './mentionPositionSuggestion';
 
 import { InputWrapper } from './style';
 
@@ -34,11 +38,72 @@ type Props = {
   children?: React$Node,
   hasAttachment?: boolean,
   code?: boolean,
+  onMentionChange: any => void,
+  mentionSuggestions: Array<any>,
 };
 
 type State = {
   plugins: Array<mixed>,
+  mentionSuggestions: Array<any>,
 };
+// const positionSuggestions = ({ state, props }) => {
+//   console.log('EDITOR STATE');
+//   console.log(state);
+//   console.log(props);
+
+//   let constantOffset = -70;
+//   let transform;
+//   let transition;
+
+//   if (state.isActive && props.suggestions.length > 0) {
+//     transform = `scaleY(1) translateY(${constantOffset -
+//       props.suggestions.length * 30}px)`;
+//     transition = 'all 0.25s cubic-bezier(.3,1.2,.2,1)';
+//   } else if (state.isActive) {
+//     transform = 'scaleY(0)';
+//     transition = 'all 0.25s cubic-bezier(.3,1,.2,1)';
+//   }
+
+//   return {
+//     transform,
+//     transition,
+//   };
+// };
+const mentions = [
+  {
+    name: 'Matthew Russell',
+    link: 'https://twitter.com/mrussell247',
+    avatar:
+      'https://pbs.twimg.com/profile_images/517863945/mattsailing_400x400.jpg',
+  },
+  {
+    name: 'Julian Krispel-Samsel',
+    link: 'https://twitter.com/juliandoesstuff',
+    avatar: 'https://avatars2.githubusercontent.com/u/1188186?v=3&s=400',
+  },
+  {
+    name: 'Jyoti Puri',
+    link: 'https://twitter.com/jyopur',
+    avatar: 'https://avatars0.githubusercontent.com/u/2182307?v=3&s=400',
+  },
+  {
+    name: 'Max Stoiber',
+    link: 'https://twitter.com/mxstbr',
+    avatar:
+      'https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg',
+  },
+  {
+    name: 'Nik Graf',
+    link: 'https://twitter.com/nikgraf',
+    avatar: 'https://avatars0.githubusercontent.com/u/223045?v=3&s=400',
+  },
+  {
+    name: 'Pascal Brandt',
+    link: 'https://twitter.com/psbrandt',
+    avatar:
+      'https://pbs.twimg.com/profile_images/688487813025640448/E6O6I011_400x400.png',
+  },
+];
 
 /*
  * NOTE(@mxstbr): DraftJS has huge troubles on Android, it's basically unusable
@@ -48,11 +113,17 @@ type State = {
  */
 class Input extends React.Component<Props, State> {
   editor: any;
+  mentionPlugin: any;
 
   constructor(props: Props) {
     super(props);
+    this.mentionPlugin = createMentionPlugin({
+      positionSuggestions: mentionPositionSuggestion,
+      mentionPrefix: '@',
+    });
 
     this.state = {
+      mentionSuggestions: [],
       plugins: [
         createPrismPlugin({
           prism: Prism,
@@ -64,6 +135,7 @@ class Input extends React.Component<Props, State> {
           },
           renderLanguageSelect: () => null,
         }),
+        this.mentionPlugin,
         createCodeEditorPlugin(),
         createLinkifyPlugin({
           target: '_blank',
@@ -78,6 +150,16 @@ class Input extends React.Component<Props, State> {
     if (editorRef && typeof editorRef === 'function') editorRef(editor);
   };
 
+  onMentionSearchChange = ({ value }: any) => {
+    this.setState({
+      mentionSuggestions: defaultSuggestionsFilter(value, mentions),
+    });
+  };
+
+  onAddMention = () => {
+    //TODO
+  };
+
   render() {
     const {
       editorState,
@@ -90,9 +172,14 @@ class Input extends React.Component<Props, State> {
       children,
       hasAttachment,
       code,
+      mentionSuggestions,
       ...rest
     } = this.props;
     const { plugins } = this.state;
+    const { MentionSuggestions } = this.mentionPlugin;
+
+    console.log('MENTION SUGGESTIONS----');
+    console.log(mentionSuggestions);
 
     return (
       <InputWrapper
@@ -115,6 +202,21 @@ class Input extends React.Component<Props, State> {
           stripPastedStyles={true}
           customStyleMap={customStyleMap}
           {...rest}
+        />
+        <MentionSuggestions
+          // onSearchChange={args => {
+          //   console.log('onsearch change');
+          //   this.onMentionSearchChange(args);
+          // }}
+          onSearchChange={({ value }) => {
+            console.log('----------On SearchChange');
+            console.log(value);
+            this.props.onMentionChange({ value });
+          }}
+          suggestions={
+            console.log(mentionSuggestions, 'mentions') || mentionSuggestions
+          }
+          // suggestions={this.state.mentionSuggestions}
         />
       </InputWrapper>
     );

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -24,6 +24,7 @@ import createMentionPlugin, {
 } from 'draft-js-mention-plugin';
 import mentionPositionSuggestion from './mentionPositionSuggestion';
 import { MentionEntry } from 'shared/clients/draft-js/mentionEntry';
+import MentionSuggestions from './MentionSuggestions';
 
 import { InputWrapper } from './style';
 
@@ -47,36 +48,6 @@ type State = {
   plugins: Array<mixed>,
   mentionSuggestions: Array<any>,
 };
-// const positionSuggestions = ({ state, props }) => {
-//   console.log('EDITOR STATE');
-//   console.log(state);
-//   console.log(props);
-
-//   let constantOffset = -70;
-//   let transform;
-//   let transition;
-
-//   if (state.isActive && props.suggestions.length > 0) {
-//     transform = `scaleY(1) translateY(${constantOffset -
-//       props.suggestions.length * 30}px)`;
-//     transition = 'all 0.25s cubic-bezier(.3,1.2,.2,1)';
-//   } else if (state.isActive) {
-//     transform = 'scaleY(0)';
-//     transition = 'all 0.25s cubic-bezier(.3,1,.2,1)';
-//   }
-
-//   return {
-//     transform,
-//     transition,
-//   };
-// };
-
-/*
- * NOTE(@mxstbr): DraftJS has huge troubles on Android, it's basically unusable
- * We work around this by replacing the DraftJS editor with a plain text Input
- * on Android, and then converting the plain text to DraftJS content State
- * debounced every couple ms
- */
 class Input extends React.Component<Props, State> {
   editor: any;
   mentionPlugin: any;
@@ -84,6 +55,7 @@ class Input extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.mentionPlugin = createMentionPlugin({
+      mentionSuggestionsComponent: MentionSuggestions,
       positionSuggestions: mentionPositionSuggestion,
       mentionPrefix: '@',
     });
@@ -165,9 +137,7 @@ class Input extends React.Component<Props, State> {
           onSearchChange={({ value }) => {
             this.props.onMentionChange({ value });
           }}
-          suggestions={
-            console.log(mentionSuggestions, 'mentions') || mentionSuggestions
-          }
+          suggestions={mentionSuggestions}
         />
       </InputWrapper>
     );

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -137,7 +137,7 @@ class Input extends React.Component<Props, State> {
           onSearchChange={({ value }) => {
             this.props.onMentionChange({ value });
           }}
-          suggestions={mentionSuggestions}
+          suggestions={console.log(mentionSuggestions) || mentionSuggestions}
         />
       </InputWrapper>
     );

--- a/src/components/chatInput/input.js
+++ b/src/components/chatInput/input.js
@@ -23,6 +23,7 @@ import createMentionPlugin, {
   defaultSuggestionsFilter,
 } from 'draft-js-mention-plugin';
 import mentionPositionSuggestion from './mentionPositionSuggestion';
+import { MentionEntry } from 'shared/clients/draft-js/mentionEntry';
 
 import { InputWrapper } from './style';
 
@@ -160,6 +161,7 @@ class Input extends React.Component<Props, State> {
           {...rest}
         />
         <MentionSuggestions
+          entryComponent={MentionEntry}
           onSearchChange={({ value }) => {
             this.props.onMentionChange({ value });
           }}

--- a/src/components/chatInput/mentionPositionSuggestion.js
+++ b/src/components/chatInput/mentionPositionSuggestion.js
@@ -1,0 +1,60 @@
+const getRelativeParent = element => {
+  if (!element) {
+    return null;
+  }
+
+  const position = window
+    .getComputedStyle(element)
+    .getPropertyValue('position');
+  if (position !== 'static') {
+    return element;
+  }
+
+  return getRelativeParent(element.parentElement);
+};
+
+export default ({ decoratorRect, popover, state, props }) => {
+  const relativeParent = getRelativeParent(popover.parentElement);
+  const relativeRect = {};
+
+  if (relativeParent) {
+    relativeRect.scrollLeft = relativeParent.scrollLeft;
+    relativeRect.scrollTop = relativeParent.scrollTop;
+
+    const relativeParentRect = relativeParent.getBoundingClientRect();
+    relativeRect.left = decoratorRect.left - relativeParentRect.left;
+    relativeRect.top =
+      decoratorRect.bottom - relativeParentRect.top - popover.clientHeight - 30;
+  } else {
+    relativeRect.scrollTop =
+      window.pageYOffset || document.documentElement.scrollTop;
+    relativeRect.scrollLeft =
+      window.pageXOffset || document.documentElement.scrollLeft;
+
+    relativeRect.top = decoratorRect.bottom;
+    relativeRect.left = decoratorRect.left;
+  }
+
+  const left = relativeRect.left + relativeRect.scrollLeft;
+  const top = relativeRect.top + relativeRect.scrollTop;
+
+  let transform;
+  let transition;
+  if (state.isActive) {
+    if (props.suggestions.length > 0) {
+      transform = 'scale(1)';
+      transition = 'all 0.25s cubic-bezier(.3,1.2,.2,1)';
+    } else {
+      transform = 'scale(0)';
+      transition = 'all 0.35s cubic-bezier(.3,1,.2,1)';
+    }
+  }
+
+  return {
+    left: `${left}px`,
+    top: `${top}px`,
+    transform,
+    transformOrigin: '1em 0%',
+    transition,
+  };
+};

--- a/src/reset.css.js
+++ b/src/reset.css.js
@@ -423,3 +423,7 @@ injectGlobal`${draftGlobalCSS}`;
 import prismGlobalCSS from '!!raw-loader!./components/rich-text-editor/prism-theme.css';
 // $FlowIssue
 injectGlobal`${prismGlobalCSS}`;
+// $FlowIssue
+import draftMentionCss from '!!raw-loader!draft-js-mention-plugin/lib/plugin.css';
+// $FlowIssue
+injectGlobal`${draftMentionCss}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,9 +3730,9 @@ draft-js-markdown-plugin@^3.0.1:
     immutable "~3.7.4"
     react-click-outside "^3.0.1"
 
-draft-js-mention-plugin@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/draft-js-mention-plugin/-/draft-js-mention-plugin-3.0.4.tgz#e8530b7c16f23ce5b980515458418b5e24376f4a"
+draft-js-mention-plugin@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/draft-js-mention-plugin/-/draft-js-mention-plugin-3.1.0.tgz#7786426419d62d1c4467cc90ad47e88877697124"
   dependencies:
     decorate-component-with-props "^1.0.2"
     find-with-regex "^1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3730,6 +3730,17 @@ draft-js-markdown-plugin@^3.0.1:
     immutable "~3.7.4"
     react-click-outside "^3.0.1"
 
+draft-js-mention-plugin@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/draft-js-mention-plugin/-/draft-js-mention-plugin-3.0.4.tgz#e8530b7c16f23ce5b980515458418b5e24376f4a"
+  dependencies:
+    decorate-component-with-props "^1.0.2"
+    find-with-regex "^1.1.3"
+    immutable "~3.7.4"
+    lodash.escaperegexp "^4.1.2"
+    prop-types "^15.5.8"
+    union-class-names "^1.0.0"
+
 draft-js-modifiers@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/draft-js-modifiers/-/draft-js-modifiers-0.1.5.tgz#5134a6dbf3fa5b76b74dc269e1877b93f29336b0"
@@ -7017,6 +7028,10 @@ lodash.defaults@^4.0.1, lodash.defaults@^4.2.0:
 lodash.difference@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+
+lodash.escaperegexp@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
 
 lodash.filter@^4.4.0:
   version "4.6.0"


### PR DESCRIPTION
**Status**
- [x] WIP
- [ ] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
TODO: Not sure yet
- api
- hyperion (frontend)
- desktop
- athena
- vulcan
- mercury
- hermes
- chronos
- pluto
- mobile



**Release notes for users (delete if codebase-only change)**
- TODO

**Related issues (delete if you don't know of any)**
Closes #2649 

- [ ] prepend current thread participants onto search results
- [ ] get typeahead working in new thread composer
- [ ] clean up old mention decorator code
- [ ] maintain backwards compat with old mentions text or otherwise create a db migration
- [ ] don't break mobile rendering of mentions
- [ ] make sure mentions still trigger appropriate serverside actions
- [ ] disable enter key from triggering a submit when suggestions menu is in focus
- [ ] tests!

# Current UI:

Chat Input:
<img width="958" alt="screen shot 2018-08-19 at 9 47 37 pm" src="https://user-images.githubusercontent.com/1619461/44316435-9530fd00-a3f9-11e8-804f-90212a31f046.png">

thread message:
<img width="1004" alt="screen shot 2018-08-19 at 9 49 59 pm" src="https://user-images.githubusercontent.com/1619461/44316484-ea6d0e80-a3f9-11e8-9923-fe26b3edff12.png">
