### PR TITLE
Fix link location on reaction notifications

### DIFF
--- a/src/views/notifications/utils.js
+++ b/src/views/notifications/utils.js
@@ -193,14 +193,13 @@ const messageToString = context => {
         return (
           <span>
             {' '}
-            your reply in
+            your reply in{' '}
             <Link
               to={{
                 pathname: window.location.pathname,
-                search: `?thread=${context.payload.id}`,
+                search: `?thread=${context.payload.threadId}`,
               }}
             >
-              {' '}
               {data.thread.content.title}
             </Link>
           </span>


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Fixes a problem where reaction notification cards linked to the right thread, but the bolded thread title did not.