### PR TITLE
Remove team badge on community profile

### DIFF
--- a/src/components/granularUserProfile/style.js
+++ b/src/components/granularUserProfile/style.js
@@ -57,7 +57,7 @@ export const Name = styled.span`
   line-height: 1.2;
   vertical-align: middle;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
 
   &:hover {
     color: ${props => props.theme.brand.alt};

--- a/src/components/upsell/index.js
+++ b/src/components/upsell/index.js
@@ -337,7 +337,10 @@ export const UpsellTeamMembers = (props: TeamMemberProps) => {
       alignItems="flex-end"
     >
       <Link to={`/${props.communitySlug}/settings/members`}>
-        <OutlineButton icon={props.small ? null : 'member-add'}>
+        <OutlineButton
+          icon={props.small ? null : 'member-add'}
+          style={{ alignSelf: 'flex-end', marginTop: '16px' }}
+        >
           Add {props.small ? 'more' : ''} team members
         </OutlineButton>
       </Link>

--- a/src/views/community/components/moderatorList.js
+++ b/src/views/community/components/moderatorList.js
@@ -72,7 +72,7 @@ class CommunityModeratorList extends React.Component<Props> {
       return (
         <ListColumn>
           {nodes.map(node => {
-            const { user, roles } = node;
+            const { user } = node;
 
             return (
               <GranularUserProfile
@@ -83,7 +83,6 @@ class CommunityModeratorList extends React.Component<Props> {
                 isCurrentUser={currentUser && user.id === currentUser.id}
                 isOnline={user.isOnline}
                 onlineSize={'small'}
-                badges={roles}
               >
                 {currentUser &&
                   node.user.id !== currentUser.id && (


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

When I view the ZEIT community it feels like overkill that we render the team badge 20 times in the 'team members' section list. It's too repetitive and isn't adding anything to that component. The badge is super helpful in a chat context or in a list where owners are mixed with regular members. Wdyt @mxstbr ? Other commits are small nits