### PR TITLE
remove Flow version specify

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -39,6 +39,3 @@ untyped-type-import=error
 untyped-import=warn
 unclear-type=warn
 unsafe-getters-setters=error
-
-[version]
-0.66.0


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Related issues (delete if you don't know of any)**
Closes https://github.com/withspectrum/spectrum/pull/3795

I saw this PR https://github.com/withspectrum/spectrum/pull/3795 failing by `.flowconfig` value.
I remove that value section In order to accept above PR.

Flow is not involved actual code, so use least version is fine!
I have a fascination to Flow I'd like to maintain it.(I'm reading OCaml book and attempt hacking flow😎)

Thanks😀