### PR TITLE
Clean up thread top area

### DIFF
--- a/shared/time-formatting.js
+++ b/shared/time-formatting.js
@@ -30,7 +30,7 @@ export const convertTimestampToDate = (timestamp: number) => {
   let minutes = date.getMinutes();
   minutes = minutes >= 10 ? minutes : '0' + minutes.toString(); // turns 4 minutes into 04 minutes
   let ampm = hours >= 12 ? 'pm' : 'am'; // todo: support 24hr time
-  return `${month} ${day}, ${year} · ${cleanHours}:${minutes}${ampm}`;
+  return `${month} ${day}, ${year} at ${cleanHours}:${minutes}${ampm}`;
 };
 
 export const convertTimestampToTime = (timestamp: Date) => {

--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -496,14 +496,12 @@ class ThreadDetailPure extends React.Component<Props, State> {
                 {thread.channel.name}
               </Link>
             </ChannelHoverProfile>
-          </ThreadSubtitle>
-
-          <ThreadSubtitle>
+            <span>&nbsp;·&nbsp;</span>
             <Link to={`/thread/${thread.id}`}>
               {timestamp}
               {thread.modifiedAt && (
                 <React.Fragment>
-                  {' · '}(Edited{' '}
+                  (Edited{' '}
                   {timeDifference(Date.now(), editedTimestamp).toLowerCase()})
                 </React.Fragment>
               )}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

No need for the community/channel and the timestamp to be on two separate lines, that wastes a lot of space. 

Before:

![screen shot 2018-08-24 at 11 08 08](https://user-images.githubusercontent.com/7525670/44576518-0fada400-a78f-11e8-8c93-0d2eb569b7fd.png)

After:

![screen shot 2018-08-24 at 11 13 27](https://user-images.githubusercontent.com/7525670/44576525-120ffe00-a78f-11e8-8e3d-3a5086380462.png)
