### PR TITLE
Remove unnecessary zindex

### DIFF
--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -163,7 +163,6 @@ export const SendButton = styled(IconButton)`
   background-color: transparent;
   transition: ${Transition.hover.off};
   align-self: flex-end;
-  z-index: ${zIndex.chatInput};
 `;
 
 export const MediaInput = styled.input`
@@ -172,7 +171,6 @@ export const MediaInput = styled.input`
   opacity: 0;
   overflow: hidden;
   position: absolute;
-  z-index: ${zIndex.hidden};
 `;
 
 export const MediaLabel = styled.label`

--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -2,13 +2,7 @@
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import { SvgWrapper } from '../icons';
-import {
-  zIndex,
-  Truncate,
-  monoStack,
-  hexa,
-  Tooltip,
-} from 'src/components/globals';
+import { Truncate, monoStack, hexa, Tooltip } from 'src/components/globals';
 
 export const Byline = styled.span`
   display: flex;
@@ -70,7 +64,6 @@ export const ActionsContainer = styled.span`
   width: 50%;
   pointer-events: none;
   opacity: 0;
-  z-index: ${zIndex.chatInput};
 `;
 
 export const Actions = styled.ul`
@@ -207,7 +200,6 @@ export const AuthorAvatarContainer = styled.div`
 const Bubble = styled.div`
   display: inline-block;
   border-radius: 16px;
-  z-index: ${zIndex.card};
   vertical-align: middle;
   white-space: pre-line;
   word-wrap: break-word;

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -88,7 +88,6 @@ export const Content = styled(FlexRow)`
 export const Input = styled(FlexRow)`
   flex: none;
   justify-content: center;
-  z-index: ${zIndex.chatInput};
   grid-area: footer;
   max-width: 100%;
   align-self: stretch;
@@ -454,7 +453,6 @@ export const CommunityHeader = styled.div`
   justify-content: space-between;
   padding: 16px 32px;
   box-shadow: ${Shadow.low} ${props => hexa(props.theme.bg.reverse, 0.15)};
-  z-index: ${zIndex.chrome};
   flex: 0 0 64px;
   align-self: stretch;
   background: ${props => props.theme.bg.default};
@@ -809,7 +807,7 @@ export const AnimatedContainer = styled.div`
   top: 0;
   left: 0;
   right: 0;
-  z-index: ${zIndex.flyout};
+  z-index: ${zIndex.card};
 
   @media (max-width: 768px) {
     display: none;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Closes #3839 - @mxstbr could you give this a quick local test as well? I think we were overdoing it with zindex usage and we should rely on the browser to handle this. By removing several of our definitions it improved a lot of bugs.

I've tested all the cases I can think of right now and zindexes on threads + navbar dropdowns seem to be working great 