### PR TITLE
Make user rported email subject lines a bit more clear

### DIFF
--- a/hermes/queues/send-admin-user-reported-email.js
+++ b/hermes/queues/send-admin-user-reported-email.js
@@ -18,9 +18,7 @@ export default async (job: Job<AdminProcessUserReportedJobData>) => {
     getUser(reportedBy),
   ]);
 
-  const subject = `☠️ User ${reportedUser.username} reported by ${
-    reportingUser.username
-  }`;
+  const subject = `☠️ ${reportedUser.username} was reported`;
   const preheader = `Reason: ${reason}`;
 
   try {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hermes

Just a small nit that was making it confusing whenever we recieved a user report email