### PR TITLE
Always show reputation on user profile

### DIFF
--- a/src/components/profile/user.js
+++ b/src/components/profile/user.js
@@ -98,53 +98,49 @@ const UserWithData = ({
             @{user.username}
             {user.isPro && <Badge type="pro" />}
           </Subtitle>
-          {(user.description || user.website) && (
-            <FullDescription>
-              {user.description && (
-                <p>{renderTextWithLinks(user.description)}</p>
-              )}
-              <Reputation
-                reputation={
-                  user.contextPermissions
-                    ? user.contextPermissions.reputation
-                    : user.totalReputation
+          <FullDescription>
+            {user.description && <p>{renderTextWithLinks(user.description)}</p>}
+            <Reputation
+              reputation={
+                user.contextPermissions
+                  ? user.contextPermissions.reputation
+                  : user.totalReputation
+              }
+            />
+            {user.website && (
+              <ExtLink>
+                <Icon glyph="link" size={24} />
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={addProtocolToString(user.website)}
+                >
+                  {user.website}
+                </a>
+              </ExtLink>
+            )}
+            <GithubProfile
+              id={user.id}
+              render={profile => {
+                if (!profile) {
+                  return null;
+                } else {
+                  return (
+                    <ExtLink>
+                      <Icon glyph="github" size={24} />
+                      <a
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href={`https://github.com/${profile.username}`}
+                      >
+                        github.com/{profile.username}
+                      </a>
+                    </ExtLink>
+                  );
                 }
-              />
-              {user.website && (
-                <ExtLink>
-                  <Icon glyph="link" size={24} />
-                  <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={addProtocolToString(user.website)}
-                  >
-                    {user.website}
-                  </a>
-                </ExtLink>
-              )}
-              <GithubProfile
-                id={user.id}
-                render={profile => {
-                  if (!profile) {
-                    return null;
-                  } else {
-                    return (
-                      <ExtLink>
-                        <Icon glyph="github" size={24} />
-                        <a
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          href={`https://github.com/${profile.username}`}
-                        >
-                          github.com/{profile.username}
-                        </a>
-                      </ExtLink>
-                    );
-                  }
-                }}
-              />
-            </FullDescription>
-          )}
+              }}
+            />
+          </FullDescription>
         </FullProfile>
       );
     case 'simple':
@@ -265,7 +261,10 @@ const UserWithData = ({
   }
 };
 
-const User = compose(displayLoadingCard, withRouter)(UserWithData);
+const User = compose(
+  displayLoadingCard,
+  withRouter
+)(UserWithData);
 const mapStateToProps = state => ({
   currentUser: state.users.currentUser,
   initNewThreadWithUser: state.directMessageThreads.initNewThreadWithUser,


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Previously when a user didn't have a description, we wouldn't show their reputation or website links either—which is kinda strange!

This makes it so we always show those if they have 'em, no matter if they have a description or not.

Ref thread: http://spectrum.chat/thread/67e9d387-2a69-46cb-9745-4aa0b73cad91