### PR TITLE
Properly guard generating thread meta images

### DIFF
--- a/src/helpers/generate-image-from-text.js
+++ b/src/helpers/generate-image-from-text.js
@@ -38,10 +38,13 @@ type GetMetaImageInput = {
   footer: string,
 };
 
-const generateImageFromText = ({ title, footer }: GetMetaImageInput) => {
+const generateImageFromText = ({
+  title,
+  footer,
+}: GetMetaImageInput): ?string => {
   const base64title = btoa(title);
   const base64footer = btoa(footer);
-  if (!base64title || !base64footer) return;
+  if (!base64title || !base64footer) return null;
 
   const titleUrl = `${IMGIX_TEXT_ENDPOINT}?${stringify(
     { ...TITLE_PARAMS, txt64: base64title.replace(/=/g, '') },
@@ -55,7 +58,7 @@ const generateImageFromText = ({ title, footer }: GetMetaImageInput) => {
   const base64titleurl = btoa(titleUrl);
   const base64footerurl = btoa(footerUrl);
 
-  if (!base64titleurl || !base64footerurl) return;
+  if (!base64titleurl || !base64footerurl) return null;
 
   const BACKGROUND_PARAMS = {
     w: WIDTH,

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -433,6 +433,12 @@ class ThreadContainer extends React.Component<Props, State> {
       const headDescription = isWatercooler
         ? `Watercooler chat for the ${thread.community.name} community`
         : description;
+      const metaImage = generateImageFromText({
+        title: isWatercooler
+          ? `Chat with the ${thread.community.name} community`
+          : thread.content.title,
+        footer: `spectrum.chat/${thread.community.slug}`,
+      });
 
       return (
         <ErrorBoundary>
@@ -458,14 +464,11 @@ class ThreadContainer extends React.Component<Props, State> {
                 title={headTitle}
                 description={headDescription}
                 type="article"
-                image={generateImageFromText({
-                  title: isWatercooler
-                    ? `Chat with the ${thread.community.name} community`
-                    : thread.content.title,
-                  footer: `spectrum.chat/${thread.community.slug}`,
-                })}
+                image={metaImage}
               >
-                <meta name="twitter:card" content="summary_large_image" />
+                {metaImage && (
+                  <meta name="twitter:card" content="summary_large_image" />
+                )}
                 <meta
                   property="article:published_time"
                   content={new Date(thread.createdAt).toISOString()}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Related to #3808 (does not fix it though)

This prevents the Twitter preview from looking shit if the thread meta image fails to generate for whatever reason. This is what it looks like right now if it fails to generate:

![screen shot 2018-08-21 at 15 53 32](https://user-images.githubusercontent.com/7525670/44406039-fd4b2480-a55a-11e8-85c4-26037eac5759.png)

Not very nice lol. This patch makes it so we don't show the `summary_large_image` card if we don't have a large image, basically.