### PR TITLE
Small UI copy changes

### DIFF
--- a/src/views/dashboard/components/communityList.js
+++ b/src/views/dashboard/components/communityList.js
@@ -120,7 +120,7 @@ class CommunityList extends React.Component<Props> {
                   <Reputation
                     ignoreClick
                     size={'mini'}
-                    tipText={`Rep in ${c.name}`}
+                    tipText={`Your rep in ${c.name}`}
                     reputation={c.communityPermissions.reputation}
                   />
                 </CommunityListMeta>
@@ -169,4 +169,7 @@ class CommunityList extends React.Component<Props> {
   }
 }
 
-export default compose(connect(), withRouter)(CommunityList);
+export default compose(
+  connect(),
+  withRouter
+)(CommunityList);

--- a/src/views/dashboard/components/sidebarChannels.js
+++ b/src/views/dashboard/components/sidebarChannels.js
@@ -101,7 +101,7 @@ class SidebarChannels extends React.Component<Props> {
           <Link to={`/${community.slug}`}>
             <ChannelListItem>
               <Icon glyph={'link'} size={24} />
-              <CommunityListName>Visit community</CommunityListName>
+              <CommunityListName>Visit landing page</CommunityListName>
             </ChannelListItem>
           </Link>
 
@@ -214,6 +214,8 @@ class SidebarChannels extends React.Component<Props> {
   }
 }
 
-export default compose(connect(), getCommunityChannels, viewNetworkHandler)(
-  SidebarChannels
-);
+export default compose(
+  connect(),
+  getCommunityChannels,
+  viewNetworkHandler
+)(SidebarChannels);

--- a/src/views/dashboard/components/sidebarChannels.js
+++ b/src/views/dashboard/components/sidebarChannels.js
@@ -101,7 +101,7 @@ class SidebarChannels extends React.Component<Props> {
           <Link to={`/${community.slug}`}>
             <ChannelListItem>
               <Icon glyph={'link'} size={24} />
-              <CommunityListName>Visit landing page</CommunityListName>
+              <CommunityListName>View community home</CommunityListName>
             </ChannelListItem>
           </Link>
 

--- a/src/views/dashboard/style.js
+++ b/src/views/dashboard/style.js
@@ -127,8 +127,7 @@ export const ChannelListItem = styled.div`
   }
 
   &:hover {
-    color: ${props =>
-      props.active ? props.theme.brand.alt : props.theme.text.default};
+    color: ${props => props.theme.brand.alt};
   }
 
 `;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Based on feedback from users this contains two fixes:

- **Fix hover styles in inbox community sidebar**: Previously it was impossible to discern whether you had selected a channel or were hovering it because they had the same color. This fixes it by setting a unique hover color by default. In the future, this could even be the community's own selected "brand color".
- **Adjust copy in inbox community sidebar**: "Visit community" was pretty unclear for users, since they were "already viewing the community?!" This makes it obvious that you visit the landing page of the community.