### PR TITLE
fixed mention regex to respect dots in usernames

### DIFF
--- a/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
+++ b/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
@@ -69,7 +69,7 @@ describe('strategy', () => {
       expect(mentions[0]).toEqual('@grdp');
       expect(mentions[1]).toEqual('@rauchg');
     });
-    it('should not include trailing special characters', () => {
+    it('should not include trailing period', () => {
       const text =
         "Hey guys it's @abc.123. where is @xyz? Any news from that guy?  @abc.123... over and out. cc: @some.other.person- @ceo; @hr,.";
 
@@ -77,7 +77,7 @@ describe('strategy', () => {
       expect(mentions[0]).toEqual('@abc.123');
       expect(mentions[1]).toEqual('@xyz');
       expect(mentions[2]).toEqual('@abc.123');
-      expect(mentions[3]).toEqual('@some.other.person');
+      expect(mentions[3]).toEqual('@some.other.person-');
       expect(mentions[4]).toEqual('@ceo');
       expect(mentions[5]).toEqual('@hr');
     });

--- a/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
+++ b/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
@@ -63,5 +63,12 @@ describe('strategy', () => {
       expect(mentions[0]).toEqual('@grdp');
       expect(mentions[1]).toEqual('@rauchg');
     });
+    it('should not include a trailing period', () => {
+      const text = "Hey guys it's @abc-123. where is @xyz.";
+      const mentions = getMentions(text);
+      expect(mentions[0]).toEqual('@abc-123');
+
+      expect(mentions[1]).toEqual('@xyz');
+    });
   });
 });

--- a/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
+++ b/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
@@ -55,6 +55,12 @@ describe('strategy', () => {
     expect(mentions[1]).toEqual('@brian');
   });
 
+  it('should allow special characters', () => {
+    const text = "Hey I'm @john-doe, I also go by @john_doe or @john.doe";
+    const mentions = getMentions(text);
+    expect(mentions).toEqual(['@john-doe', '@john_doe', '@john.doe']);
+  });
+
   describe('edge cases', () => {
     it('should handle sentences with compound emojis (withspectrum/spectrum#2077)', () => {
       const text =

--- a/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
+++ b/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
@@ -63,12 +63,17 @@ describe('strategy', () => {
       expect(mentions[0]).toEqual('@grdp');
       expect(mentions[1]).toEqual('@rauchg');
     });
-    it('should not include a trailing period', () => {
+    it('should not include trailing special characters', () => {
       const text =
-        "Hey guys it's @abc-123. where is @xyz.. Any news from that guy?";
+        "Hey guys it's @abc.123. where is @xyz? Any news from that guy?  @abc.123... over and out. cc: @some.other.person- @ceo; @hr,.";
+
       const mentions = getMentions(text);
-      expect(mentions[0]).toEqual('@abc-123');
+      expect(mentions[0]).toEqual('@abc.123');
       expect(mentions[1]).toEqual('@xyz');
+      expect(mentions[2]).toEqual('@abc.123');
+      expect(mentions[3]).toEqual('@some.other.person');
+      expect(mentions[4]).toEqual('@ceo');
+      expect(mentions[5]).toEqual('@hr');
     });
   });
 });

--- a/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
+++ b/shared/clients/draft-js/mentions-decorator/test/mentions-decorator.test.js
@@ -64,10 +64,10 @@ describe('strategy', () => {
       expect(mentions[1]).toEqual('@rauchg');
     });
     it('should not include a trailing period', () => {
-      const text = "Hey guys it's @abc-123. where is @xyz.";
+      const text =
+        "Hey guys it's @abc-123. where is @xyz.. Any news from that guy?";
       const mentions = getMentions(text);
       expect(mentions[0]).toEqual('@abc-123');
-
       expect(mentions[1]).toEqual('@xyz');
     });
   });

--- a/shared/regexps.js
+++ b/shared/regexps.js
@@ -1,5 +1,5 @@
 // @flow
 
-module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+[a-z0-9]/gi;
+module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+[a-z0-9_-]/gi;
 module.exports.URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/gi;
 module.exports.RELATIVE_URL = /^\/([^\/].*|$)/g;

--- a/shared/regexps.js
+++ b/shared/regexps.js
@@ -1,5 +1,5 @@
 // @flow
 
-module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+[^.\s]\b/gi;
+module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+[^.\s]/gi;
 module.exports.URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/gi;
 module.exports.RELATIVE_URL = /^\/([^\/].*|$)/g;

--- a/shared/regexps.js
+++ b/shared/regexps.js
@@ -1,5 +1,5 @@
 // @flow
 
-module.exports.MENTIONS = /\/?\B@[a-z0-9_-]+/gi;
+module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+/gi;
 module.exports.URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/gi;
 module.exports.RELATIVE_URL = /^\/([^\/].*|$)/g;

--- a/shared/regexps.js
+++ b/shared/regexps.js
@@ -1,5 +1,5 @@
 // @flow
 
-module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+[^.\s]/gi;
+module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+[a-z0-9]/gi;
 module.exports.URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/gi;
 module.exports.RELATIVE_URL = /^\/([^\/].*|$)/g;

--- a/shared/regexps.js
+++ b/shared/regexps.js
@@ -1,5 +1,5 @@
 // @flow
 
-module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+/gi;
+module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+[^.\s]\b/gi;
 module.exports.URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/gi;
 module.exports.RELATIVE_URL = /^\/([^\/].*|$)/g;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- desktop

**Release notes for users (delete if codebase-only change)**
- Bug fix: mention regexp wasn't honoring `.` within usernames

**Related issues**
tangentially related to #3793 #2649 

before this fix:
<img width="184" alt="screen shot 2018-08-18 at 7 59 40 pm" src="https://user-images.githubusercontent.com/1619461/44304133-46b02f80-a321-11e8-8daa-b14cb0b7c3fb.png">


after this fix:
<img width="198" alt="screen shot 2018-08-18 at 7 58 52 pm" src="https://user-images.githubusercontent.com/1619461/44304131-2ed8ab80-a321-11e8-9fc2-ad78722d8639.png">


