### PR TITLE
Fix new messages indicator

### DIFF
--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';
 import { withApollo } from 'react-apollo';
+import idx from 'idx';
 import generateMetaInfo from 'shared/generate-meta-info';
 import { addCommunityToOnboarding } from '../../actions/newUserOnboarding';
 import Titlebar from 'src/views/titlebar';
@@ -94,26 +95,12 @@ class ThreadContainer extends React.Component<Props, State> {
   // see how to do this here: https://github.com/reactjs/rfcs/blob/master/text/0006-static-lifecycle-methods.md#state-derived-from-propsstate
   // with implementation below
   static getDerivedStateFromProps(nextProps, prevState) {
-    const curr = prevState.derivedState;
-    const newThread = curr.data && !curr.data.thread && nextProps.data.thread;
+    const lastSeen = idx(nextProps, _ => _.data.thread.currentUserLastSeen);
+    if (lastSeen === prevState.lastSeen) return null;
 
-    const threadChanged =
-      curr.data &&
-      curr.data.thread &&
-      nextProps.data.thread &&
-      curr.data.thread.id !== nextProps.data.thread.id;
-
-    // Update the cached lastSeen value when switching threads
-    if (newThread || threadChanged) {
-      return {
-        lastSeen: nextProps.data.thread.currentUserLastSeen
-          ? nextProps.data.thread.currentUserLastSeen
-          : null,
-        derivedState: nextProps,
-      };
-    }
-
-    return null;
+    return {
+      lastSeen,
+    };
   }
 
   toggleEdit = () => {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This thing hasn't shown its face in quite some time due to a broken implementation of `getDerivedStateFromProps`!

This patch fixes it, which means the "New messages" indicator shows again.