### PR TITLE
Fix perpetually being signed out AGAIN

### DIFF
--- a/api/routes/auth/create-signin-routes.js
+++ b/api/routes/auth/create-signin-routes.js
@@ -80,6 +80,11 @@ export const createSigninRoutes = (
         // to the old URL the next time around
         // $FlowIssue
         req.session.redirectUrl = undefined;
+        res.cookie('_now_no_cache', '1', {
+          expires: new Date(2147483647000),
+          sameSite: 'lax',
+          secure: false,
+        });
         return res.redirect(redirectUrl.href);
       },
     ],

--- a/api/routes/auth/create-signin-routes.js
+++ b/api/routes/auth/create-signin-routes.js
@@ -81,7 +81,7 @@ export const createSigninRoutes = (
         // $FlowIssue
         req.session.redirectUrl = undefined;
         res.cookie('_now_no_cache', '1', {
-          expires: new Date(2147483647000),
+          maxAge: 315569260000, // 10 years
           sameSite: 'lax',
           secure: false,
         });


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

The issue with being perpetually signed out turns out to be that the Zeit CDN caches the homepage, and for some reason serves the logged-out homepage even to signed out users! :scream:

[The announcement blogpost](https://zeit.co/blog/now-cdn) said the following:

> Our CDN layer will hit origin every time if it finds it in the Cookie header.

I read that as "any time we find any Cookie header we don't server cached content", but you have to set a specific `__now_no_cache` cookie. :confused: This fixes it by setting said cookie when signing in.