### PR TITLE
Replace all props.theme function interpolations with static interpolations

### DIFF
--- a/src/components/avatar/style.js
+++ b/src/components/avatar/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import ReactImage from 'react-image';
 import { zIndex } from '../globals';
@@ -13,7 +14,7 @@ export const Status = styled.div`
   border-radius: ${props =>
     props.type === 'community' ? `${props.size / 8}px` : '100%'};
   border: none;
-  background-color: ${({ theme }) => theme.bg.default};
+  background-color: ${theme.bg.default};
 
   ${props =>
     props.mobilesize &&
@@ -30,10 +31,10 @@ export const Status = styled.div`
     display: ${props => (props.isOnline ? 'inline-block' : 'none')};
     width: ${props => (props.onlineSize === 'large' ? '8px' : '6px')};
     height: ${props => (props.onlineSize === 'large' ? '8px' : '6px')};
-    background: ${props => props.theme.success.alt};
+    background: ${theme.success.alt};
     border-radius: ${props =>
       props.type === 'community' ? `${props.size / 8}px` : '100%'};
-    border: 2px solid ${props => props.theme.text.reverse};
+    border: 2px solid ${theme.text.reverse};
     bottom: ${props =>
       props.onlineSize === 'large'
         ? '0'
@@ -77,7 +78,7 @@ export const Img = styled(ReactImage)`
   border-radius: ${props =>
     props.type === 'community' ? `${props.size / 8}px` : '100%'};
   object-fit: cover;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
 
   ${props =>
     props.mobilesize &&
@@ -96,7 +97,7 @@ export const FallbackImg = styled.img`
   border-radius: ${props =>
     props.type === 'community' ? `${props.size / 8}px` : '100%'};
   object-fit: cover;
-  background-color: ${props => props.theme.bg.wash};
+  background-color: ${theme.bg.wash};
 
   ${props =>
     props.mobilesize &&
@@ -114,7 +115,7 @@ export const LoadingImg = styled.div`
   height: ${props => (props.size ? `${props.size}px` : '32px')};
   border-radius: ${props =>
     props.type === 'community' ? `${props.size / 8}px` : '100%'};
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
 
   ${props =>
     props.mobilesize &&

--- a/src/components/badges/style.js
+++ b/src/components/badges/style.js
@@ -1,11 +1,12 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { Tooltip, Gradient } from '../globals';
 
 export const Span = styled.span`
   display: flex;
-  color: ${({ theme }) => theme.text.reverse};
-  background-color: ${props => props.theme.text.alt};
+  color: ${theme.text.reverse};
+  background-color: ${theme.text.alt};
   text-transform: uppercase;
   padding: 3px 4px;
   margin-left: 4px;
@@ -21,7 +22,7 @@ export const Span = styled.span`
 `;
 
 export const ProBadge = styled(Span)`
-  background-color: ${props => props.theme.special.default};
+  background-color: ${theme.special.default};
   background-image: ${props =>
     Gradient(props.theme.special.alt, props.theme.special.default)};
   cursor: pointer;
@@ -32,13 +33,13 @@ export const ProBadge = styled(Span)`
 `;
 
 export const TeamBadge = styled(Span)`
-  background-color: ${props => props.theme.success.default};
+  background-color: ${theme.success.default};
   background-image: ${props =>
     Gradient(props.theme.success.alt, props.theme.success.default)};
 `;
 
 export const BlockedBadge = styled(Span)`
-  background-color: ${props => props.theme.warn.alt};
+  background-color: ${theme.warn.alt};
   background-image: ${props =>
     Gradient(props.theme.warn.alt, props.theme.warn.default)};
   cursor: pointer;
@@ -49,7 +50,7 @@ export const BlockedBadge = styled(Span)`
 `;
 
 export const PendingBadge = styled(Span)`
-  background-color: ${props => props.theme.special.alt};
+  background-color: ${theme.special.alt};
   background-image: ${props =>
     Gradient(props.theme.special.alt, props.theme.special.default)};
   cursor: pointer;
@@ -60,7 +61,7 @@ export const PendingBadge = styled(Span)`
 `;
 
 export const DefaultPaymentMethodBadge = styled(Span)`
-  background-color: ${props => props.theme.space.default};
+  background-color: ${theme.space.default};
   background-image: ${props =>
     Gradient(props.theme.space.default, props.theme.space.default)};
   cursor: pointer;

--- a/src/components/badges/style.js
+++ b/src/components/badges/style.js
@@ -23,8 +23,7 @@ export const Span = styled.span`
 
 export const ProBadge = styled(Span)`
   background-color: ${theme.special.default};
-  background-image: ${props =>
-    Gradient(props.theme.special.alt, props.theme.special.default)};
+  background-image: ${Gradient(theme.special.alt, theme.special.default)};
   cursor: pointer;
 
   &:hover {
@@ -34,14 +33,12 @@ export const ProBadge = styled(Span)`
 
 export const TeamBadge = styled(Span)`
   background-color: ${theme.success.default};
-  background-image: ${props =>
-    Gradient(props.theme.success.alt, props.theme.success.default)};
+  background-image: ${Gradient(theme.success.alt, theme.success.default)};
 `;
 
 export const BlockedBadge = styled(Span)`
   background-color: ${theme.warn.alt};
-  background-image: ${props =>
-    Gradient(props.theme.warn.alt, props.theme.warn.default)};
+  background-image: ${Gradient(theme.warn.alt, theme.warn.default)};
   cursor: pointer;
 
   &:hover {
@@ -51,8 +48,7 @@ export const BlockedBadge = styled(Span)`
 
 export const PendingBadge = styled(Span)`
   background-color: ${theme.special.alt};
-  background-image: ${props =>
-    Gradient(props.theme.special.alt, props.theme.special.default)};
+  background-image: ${Gradient(theme.special.alt, theme.special.default)};
   cursor: pointer;
 
   &:hover {
@@ -62,8 +58,7 @@ export const PendingBadge = styled(Span)`
 
 export const DefaultPaymentMethodBadge = styled(Span)`
   background-color: ${theme.space.default};
-  background-image: ${props =>
-    Gradient(props.theme.space.default, props.theme.space.default)};
+  background-image: ${Gradient(theme.space.default, theme.space.default)};
   cursor: pointer;
   margin-left: 8px;
 

--- a/src/components/buttons/style.js
+++ b/src/components/buttons/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 /* eslint no-eval: 0 */
 // $FlowFixMe
 import styled, { css } from 'styled-components';
@@ -22,8 +23,12 @@ const baseButton = css`
   text-align: center;
   padding: ${props =>
     props.icon
-      ? props.large ? '8px 12px' : '4px 8px'
-      : props.large ? '16px 32px' : '12px 16px'};
+      ? props.large
+        ? '8px 12px'
+        : '4px 8px'
+      : props.large
+        ? '16px 32px'
+        : '12px 16px'};
 
   &:hover {
     transition: ${Transition.hover.on};
@@ -65,7 +70,7 @@ export const StyledSolidButton = styled.button`
             eval(`props.theme.${props.gradientTheme}.default`)
           )
         : Gradient(props.theme.brand.alt, props.theme.brand.default)};
-  color: ${props => props.theme.text.reverse};
+  color: ${theme.text.reverse};
 
   &:hover {
     background-color: ${props =>

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
@@ -7,7 +8,7 @@ import styled from 'styled-components';
 import { FlexCol } from '../globals';
 
 const StyledCard = styled(FlexCol)`
-  background: ${({ theme }) => theme.bg.default};
+  background: ${theme.bg.default};
   position: relative;
   width: 100%;
   max-width: 100%;

--- a/src/components/chatInput/components/style.js
+++ b/src/components/chatInput/components/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { zIndex } from 'src/components/globals';
 
@@ -17,14 +18,14 @@ export const MediaLabel = styled.label`
   display: inline-block;
   background: transparent;
   transition: color 0.3s ease-out;
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
   height: 32px;
   width: 32px;
   margin: 4px;
 
   &:hover {
     cursor: pointer;
-    color: ${({ theme }) => theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 

--- a/src/components/chatInput/style.js
+++ b/src/components/chatInput/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import { IconButton } from '../buttons';
 import { QuoteWrapper } from '../message/style';
@@ -32,10 +33,9 @@ export const ChatInputWrapper = styled.div`
   width: 100%;
   margin: 0;
   padding: 8px 12px 0 12px;
-  background-color: ${props => props.theme.bg.default};
-  border-top: 1px solid ${({ theme }) => theme.bg.border};
-  box-shadow: -1px 0 0 ${props => props.theme.bg.border},
-    1px 0 0 ${props => props.theme.bg.border};
+  background-color: ${theme.bg.default};
+  border-top: 1px solid ${theme.bg.border};
+  box-shadow: -1px 0 0 ${theme.bg.border}, 1px 0 0 ${theme.bg.border};
 
   @media (max-width: 768px) {
     bottom: ${props => (props.focus ? '0' : 'auto')};
@@ -128,8 +128,8 @@ export const InputWrapper = styled(EditorWrapper)`
     ${monoStack};
     font-size: 15px;
     font-weight: 500;
-    background-color: ${props => props.theme.bg.wash};
-    border: 1px solid ${props => props.theme.bg.border};
+    background-color: ${theme.bg.wash};
+    border: 1px solid ${theme.bg.border};
     border-radius: 2px;
     padding: 4px;
     margin-right: 16px;
@@ -137,8 +137,8 @@ export const InputWrapper = styled(EditorWrapper)`
 
   blockquote {
     line-height: 1.5;
-    border-left: 4px solid ${props => props.theme.bg.border};
-    color: ${props => props.theme.text.alt};
+    border-left: 4px solid ${theme.bg.border};
+    color: ${theme.text.alt};
     padding: 4px 12px 4px 16px;
   }
 
@@ -183,11 +183,11 @@ export const MediaLabel = styled.label`
   padding: 4px;
   position: relative;
   top: 2px;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
 
   &:hover {
     cursor: pointer;
-    color: ${({ theme }) => theme.brand.default};
+    color: ${theme.brand.default};
   }
 `;
 
@@ -209,21 +209,21 @@ export const PhotoSizeError = styled.div`
   align-content: center;
   padding: 8px 16px;
   width: 100%;
-  background: ${props => props.theme.special.wash};
-  border-top: 1px solid ${props => props.theme.special.border};
+  background: ${theme.special.wash};
+  border-top: 1px solid ${theme.special.border};
 
   &:hover {
     cursor: pointer;
 
     p {
-      color: ${props => props.theme.brand.default};
+      color: ${theme.brand.default};
     }
   }
 
   p {
     font-size: 14px;
     line-height: 1.4;
-    color: ${props => props.theme.special.default};
+    color: ${theme.special.default};
     max-width: calc(100% - 48px);
   }
 
@@ -237,8 +237,8 @@ export const RemovePreviewButton = styled.button`
   top: 0;
   right: 0;
   vertical-align: top;
-  background-color: ${props => props.theme.text.placeholder};
-  color: ${props => props.theme.text.reverse};
+  background-color: ${theme.text.placeholder};
+  color: ${theme.text.reverse};
   border: none;
   border-radius: 100%;
   outline: none;
@@ -249,7 +249,7 @@ export const RemovePreviewButton = styled.button`
   z-index: 1;
 
   &:hover {
-    background-color: ${props => props.theme.warn.alt};
+    background-color: ${theme.warn.alt};
   }
 `;
 
@@ -257,7 +257,7 @@ export const PreviewWrapper = styled.div`
   position: relative;
   padding: 0;
   padding-bottom: 8px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 
   ${QuoteWrapper} {
     margin: 0;
@@ -273,8 +273,8 @@ export const PreviewWrapper = styled.div`
 `;
 
 export const Preformatted = styled.code`
-  background-color: ${props => props.theme.bg.wash};
-  border: 1px solid ${props => props.theme.bg.border};
+  background-color: ${theme.bg.wash};
+  border: 1px solid ${theme.bg.border};
   white-space: nowrap;
 `;
 
@@ -284,7 +284,7 @@ export const MarkdownHint = styled.div`
   justify-content: flex-end;
   margin-right: 12px;
   font-size: 11px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1;
   padding: 6px 0;
   opacity: ${({ showHint }) => (showHint ? 1 : 0)};

--- a/src/components/composer/style.js
+++ b/src/components/composer/style.js
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 import { hexa, Shadow, FlexRow, FlexCol, zIndex } from '../globals';
 
 export const Container = styled(FlexCol)`
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
   display: grid;
   grid-template-rows: 60px 1fr 64px;
   grid-template-columns: 100%;
@@ -21,8 +22,8 @@ export const Container = styled(FlexCol)`
 `;
 
 export const Actions = styled(FlexCol)`
-  background: ${props => props.theme.bg.wash};
-  border-top: 2px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.wash};
+  border-top: 2px solid ${theme.bg.border};
   padding: 8px;
   border-radius: 0;
   align-self: stretch;
@@ -59,7 +60,7 @@ export const Dropdowns = styled(FlexRow)`
   display: flex;
   align-items: center;
   grid-area: header;
-  background-color: ${props => props.theme.bg.wash};
+  background-color: ${theme.bg.wash};
   box-shadow: ${Shadow.low} ${props => hexa(props.theme.bg.reverse, 0.15)};
   z-index: ${zIndex.composer};
   grid-area: header;
@@ -67,7 +68,7 @@ export const Dropdowns = styled(FlexRow)`
   span {
     font-size: 14px;
     font-weight: 500;
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
     margin-left: 16px;
     line-height: 1;
     vertical-align: middle;
@@ -108,14 +109,14 @@ const Selector = styled.select`
 
 export const RequiredSelector = styled(Selector)`
   padding: 8px 12px;
-  border: 2px solid ${props => props.theme.bg.border};
+  border: 2px solid ${theme.bg.border};
   border-radius: 8px;
-  color: ${props => props.theme.text.default};
-  background-color: ${props => props.theme.bg.default};
+  color: ${theme.text.default};
+  background-color: ${theme.bg.default};
 `;
 
 export const OptionalSelector = styled(Selector)`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-left: 16px;
   background-color: transparent;
 `;
@@ -125,7 +126,7 @@ export const ThreadInputs = styled(FlexCol)`
   overflow-y: scroll;
   padding: 64px;
   padding-left: 80px;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
 
   @media (max-width: 768px) {
     max-width: 100vw;
@@ -184,5 +185,5 @@ export const DisabledWarning = styled.div`
   font-size: 16px;
   font-weight: 500;
   background: ${props => hexa(props.theme.warn.default, 0.1)};
-  color: ${props => props.theme.warn.default};
+  color: ${theme.warn.default};
 `;

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 // $FlowFixMe
 import compose from 'recompose/compose';
@@ -15,7 +16,7 @@ const StyledDropdown = styled(FlexCol)`
   right: 0px;
   z-index: ${zIndex.dropdown};
   padding-top: 8px;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   transition: ${Transition.dropdown.off};
 `;
 

--- a/src/components/editForm/style.js
+++ b/src/components/editForm/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 import Card from '../card';
 import { FlexRow, FlexCol, Truncate } from '../globals';
 
@@ -16,7 +17,7 @@ export const Form = styled.form`
 
 export const FormTitle = styled.h1`
   font-size: 20px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   font-weight: 800;
   line-height: 1.2;
   flex: 1 0 auto;
@@ -25,7 +26,7 @@ export const FormTitle = styled.h1`
 
 export const Subtitle = styled.h4`
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1.3;
   width: 100%;
   ${Truncate};
@@ -33,12 +34,12 @@ export const Subtitle = styled.h4`
 
 export const Description = styled.p`
   font-size: 14px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   padding: 8px 0 16px;
   line-height: 1.4;
 
   a {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
   }
 `;
 
@@ -53,7 +54,7 @@ export const Actions = styled(FlexRow)`
   padding: 16px 16px 0;
   justify-content: flex-start;
   flex-direction: row-reverse;
-  border-top: 1px solid ${props => props.theme.bg.border};
+  border-top: 1px solid ${theme.bg.border};
 
   button + button {
     margin-left: 8px;
@@ -73,8 +74,8 @@ export const GeneralNotice = styled.span`
   padding: 8px 12px;
   font-size: 12px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
-  background: ${props => props.theme.bg.wash};
+  color: ${theme.text.alt};
+  background: ${theme.bg.wash};
   border-radius: 4px;
   margin-top: 24px;
   line-height: 1.4;
@@ -96,21 +97,21 @@ export const ImageInputWrapper = styled(FlexCol)`
 
 export const Location = styled(FlexRow)`
   font-weight: 500;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   font-size: 14px;
   margin-bottom: 8px;
 
   > div {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   > span {
     padding: 0 4px;
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   > a:hover {
-    color: ${({ theme }) => theme.brand.alt};
+    color: ${theme.brand.alt};
     text-decoration: underline;
   }
 

--- a/src/components/emailInvitationForm/style.js
+++ b/src/components/emailInvitationForm/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 
 export const EmailInviteForm = styled.div`
   display: flex;
@@ -31,7 +32,7 @@ export const EmailInviteInput = styled.input`
   }
 
   &:focus {
-    border: 2px solid ${props => props.theme.brand.default};
+    border: 2px solid ${theme.brand.default};
   }
 
   @media screen and (max-width: 768px) {
@@ -44,37 +45,37 @@ export const AddRow = styled.div`
   width: 100%;
   justify-content: center;
   padding: 8px;
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
   margin-top: 8px;
   margin-bottom: 16px;
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
   border-radius: 4px;
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
     cursor: pointer;
   }
 `;
 
 export const RemoveRow = styled.div`
   margin-left: 4px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 
   &:hover {
     cursor: pointer;
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
 export const CustomMessageToggle = styled.h4`
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-top: 16px;
 
   &:hover {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
     cursor: pointer;
   }
 

--- a/src/components/flyout/index.js
+++ b/src/components/flyout/index.js
@@ -1,11 +1,12 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 import styled from 'styled-components';
 import { FlexCol, FlexRow, zIndex } from '../globals';
 
 const StyledFlyout = styled(FlexRow)`
-  background-color: ${props => props.theme.bg.default};
-  border: 1px solid ${props => props.theme.bg.border};
+  background-color: ${theme.bg.default};
+  border: 1px solid ${theme.bg.border};
   border-radius: 4px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   position: absolute;
@@ -13,7 +14,7 @@ const StyledFlyout = styled(FlexRow)`
   right: -25%;
   top: 36px;
   z-index: ${zIndex.flyout};
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   ${props => props.style};
 `;
 

--- a/src/components/formElements/style.js
+++ b/src/components/formElements/style.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import theme from 'shared/theme';
 import { FlexRow, Transition, hexa, zIndex } from '../globals';
 import Textarea from 'react-textarea-autosize';
 
@@ -10,7 +11,7 @@ export const StyledLabel = styled.label`
   font-weight: 500;
   font-size: 14px;
   letter-spacing: -0.4px;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   transition: ${Transition.hover.off};
   position: relative;
 
@@ -38,7 +39,7 @@ export const StyledPrefixLabel = styled.label`
   margin-top: 4px;
   font-size: 14px;
   font-weight: 500;
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
   white-space: nowrap;
   text-overflow: ellipsis;
 
@@ -76,20 +77,20 @@ export const StyledInput = styled.input`
       width: initial;
       margin-right: 0.5em;
     `} &::placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &::-webkit-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-moz-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-ms-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   &:focus {
-    border-color: ${({ theme }) => theme.brand.default};
+    border-color: ${theme.brand.default};
     transition: ${Transition.hover.on};
   }
 
@@ -104,10 +105,10 @@ export const StyledInput = styled.input`
 export const StyledTextArea = styled(Textarea)`
   flex: 1 0 auto;
   width: 100%;
-  background: ${({ theme }) => theme.bg.default};
+  background: ${theme.bg.default};
   font-weight: 500;
   font-size: 14px;
-  border: 2px solid ${({ theme }) => theme.bg.inactive};
+  border: 2px solid ${theme.bg.inactive};
   border-radius: 4px;
   padding: 12px;
   margin-top: 2px;
@@ -115,20 +116,20 @@ export const StyledTextArea = styled(Textarea)`
   transition: ${Transition.hover.off};
 
   &::placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &::-webkit-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-moz-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-ms-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   &:focus {
-    border-color: ${({ theme }) => theme.brand.default};
+    border-color: ${theme.brand.default};
     transition: ${Transition.hover.on};
   }
 `;
@@ -151,7 +152,7 @@ export const StyledUnderlineInput = styled.input`
   }
 
   &:focus {
-    border-color: ${({ theme }) => theme.brand.default};
+    border-color: ${theme.brand.default};
     transition: ${Transition.hover.on};
   }
 `;
@@ -163,7 +164,7 @@ export const StyledHiddenInput = styled.input`
 `;
 
 export const StyledCheckboxWrapper = styled(FlexRow)`
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   align-items: ${props => props.align};
   line-height: 1.4;
@@ -181,7 +182,7 @@ export const StyledCheckboxWrapper = styled(FlexRow)`
 
   > a {
     text-decoration: none;
-    color: ${({ theme }) => theme.brand.alt};
+    color: ${theme.brand.alt};
     font-weight: 600;
     border-bottom: 2px solid transparent;
     position: relative;
@@ -189,7 +190,7 @@ export const StyledCheckboxWrapper = styled(FlexRow)`
     transition: ${Transition.hover.off};
 
     &:hover {
-      border-bottom: 2px solid ${({ theme }) => theme.brand.alt};
+      border-bottom: 2px solid ${theme.brand.alt};
       padding-bottom: 2px;
       transition: ${Transition.hover.on};
     }
@@ -198,7 +199,7 @@ export const StyledCheckboxWrapper = styled(FlexRow)`
 
 export const StyledError = styled.p`
   font-size: 14px;
-  color: ${props => props.theme.warn.default};
+  color: ${theme.warn.default};
   padding: 8px 0 16px;
   line-height: 1.4;
   font-weight: 600;
@@ -206,7 +207,7 @@ export const StyledError = styled.p`
 
 export const StyledSuccess = styled.p`
   font-size: 14px;
-  color: ${props => props.theme.success.default};
+  color: ${theme.success.default};
   padding: 8px 0 16px;
   line-height: 1.4;
   font-weight: 600;
@@ -220,7 +221,7 @@ export const PhotoInputLabel = styled.label`
   border-radius: ${props =>
     props.type === 'user' ? `${props.size}px` : '8px'};
   margin-top: 8px;
-  background-color: ${({ theme }) => theme.bg.reverse};
+  background-color: ${theme.bg.reverse};
 `;
 
 export const PhotoInputImage = styled.img`
@@ -228,7 +229,7 @@ export const PhotoInputImage = styled.img`
   height: ${props => `${props.size}px`};
   border-radius: ${props =>
     props.type === 'user' ? `${props.size}px` : '8px'};
-  box-shadow: 0 0 0 2px ${props => props.theme.bg.default};
+  box-shadow: 0 0 0 2px ${theme.bg.default};
 `;
 
 export const CoverInputLabel = styled.label`
@@ -238,7 +239,7 @@ export const CoverInputLabel = styled.label`
   width: 100%;
   margin-top: 8px;
   border-radius: 8px;
-  background-color: ${({ theme }) => theme.bg.reverse};
+  background-color: ${theme.bg.reverse};
 `;
 
 export const ProfileImage = styled.img`
@@ -253,11 +254,11 @@ export const ProfileImage = styled.img`
   height: 100%;
   border-radius: ${props =>
     props.type === 'user' ? `${props.size}px` : '8px'};
-  border: 2px solid ${({ theme }) => theme.text.reverse};
+  border: 2px solid ${theme.text.reverse};
 `;
 
 export const CoverImage = styled.div`
-  background-color: ${props => props.theme.brand.default};
+  background-color: ${theme.brand.default};
   background-image: url('${props => props.src}');
   background-position: center;
   background-size: cover;
@@ -284,7 +285,7 @@ export const InputOverlay = styled.div`
   left: 0;
   width: 100%;
   height: 100%;
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
   background-color: ${({ theme }) => hexa(theme.bg.reverse, 0.6)};
   padding: 8px;
   border-radius: ${props =>

--- a/src/components/fullscreenView/style.js
+++ b/src/components/fullscreenView/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import { zIndex } from '../globals';
 
@@ -34,7 +35,7 @@ export const Illustrations = styled.span`
 `;
 
 export const Close = styled.div`
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   position: absolute;
   top: 8px;
   right: 8px;

--- a/src/components/gallery/style.js
+++ b/src/components/gallery/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 import { Shadow, zIndex } from '../globals';
 
 export const GalleryWrapper = styled.div`
@@ -18,7 +19,7 @@ export const Overlay = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: ${({ theme }) => theme.bg.reverse};
+  background: ${theme.bg.reverse};
   opacity: 0.95;
   z-index: ${zIndex.fullscreen + 1};
 `;

--- a/src/components/globals/index.js
+++ b/src/components/globals/index.js
@@ -1,4 +1,5 @@
 /* eslint no-eval: 0 */
+import theme from 'shared/theme';
 import styled, { css, keyframes } from 'styled-components';
 
 export const Gradient = (g1, g2) =>
@@ -134,7 +135,7 @@ export const Label = styled.label`
   font-weight: 500;
   font-size: 0.875rem;
   letter-spacing: -0.4px;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
 
   &:not(:first-of-type) {
     margin-top: 1.5rem;
@@ -152,7 +153,7 @@ export const PrefixLabel = styled.label`
   padding-left: 0.875rem;
   font-size: 0.875rem;
   font-weight: 500;
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
 
   > input {
     margin-left: 2px;
@@ -161,11 +162,11 @@ export const PrefixLabel = styled.label`
 
 export const Input = styled.input`
   flex: 1 0 auto;
-  background: ${({ theme }) => theme.bg.default};
+  background: ${theme.bg.default};
   font-weight: 500;
   width: 100%;
   font-size: 0.875rem;
-  border: 0.125rem solid ${({ theme }) => theme.bg.inactive};
+  border: 0.125rem solid ${theme.bg.inactive};
   border-radius: 0.25rem;
   padding: 0.5rem 0.75rem;
   margin-top: 0.125rem;
@@ -178,67 +179,67 @@ export const Input = styled.input`
       width: initial;
       margin-right: 0.5rem;
     `} &::placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &::-webkit-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-moz-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-ms-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   &:focus {
-    border-color: ${({ theme }) => theme.brand.default};
+    border-color: ${theme.brand.default};
   }
 `;
 
 export const TextArea = styled.textarea`
   flex: 1 0 auto;
   width: 100%;
-  background: ${({ theme }) => theme.bg.default};
+  background: ${theme.bg.default};
   font-weight: 500;
   font-size: 0.875rem;
-  border: 0.125rem solid ${({ theme }) => theme.bg.inactive};
+  border: 0.125rem solid ${theme.bg.inactive};
   border-radius: 0.25rem;
   padding: 0.75rem;
   margin-top: 0.125rem;
   box-shadow: none;
 
   &::placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &::-webkit-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-moz-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-ms-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   &:focus {
-    border-color: ${({ theme }) => theme.brand.default};
+    border-color: ${theme.brand.default};
   }
 `;
 
 export const UnderlineInput = styled.input`
   font-size: inherit;
   font-weight: inherit;
-  color: ${({ theme }) => theme.text.default};
-  border-bottom: 0.125rem solid ${({ theme }) => theme.bg.inactive};
+  color: ${theme.text.default};
+  border-bottom: 0.125rem solid ${theme.bg.inactive};
 
   &:focus {
-    border-color: ${({ theme }) => theme.brand.default};
+    border-color: ${theme.brand.default};
   }
 `;
 
 export const H1 = styled.h1`
   ${fontStack};
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   font-weight: 900;
   font-size: 1.5rem;
   line-height: 1.25;
@@ -247,7 +248,7 @@ export const H1 = styled.h1`
 `;
 
 export const H2 = styled.h2`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   ${fontStack};
   font-weight: 700;
   font-size: 1.25rem;
@@ -257,7 +258,7 @@ export const H2 = styled.h2`
 `;
 
 export const H3 = styled.h3`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   ${fontStack};
   font-weight: 500;
   font-size: 1rem;
@@ -267,7 +268,7 @@ export const H3 = styled.h3`
 `;
 
 export const H4 = styled.h4`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   ${fontStack};
   font-weight: 500;
   font-size: 0.875rem;
@@ -277,7 +278,7 @@ export const H4 = styled.h4`
 `;
 
 export const H5 = styled.h5`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   ${fontStack};
   font-weight: 500;
   font-size: 0.75rem;
@@ -287,7 +288,7 @@ export const H5 = styled.h5`
 `;
 
 export const H6 = styled.h6`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   ${fontStack};
   font-weight: 600;
   text-transform: uppercase;
@@ -298,7 +299,7 @@ export const H6 = styled.h6`
 `;
 
 export const P = styled.p`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   ${fontStack};
   font-weight: 400;
   font-size: 0.875rem;
@@ -308,7 +309,7 @@ export const P = styled.p`
 `;
 
 export const Span = styled.span`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   ${fontStack};
   font-weight: 400;
   font-size: 0.875rem;
@@ -578,12 +579,12 @@ export const HorizontalRule = styled(FlexRow)`
   justify-content: center;
   align-items: center;
   align-self: stretch;
-  color: ${props => props.theme.bg.border};
+  color: ${theme.bg.border};
 
   hr {
     display: inline-block;
     flex: 1 0 auto;
-    border-top: 1px solid ${props => props.theme.bg.border};
+    border-top: 1px solid ${theme.bg.border};
   }
 
   div {

--- a/src/components/granularUserProfile/style.js
+++ b/src/components/granularUserProfile/style.js
@@ -1,9 +1,10 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { Tooltip, Truncate } from '../globals';
 
 export const Content = styled.div`
-  border-bottom: 1px solid ${props => props.theme.bg.wash};
+  border-bottom: 1px solid ${theme.bg.wash};
   padding: 12px 0;
   display: flex;
   align-items: center;
@@ -23,8 +24,8 @@ export const Row = styled.div`
   grid-column-gap: 16px;
   padding: 12px 16px;
   width: 100%;
-  background: ${props => props.theme.bg.default};
-  border-bottom: 1px solid ${props => props.theme.bg.wash};
+  background: ${theme.bg.default};
+  border-bottom: 1px solid ${theme.bg.wash};
 
   &:last-of-type {
     > ${Content} {
@@ -51,7 +52,7 @@ export const Row = styled.div`
 `;
 
 export const Name = styled.span`
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   font-size: 16px;
   font-weight: 600;
   line-height: 1.2;
@@ -60,32 +61,32 @@ export const Name = styled.span`
   align-items: flex-end;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
 export const Username = styled.span`
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 400;
   margin: 0px 4px;
   line-height: 1;
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
 export const Description = styled.p`
   grid-area: description;
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const MessageIcon = styled.div`
   grid-area: message;
   height: 32px;
-  color: ${props => props.theme.brand.alt};
+  color: ${theme.brand.alt};
   cursor: pointer;
   ${Tooltip};
 `;

--- a/src/components/hoverProfile/style.js
+++ b/src/components/hoverProfile/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { zIndex } from 'src/components/globals';
 import Link from 'src/components/link';
@@ -28,7 +29,7 @@ export const Span = styled.span`
 
 export const ProfileCard = styled.div`
   width: 256px;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   border-radius: 4px;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.16);
   min-height: 128px;
@@ -42,20 +43,20 @@ export const Content = styled.div`
 export const Title = styled.h2`
   font-size: 20px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const Description = styled.p`
   font-size: 14px;
   font-weight: 400;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
   margin-top: 4px;
   line-height: 1.4;
   white-space: pre-wrap;
 
   a {
     font-weight: 500;
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   a:hover {
@@ -104,7 +105,7 @@ export const ProfilePhotoContainer = styled.div`
   margin-bottom: -16px;
 
   img {
-    box-shadow: 0 0 0 2px ${props => props.theme.bg.default};
+    box-shadow: 0 0 0 2px ${theme.bg.default};
   }
 `;
 
@@ -116,7 +117,7 @@ CHANNEL SPECIFIC
 export const ChannelCommunityLabel = styled.h5`
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const ChannelCommunityRow = styled(Link)`
@@ -131,7 +132,7 @@ export const ChannelCommunityRow = styled(Link)`
 
   &:hover {
     ${ChannelCommunityLabel} {
-      color: ${props => props.theme.text.secondary};
+      color: ${theme.text.secondary};
     }
   }
 `;

--- a/src/components/icons/index.js
+++ b/src/components/icons/index.js
@@ -1,4 +1,5 @@
 //@flow
+import theme from 'shared/theme';
 import React from 'react';
 import styled, { css } from 'styled-components';
 import { Tooltip } from '../globals';
@@ -53,7 +54,7 @@ export const SvgWrapper = styled.div`
         top: -2px;
         font-size: 14px;
         font-weight: 600;
-        background: ${({ theme }) => theme.bg.default};
+        background: ${theme.bg.default};
         color: ${({ theme }) =>
           process.env.NODE_ENV === 'production'
             ? theme.text.default

--- a/src/components/illustrations/index.js
+++ b/src/components/illustrations/index.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 import styled from 'styled-components';
 import { zIndex } from '../globals';
@@ -61,7 +62,7 @@ export const ConversationWrapper = styled.div`
 
   max-width: 480px;
   overflow-y: hidden;
-  box-shadow: 0 0 32px 24px ${props => props.theme.bg.default};
+  box-shadow: 0 0 32px 24px ${theme.bg.default};
   display: inline-block;
   align-items: center;
   justify-content: center;

--- a/src/components/linkPreview/style.js
+++ b/src/components/linkPreview/style.js
@@ -1,4 +1,5 @@
 import styled, { keyframes } from 'styled-components';
+import theme from 'shared/theme';
 import { Transition, Shadow, hexa, zIndex, Truncate } from '../globals';
 
 export const LinkPreviewContainer = styled.a`
@@ -6,8 +7,8 @@ export const LinkPreviewContainer = styled.a`
   flex-direction: ${props => (props.size === 'large' ? 'row' : 'row')};
   align-items: ${props => (props.size === 'large' ? 'flex-start' : 'center')};
   border-radius: 4px;
-  background: ${props => props.theme.bg.default};
-  border: 1px solid ${({ theme }) => theme.bg.border};
+  background: ${theme.bg.default};
+  border: 1px solid ${theme.bg.border};
   ${'' /* box-shadow: ${Shadow.low} ${props => hexa(props.theme.bg.reverse, 0.1)}; */} overflow: hidden;
   position: relative;
   margin: ${props => (props.margin ? props.margin : '0')};
@@ -19,7 +20,7 @@ export const LinkPreviewContainer = styled.a`
   &:hover {
     transition: ${Transition.reaction.on};
     box-shadow: ${Shadow.high} ${props => hexa(props.theme.bg.reverse, 0.1)};
-    border: 1px solid ${({ theme }) => theme.bg.border};
+    border: 1px solid ${theme.bg.border};
     text-decoration: none !important;
   }
 `;
@@ -65,7 +66,7 @@ export const MetaTitle = styled(BaseMeta)`
   font-size: 16px;
   font-weight: 800;
   white-space: normal;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   ${Truncate};
 `;
 
@@ -73,11 +74,11 @@ export const MetaDescription = styled(BaseMeta)`
   font-size: 14px;
   font-weight: 500;
   line-height: 1.4;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const MetaUrl = styled(BaseMeta)`
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
   font-weight: 500;
   margin-top: 8px;
   font-size: 12px;
@@ -89,7 +90,7 @@ export const LinkPreviewSkeleton = styled.div`
   align-items: center;
   border-radius: 4px;
   background: #fff;
-  border: 1px solid ${({ theme }) => theme.bg.border};
+  border: 1px solid ${theme.bg.border};
   box-shadow: ${Shadow.low} ${props => hexa(props.theme.bg.reverse, 0.1)};
   overflow: hidden;
   position: relative;
@@ -118,9 +119,9 @@ export const AnimatedBackground = styled.div`
   animation-timing-function: ease-in-out;
   background: linear-gradient(
     to right,
-    ${({ theme }) => theme.bg.wash} 10%,
+    ${theme.bg.wash} 10%,
     ${({ theme }) => hexa(theme.generic.default, 0.65)} 20%,
-    ${({ theme }) => theme.bg.wash} 30%
+    ${theme.bg.wash} 30%
   );
   animation-name: ${placeHolderShimmer};
   z-index: ${zIndex.loading + 1};
@@ -128,7 +129,7 @@ export const AnimatedBackground = styled.div`
 
 const Cover = styled.div`
   position: absolute;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   z-index: ${zIndex.loading + 2};
 `;
 

--- a/src/components/listItems/channel/style.js
+++ b/src/components/listItems/channel/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { Truncate } from 'src/components/globals';
 import Link from 'src/components/link';
@@ -8,21 +9,21 @@ export const ChannelContainer = styled.div`
   align-items: center;
   flex: 1;
   justify-content: space-between;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
   min-width: 0;
 
-  border-top: 1px solid ${props => props.theme.bg.wash};
+  border-top: 1px solid ${theme.bg.wash};
 
   &:first-of-type {
     border-top: 0;
   }
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   .icon {
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
   }
 `;
 
@@ -37,7 +38,7 @@ export const ChannelNameLink = styled(Link)`
 export const ChannelName = styled.span`
   font-size: 16px;
   font-weight: 600;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 
   ${Truncate};
 `;

--- a/src/components/listItems/style.js
+++ b/src/components/listItems/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 import Link from 'src/components/link';
 import {
   Truncate,
@@ -66,7 +67,7 @@ export const Heading = styled(H3)`
   ${Truncate};
 
   > div {
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
     margin-right: 4px;
   }
 `;
@@ -74,7 +75,7 @@ export const Heading = styled(H3)`
 export const Meta = styled(H4)`
   font-size: 14px;
   font-weight: 400;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
 
   a {
     display: inline-block;
@@ -86,7 +87,7 @@ export const Meta = styled(H4)`
 export const ActionContainer = styled(FlexCol)`
   justify-content: center;
   align-items: center;
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
   transition: ${Transition.hover.off};
 `;
 
@@ -104,7 +105,7 @@ export const ListHeading = styled(H3)`
   font-size: 18px;
   padding: 16px;
   padding-left: 0;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const ListContainer = styled(FlexCol)`
@@ -118,12 +119,12 @@ export const MoreLink = styled(Link)`
   font-size: 14px;
   font-weight: 700;
   line-height: 1;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   transition: ${Transition.hover.off};
   padding: 0;
 
   &:hover {
-    color: ${({ theme }) => theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 
   > div {
@@ -133,7 +134,7 @@ export const MoreLink = styled(Link)`
 
 export const ListFooter = styled(FlexRow)`
   padding-top: 8px;
-  border-top: 2px solid ${({ theme }) => theme.bg.wash};
+  border-top: 2px solid ${theme.bg.wash};
   justify-content: flex-start;
   width: 100%;
 `;
@@ -141,25 +142,25 @@ export const ListFooter = styled(FlexRow)`
 export const ListHeader = styled(FlexRow)`
   justify-content: space-between;
   width: 100%;
-  border-bottom: 2px solid ${({ theme }) => theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
   margin-top: ${props => (props.secondary ? '24px' : '0')};
 `;
 
 export const LargeListHeading = styled(H3)`
   font-weight: 800;
   font-size: 20px;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
 `;
 export const Description = styled.div`
   margin-top: 8px;
   font-weight: 400;
   font-size: 14px;
   line-height: 1.4;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
 
   strong {
     font-weight: 600;
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   &:last-of-type {
@@ -200,7 +201,7 @@ export const BadgeContainer = styled(FlexCol)`
 `;
 
 export const Lock = styled.span`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   position: relative;
   top: 2px;
   margin-left: -2px;

--- a/src/components/loading/style.js
+++ b/src/components/loading/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled, { keyframes } from 'styled-components';
 import { Card } from '../card';
@@ -82,9 +83,9 @@ export const ShimmerThread = styled(Card)`
 `;
 
 export const ShimmerInboxThread = styled.div`
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   padding: 16px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 
   section {
     min-height: 96px;
@@ -126,7 +127,7 @@ export const ShimmerDM = styled(ShimmerProfile)`
   margin: 0;
   box-shadow: none;
   border-radius: 0;
-  border-bottom: 2px solid ${({ theme }) => theme.bg.wash};
+  border-bottom: 2px solid ${theme.bg.wash};
 
   section {
     min-height: 40px;
@@ -151,10 +152,10 @@ export const ShimmerComposer = styled(Card)`
 
 export const ShimmerInboxComposer = styled.div`
   padding: 16px;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   margin: 8px 0;
-  border-top: 1px solid ${props => props.theme.bg.border};
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-top: 1px solid ${theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 
   section {
     min-height: 32px;
@@ -170,8 +171,8 @@ export const ShimmerSelect = styled.div`
   width: 196px;
   margin-left: 8px;
   border-radius: 8px;
-  background: ${props => props.theme.bg.default};
-  border: 2px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.default};
+  border: 2px solid ${theme.bg.border};
 
   @media (max-width: 768px) {
     width: calc(50% - 12px);
@@ -201,7 +202,7 @@ export const ShimmerBase = styled.section`
   height: 100%;
   position: relative;
   z-index: ${zIndex.loading};
-  background: ${({ theme }) => theme.bg.wash};
+  background: ${theme.bg.wash};
   overflow: hidden;
 `;
 
@@ -216,16 +217,16 @@ export const ShimmerLine = styled.span`
   animation-timing-function: ease-in-out;
   background: linear-gradient(
     to right,
-    ${({ theme }) => theme.bg.wash} 10%,
+    ${theme.bg.wash} 10%,
     ${({ theme }) => hexa(theme.generic.default, 0.65)} 20%,
-    ${({ theme }) => theme.bg.wash} 30%
+    ${theme.bg.wash} 30%
   );
   ${/* background-size: 100%; */ ''} animation-name: ${placeHolderShimmer};
 `;
 
 export const Cover = styled.span`
   position: absolute;
-  background: ${({ theme }) => theme.bg.default};
+  background: ${theme.bg.default};
   z-index: ${zIndex.loading + 2};
 `;
 
@@ -235,7 +236,7 @@ export const LoadingOverlay = styled.div`
   left: 0;
   right: 0;
   bottom: 0;
-  background: ${({ theme }) => theme.bg.reverse};
+  background: ${theme.bg.reverse};
   opacity: 0.95;
   width: 100%;
   height: 100%;
@@ -244,7 +245,7 @@ export const LoadingOverlay = styled.div`
 
 export const LoadingNavbarContainer = styled.nav`
   width: 100%;
-  background: ${({ theme }) => theme.text.default};
+  background: ${theme.text.default};
   display: flex;
   align-items: center;
   color: #fff;
@@ -295,7 +296,7 @@ export const GridProfile = styled.div`
   max-width: 100%;
   height: 100%;
   min-height: 100vh;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
 
   @media (max-width: 1028px) {
     grid-template-columns: 240px 1fr;
@@ -328,5 +329,5 @@ export const GridContent = styled(Column)`
 export const LoadingCoverPhoto = styled.div`
   grid-area: cover;
   width: 100%;
-  background-color: ${({ theme }) => theme.bg.wash};
+  background-color: ${theme.bg.wash};
 `;

--- a/src/components/loginButtonSet/style.js
+++ b/src/components/loginButtonSet/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { zIndex } from '../globals';
 
@@ -24,7 +25,7 @@ export const SigninButton = styled.div`
   align-self: flex-start;
   align-items: center;
   justify-content: flex-start;
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
   border-radius: 8px;
   padding: 8px;
   padding-right: 16px;
@@ -74,7 +75,7 @@ export const TwitterButton = styled(SigninButton)`
     props.preferred ? '#fff' : props.theme.social.twitter.default};
 
   &:after {
-    color: ${props => props.theme.social.twitter.default};
+    color: ${theme.social.twitter.default};
   }
 `;
 
@@ -85,7 +86,7 @@ export const FacebookButton = styled(SigninButton)`
     props.preferred ? '#fff' : props.theme.social.facebook.default};
 
   &:after {
-    color: ${props => props.theme.social.facebook.default};
+    color: ${theme.social.facebook.default};
   }
 `;
 
@@ -96,7 +97,7 @@ export const GoogleButton = styled(SigninButton)`
     props.preferred ? '#fff' : props.theme.social.google.default};
 
   &:after {
-    color: ${props => props.theme.social.google.default};
+    color: ${theme.social.google.default};
   }
 `;
 
@@ -107,6 +108,6 @@ export const GithubButton = styled(SigninButton)`
     props.preferred ? '#fff' : props.theme.social.github.default};
 
   &:after {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;

--- a/src/components/mediaInput/style.js
+++ b/src/components/mediaInput/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 import { zIndex } from '../globals';
 
 export const MediaInput = styled.input`
@@ -16,12 +17,12 @@ export const MediaLabel = styled.label`
   display: inline-block;
   background: transparent;
   transition: color 0.3s ease-out;
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
   height: 32px;
   width: 32px;
 
   &:hover {
     cursor: pointer;
-    color: ${({ theme }) => theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;

--- a/src/components/menu/style.js
+++ b/src/components/menu/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import { Transition, Shadow, zIndex, hexa } from '../../components/globals';
 import { isDesktopApp } from 'src/helpers/is-desktop-app';
@@ -10,11 +11,11 @@ export const Wrapper = styled.div`
     props.darkContext &&
     css`
       > button {
-        color: ${props => props.theme.text.reverse};
+        color: ${theme.text.reverse};
         transition: ${Transition.hover.off};
 
         &:hover {
-          color: ${props => props.theme.text.reverse};
+          color: ${theme.text.reverse};
           transform: scale(1.1);
           transition: ${Transition.hover.on};
         }
@@ -36,7 +37,7 @@ export const Absolute = styled.div`
   z-index: 1;
 
   button {
-    color: ${props => props.theme.text.reverse};
+    color: ${theme.text.reverse};
     z-index: 2;
     align-self: flex-start;
     margin-top: ${props => (props.hasNavBar ? '56px' : '8px')};
@@ -44,7 +45,7 @@ export const Absolute = styled.div`
   }
 
   button:hover {
-    color: ${props => props.theme.text.reverse};
+    color: ${theme.text.reverse};
   }
 `;
 
@@ -59,8 +60,8 @@ export const MenuContainer = styled.div`
   bottom: 0;
   height: 100%;
   width: 300px;
-  color: ${props => props.theme.brand.alt};
-  background-color: ${props => props.theme.bg.wash};
+  color: ${theme.brand.alt};
+  background-color: ${theme.bg.wash};
   box-shadow: ${Shadow.high} ${props => hexa(props.theme.bg.reverse, 0.25)};
   padding-top: ${props =>
     props.hasNavBar ? '48px' : isDesktopApp() ? '40px' : '0'};

--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import { SvgWrapper } from '../icons';
@@ -11,7 +12,7 @@ export const Byline = styled.span`
   font-weight: 500;
   margin-bottom: 4px;
   user-select: none;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   max-width: 100%;
   position: relative;
   flex-wrap: wrap;
@@ -30,12 +31,12 @@ export const Byline = styled.span`
 export const Name = styled.span`
   font-weight: 600;
   font-size: 15px;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   margin-right: 2px;
   display: flex;
 
   &:hover {
-    color: ${({ theme }) => theme.text.default};
+    color: ${theme.text.default};
     cursor: pointer;
   }
 
@@ -48,7 +49,7 @@ export const Username = styled(Name)`
   font-weight: 400;
   margin-left: 2px;
   margin-right: 2px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
 
   @media (max-width: 400px) {
@@ -71,8 +72,8 @@ export const Actions = styled.ul`
   top: 0;
   right: 16px;
   border-radius: 4px;
-  border: 1px solid ${props => props.theme.bg.border};
-  background: ${props => props.theme.bg.default};
+  border: 1px solid ${theme.bg.border};
+  background: ${theme.bg.default};
   list-style-type: none;
   display: flex;
   margin-left: 30px;
@@ -83,15 +84,15 @@ export const Actions = styled.ul`
 `;
 
 export const Action = styled.li`
-  border-left: 1px solid ${props => props.theme.bg.border};
+  border-left: 1px solid ${theme.bg.border};
   padding: 3px 10px;
   display: flex;
   flex: 0 1 auto;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
 
   &:hover {
     cursor: pointer;
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   &:first-child {
@@ -119,7 +120,7 @@ export const GutterTimestamp = styled(Link)`
   width: 72px;
   font-size: 14px;
   font-weight: 400;
-  color: ${props => props.theme.text.placeholder};
+  color: ${theme.text.placeholder};
   opacity: 0;
   ${Truncate};
 
@@ -208,15 +209,15 @@ const Bubble = styled.div`
   clear: both;
 
   &::selection {
-    background-color: ${props => props.theme.brand.alt};
+    background-color: ${theme.brand.alt};
   }
 
   code {
     border-radius: 4px;
     padding: 2px 4px;
-    background: ${props => props.theme.bg.wash};
-    border: 1px solid ${props => props.theme.bg.border};
-    color: ${props => props.theme.text.secondary};
+    background: ${theme.bg.wash};
+    border: 1px solid ${theme.bg.border};
+    color: ${theme.text.secondary};
   }
 
   pre {
@@ -225,9 +226,9 @@ const Bubble = styled.div`
     width: 100%;
     border-radius: 8px;
     padding: 8px 16px;
-    background: ${props => props.theme.bg.wash};
-    border: 1px solid ${props => props.theme.bg.border};
-    color: ${props => props.theme.text.secondary};
+    background: ${theme.bg.wash};
+    border: 1px solid ${theme.bg.border};
+    color: ${theme.text.secondary};
   }
 `;
 
@@ -302,9 +303,9 @@ export const Code = styled(Bubble)`
   padding: 12px 16px;
   font-size: 14px;
   font-weight: 500;
-  background-color: ${props => props.theme.bg.reverse};
-  border: 1px solid ${props => props.theme.bg.border};
-  color: ${props => props.theme.text.reverse};
+  background-color: ${theme.bg.reverse};
+  border: 1px solid ${theme.bg.border};
+  color: ${theme.text.reverse};
   max-width: 100%;
   overflow-x: scroll;
   list-style: none;
@@ -317,7 +318,7 @@ export const Line = styled.pre`
   word-break: break-all;
   word-wrap: break-word;
   ${monoStack};
-  border: 1px solid ${props => props.theme.bg.border};
+  border: 1px solid ${theme.bg.border};
 `;
 
 export const Paragraph = styled.p`
@@ -330,16 +331,16 @@ export const Paragraph = styled.p`
 
 export const BlockQuote = styled.blockquote`
   line-height: 1.5;
-  border-left: 4px solid ${props => props.theme.bg.border};
-  color: ${props => props.theme.text.alt};
+  border-left: 4px solid ${theme.bg.border};
+  color: ${theme.text.alt};
   padding: 4px 12px 4px 16px;
 `;
 
 export const QuotedParagraph = Paragraph.withComponent('div').extend`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 
   code {
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
   }
   /* overrides Bubble component styles to fix #3098 */
   pre {
@@ -347,7 +348,7 @@ export const QuotedParagraph = Paragraph.withComponent('div').extend`
     margin-top: 8px;
     width: 100%;
     border: 1px solid ${props => hexa(props.theme.brand.border, 0.5)};
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
   }
 `;
 
@@ -365,8 +366,8 @@ export const QuoteWrapperGradient = styled.div`
 `;
 
 export const QuoteWrapper = styled.div`
-  border-left: 4px solid ${props => props.theme.bg.border};
-  color: ${props => props.theme.text.alt};
+  border-left: 4px solid ${theme.bg.border};
+  color: ${theme.text.alt};
   padding: 4px 12px 4px 16px;
   max-height: ${props => (props.expanded ? 'none' : '7em')};
   margin-top: 4px;
@@ -382,23 +383,23 @@ export const QuoteWrapper = styled.div`
 
   /* Don't change the color of the name and username on hover since they aren't clickable in quotes */
   ${Username}:hover, ${Byline}:hover {
-    color: ${props => props.theme.text.secondary};
+    color: ${theme.text.secondary};
   }
 
   ${Name} {
     font-size: 14px;
     font-weight: 600;
-    color: ${props => props.theme.text.secondary};
+    color: ${theme.text.secondary};
   }
 
   ${Name}:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   ${Username} {
     font-size: 13px;
     font-weight: 500;
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
   }
 `;
 

--- a/src/components/messageGroup/style.js
+++ b/src/components/messageGroup/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { Transition, HorizontalRule } from '../globals';
 
@@ -29,36 +30,36 @@ export const Timestamp = styled(HorizontalRule)`
   user-select: none;
 
   hr {
-    border-color: ${props => props.theme.bg.wash};
+    border-color: ${theme.bg.wash};
   }
 `;
 
 export const UnseenRobotext = styled(Timestamp)`
   hr {
-    border-color: ${props => props.theme.warn.alt};
+    border-color: ${theme.warn.alt};
     opacity: 0.1;
   }
 `;
 
 export const Time = styled.span`
   text-align: center;
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
   font-size: 14px;
   font-weight: 400;
   margin: 0 16px;
   transition: ${Transition.hover.off};
 
   &:hover {
-    color: ${({ theme }) => theme.text.alt};
+    color: ${theme.text.alt};
     transiton: ${Transition.hover.on};
   }
 `;
 
 export const UnseenTime = styled(Time)`
-  color: ${({ theme }) => theme.warn.alt};
+  color: ${theme.warn.alt};
 
   &:hover {
-    color: ${({ theme }) => theme.warn.alt};
+    color: ${theme.warn.alt};
     transiton: ${Transition.hover.on};
   }
 `;
@@ -72,7 +73,7 @@ export const MessageLink = styled.a`
   white-space: nowrap;
   font-size: 12px;
   top: 0;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   left: calc(100% + 4px);
 `;
 

--- a/src/components/modals/AdminEmailAddressVerificationModal/style.js
+++ b/src/components/modals/AdminEmailAddressVerificationModal/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const Section = styled.section`
@@ -12,6 +13,6 @@ export const Section = styled.section`
 export const Title = styled.h3`
   font-size: 24px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin: 0;
 `;

--- a/src/components/modals/ChangeChannelModal/style.js
+++ b/src/components/modals/ChangeChannelModal/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 import { zIndex } from '../../globals';
 import { isMobile } from '../../../helpers/utils';
 
@@ -52,7 +53,7 @@ export const Section = styled.section`
 export const Title = styled.h3`
   font-size: 24px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin: 16px 0 8px;
   text-align: center;
   line-height: 1.4;
@@ -61,7 +62,7 @@ export const Title = styled.h3`
 export const Subtitle = styled.h3`
   font-size: 16px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   text-align: center;
 `;
 

--- a/src/components/modals/RepExplainerModal/style.js
+++ b/src/components/modals/RepExplainerModal/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 import { zIndex } from '../../globals';
 import { isMobile } from '../../../helpers/utils';
 
@@ -52,29 +53,29 @@ export const Section = styled.section`
 export const Title = styled.h3`
   font-size: 24px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin: 16px 0 8px;
 `;
 
 export const Subtitle = styled.h3`
   font-size: 16px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   text-align: center;
 `;
 
 export const Rep = styled.div`
   display: flex;
-  background: ${props => props.theme.bg.wash};
-  border: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.wash};
+  border: 1px solid ${theme.bg.border};
   padding: 8px;
   border-radius: 4px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-top: 32px;
 `;
 
 export const IconContainer = styled.div`
-  color: ${props => props.theme.brand.alt};
+  color: ${theme.brand.alt};
 `;
 
 export const RepWrapper = styled.span`

--- a/src/components/modals/UpgradeAnalyticsModal/style.js
+++ b/src/components/modals/UpgradeAnalyticsModal/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const Section = styled.section`
@@ -12,13 +13,13 @@ export const Section = styled.section`
 export const Title = styled.h3`
   font-size: 24px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin: 0;
 `;
 
 export const Subtitle = styled.h3`
   font-size: 16px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-bottom: 16px;
 `;

--- a/src/components/modals/UpgradeModal/style.js
+++ b/src/components/modals/UpgradeModal/style.js
@@ -1,4 +1,5 @@
 import styled, { keyframes } from 'styled-components';
+import theme from 'shared/theme';
 import { Gradient, Transition, zIndex } from '../../globals';
 import { isMobile } from '../../../helpers/utils';
 
@@ -69,10 +70,10 @@ export const SectionActions = styled(Section)`
 `;
 
 export const SectionAlert = styled(Section)`
-  background-color: ${({ theme }) => theme.success.alt};
+  background-color: ${theme.success.alt};
   background-image: ${({ theme }) =>
     Gradient(theme.success.alt, theme.success.default)};
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
   line-height: 1.3;
   font-weight: 600;
   font-size: 0.875rem;
@@ -107,7 +108,7 @@ export const Heading = styled.h2`
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.2px;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   margin: 0.5rem 0;
 `;
 
@@ -115,7 +116,7 @@ export const Subheading = styled.h4`
   font-size: 0.875rem;
   font-weight: 500;
   line-height: 1.3;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const Flex = styled.div`
@@ -143,7 +144,7 @@ export const Spinner = styled.div`
   height: ${props => (props.size ? props.size + 'px' : '1rem')};
   width: ${props => (props.size ? props.size + 'px' : '1rem')};
   border-radius: 50%;
-  border: 2px solid ${({ theme }) => theme.text.reverse};
+  border: 2px solid ${theme.text.reverse};
   border-top-color: ${props => props.color};
   animation: ${rotate} 1s infinite linear;
   position: absolute;
@@ -170,13 +171,13 @@ export const Profile = styled.div`
   }
 
   span {
-    background-color: ${({ theme }) => theme.success.alt};
+    background-color: ${theme.success.alt};
     background-image: ${({ theme }) =>
       Gradient(theme.success.alt, theme.success.default)};
     position: absolute;
     left: 52%;
     top: 32px;
-    color: ${({ theme }) => theme.text.reverse};
+    color: ${theme.text.reverse};
     font-size: 10px;
     font-weight: 800;
     padding: 2px 4px;

--- a/src/components/modals/UpgradeModeratorSeatModal/style.js
+++ b/src/components/modals/UpgradeModeratorSeatModal/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const Section = styled.section`
@@ -12,13 +13,13 @@ export const Section = styled.section`
 export const Title = styled.h3`
   font-size: 24px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin: 0;
 `;
 
 export const Subtitle = styled.h3`
   font-size: 16px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-bottom: 16px;
 `;

--- a/src/components/modals/styles.js
+++ b/src/components/modals/styles.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { zIndex } from '../globals';
@@ -64,7 +65,7 @@ export const ModalBody = styled.div`
   flex-direction: column;
   justify-content: space-between;
   height: 100%;
-  background-color: ${({ theme }) => theme.bg.default};
+  background-color: ${theme.bg.default};
   overflow: visible;
 `;
 
@@ -88,21 +89,21 @@ export const CloseButton = styled(IconButton)`
   right: 8px;
   top: 8px;
   z-index: ${zIndex.modal + 1};
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
 
   &:hover {
-    color: ${({ theme }) => theme.warn.alt};
+    color: ${theme.warn.alt};
   }
 `;
 
 export const Description = styled.p`
   font-size: 14px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   padding: 8px 0 16px;
   line-height: 1.4;
 
   a {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
   }
 `;
 
@@ -110,12 +111,12 @@ export const UpsellDescription = styled(Description)`
   padding: 8px 12px;
   margin: 8px 0;
   border-radius: 4px;
-  border: 1px solid ${props => props.theme.success.border};
-  background: ${props => props.theme.success.wash};
-  color: ${props => props.theme.success.dark};
+  border: 1px solid ${theme.success.border};
+  background: ${theme.success.wash};
+  color: ${theme.success.dark};
 
   a {
-    color: ${props => props.theme.success.default};
+    color: ${theme.success.default};
     font-weight: 700;
     display: block;
     margin-top: 4px;
@@ -126,19 +127,19 @@ export const Notice = styled(Description)`
   padding: 8px 16px;
   margin: 8px 0;
   border-radius: 4px;
-  background: ${props => props.theme.special.wash};
-  border: 2px solid ${props => props.theme.special.border};
-  color: ${props => props.theme.special.dark};
+  background: ${theme.special.wash};
+  border: 2px solid ${theme.special.border};
+  color: ${theme.special.dark};
 `;
 
 export const PoweredByStripeFooter = styled.div`
   width: 100%;
-  background: ${props => props.theme.bg.wash};
-  border-top: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.wash};
+  border-top: 1px solid ${theme.bg.border};
   padding: 8px 12px;
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/components/newActivityIndicator/index.js
+++ b/src/components/newActivityIndicator/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import theme from 'shared/theme';
 import { connect } from 'react-redux';
 import { clearActivityIndicator } from '../../actions/newActivityIndicator';
 import styled from 'styled-components';
@@ -7,7 +8,7 @@ import { Gradient } from '../globals';
 const Pill = styled.div`
   padding: ${props => (props.refetching ? '8px' : '8px 16px')};
   border-radius: 20px;
-  color: ${props => props.theme.text.reverse};
+  color: ${theme.text.reverse};
   background: ${props =>
     Gradient(props.theme.brand.alt, props.theme.brand.default)};};
   font-size: 14px;
@@ -57,7 +58,7 @@ const Pill = styled.div`
 const scrollTo = (element, to, duration) => {
   if (duration < 0) return;
   const difference = to - element.scrollTop;
-  const perTick = difference / duration * 2;
+  const perTick = (difference / duration) * 2;
 
   setTimeout(() => {
     element.scrollTop = element.scrollTop + perTick;

--- a/src/components/nextPageButton/style.js
+++ b/src/components/nextPageButton/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const HasNextPage = styled.div`
@@ -12,15 +13,15 @@ export const NextPageButton = styled.div`
   flex: 1;
   justify-content: center;
   padding: 8px;
-  background: ${props => props.theme.bg.wash};
-  color: ${props => props.theme.text.alt};
+  background: ${theme.bg.wash};
+  color: ${theme.text.alt};
   font-size: 14px;
   font-weight: 500;
   position: relative;
   min-height: 40px;
 
   &:hover {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
     cursor: pointer;
     background: rgba(56, 24, 229, 0.1);
   }

--- a/src/components/profile/coverPhoto.js
+++ b/src/components/profile/coverPhoto.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 // $FlowFixMe
@@ -11,7 +12,7 @@ const PhotoContainer = styled.div`
   position: relative;
   width: 100%;
   flex: 0 0 ${props => (props.large ? '320px' : '96px')};
-  background-color: ${({ theme }) => theme.bg.reverse};
+  background-color: ${theme.bg.reverse};
   background-image: ${props =>
     props.coverURL
       ? `url("${optimize(props.coverURL, {

--- a/src/components/profile/style.js
+++ b/src/components/profile/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import Link from 'src/components/link';
 import {
@@ -31,7 +32,7 @@ export const ProfileHeaderLink = styled(Link)`
 
   &:hover h3 {
     transition: ${Transition.hover.on};
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
@@ -45,7 +46,7 @@ export const ProfileHeaderNoLink = styled.div`
 
   &:hover h3 {
     transition: ${Transition.hover.on};
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
@@ -62,7 +63,7 @@ export const ProfileHeaderAction = styled(IconButton)`
 
 export const Title = styled.h3`
   font-size: 16px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   font-weight: 700;
   line-height: 1.2;
   transition: ${Transition.hover.off};
@@ -76,7 +77,7 @@ export const FullTitle = styled(Title)`
 export const FullProfile = styled.div`
   margin-left: 32px;
   margin-top: -64px;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
 
   @media (max-width: 768px) {
     margin-top: -48px;
@@ -87,7 +88,7 @@ export const Subtitle = styled.div`
   display: flex;
   align-items: center;
   font-size: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1.2;
   margin-top: 4px;
 
@@ -106,14 +107,14 @@ export const Subtitle = styled.div`
 
 export const Description = styled.div`
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   padding: 0 16px 16px;
   line-height: 1.4;
   white-space: pre-wrap;
 
   a {
     font-weight: 500;
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
 
     &:hover {
       text-decoration: underline;
@@ -124,18 +125,18 @@ export const Description = styled.div`
 export const FullDescription = styled.div`
   padding: 0;
   margin-top: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 
   p {
     white-space: pre-wrap;
   }
 
   a {
-    color: ${props => props.theme.text.secondary};
+    color: ${theme.text.secondary};
   }
 
   a:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
     text-decoration: none;
   }
 
@@ -152,7 +153,7 @@ export const FullDescription = styled.div`
 
 export const ExtLink = styled(FlexRow)`
   align-items: center;
-  color: ${({ theme }) => theme.brand.alt};
+  color: ${theme.brand.alt};
   font-weight: 600;
   transition: ${Transition.hover.off};
   ${Truncate};
@@ -165,7 +166,7 @@ export const ExtLink = styled(FlexRow)`
   }
 
   > div {
-    color: ${({ theme }) => theme.text.alt};
+    color: ${theme.text.alt};
     margin-right: 4px;
     margin-top: 1px;
   }
@@ -194,7 +195,7 @@ export const ActionOutline = styled(OutlineButton)`
 
 export const Meta = styled.div`
   background: #f8fbfe;
-  border-top: 2px solid ${props => props.theme.bg.border};
+  border-top: 2px solid ${theme.bg.border};
   padding: 8px 16px;
   width: 100%;
   border-radius: 0 0 12px 12px;
@@ -206,9 +207,9 @@ export const MetaListItem = styled.li`
   list-style-type: none;
   font-size: 14px;
   font-weight: 600;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   padding: 8px 0;
-  border-top: 2px solid ${props => props.theme.bg.border};
+  border-top: 2px solid ${theme.bg.border};
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -269,7 +270,7 @@ export const ProfileCard = styled(Card)`
     padding: 16px;
 
     h4 > a:hover {
-      color: ${({ theme }) => theme.brand.alt};
+      color: ${theme.brand.alt};
       text-decoration: underline;
     }
   }
@@ -295,18 +296,18 @@ export const ProUpgrade = styled.div`
 `;
 
 // export const ReputationContainer = styled.div`
-//   border-top: 2px solid ${props => props.theme.bg.border};
+//   border-top: 2px solid ${theme.bg.border};
 //   padding: 12px 0;
 //   margin: 0 16px;
 //   display: flex;
-//   color: ${props => props.theme.text.alt};
+//   color: ${theme.text.alt};
 // `;
 
 export const CoverPhoto = styled.div`
   position: relative;
   width: 100%;
   height: ${props => (props.large ? '320px' : '96px')};
-  background-color: ${({ theme }) => theme.brand.default};
+  background-color: ${theme.brand.default};
   background-image: url('${props => props.url}');
   background-size: cover;
   background-repeat: no-repeat;
@@ -315,7 +316,7 @@ export const CoverPhoto = styled.div`
 `;
 
 export const Container = styled.div`
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   box-shadow: ${Shadow.mid} ${props => hexa(props.theme.bg.reverse, 0.15)};
   flex: 0 0 22%;
   display: flex;

--- a/src/components/reputation/style.js
+++ b/src/components/reputation/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { Tooltip, zIndex } from '../globals';
 
@@ -6,7 +7,7 @@ export const ReputationWrapper = styled.div`
   display: flex;
   align-items: center;
   flex: none;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   cursor: pointer;
   position: relative;
   z-index: ${zIndex.fullScreen};
@@ -17,5 +18,5 @@ export const ReputationWrapper = styled.div`
 export const ReputationLabel = styled.span`
   font-size: 13px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;

--- a/src/components/rich-text-editor/Image.js
+++ b/src/components/rich-text-editor/Image.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 import styled, { css, keyframes } from 'styled-components';
 
@@ -38,7 +39,7 @@ export const ActiveOverlay = styled.span`
   bottom: 0;
   background: rgba(56, 24, 229, 0.1);
   border-radius: 8px;
-  border: 1px solid ${props => props.theme.brand.default};
+  border: 1px solid ${theme.brand.default};
   opacity: ${props => (props.active ? 1 : 0)};
   transition: opacity 0.1s ease-in-out;
 `;

--- a/src/components/rich-text-editor/style.js
+++ b/src/components/rich-text-editor/style.js
@@ -1,10 +1,10 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 import { connect } from 'react-redux';
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import { Transition, zIndex } from 'src/components/globals';
-import theme from 'shared/theme';
 import { UserHoverProfile } from 'src/components/hoverProfile';
 import type { Node } from 'react';
 
@@ -82,8 +82,8 @@ export const Wrapper = styled.div`
 
 export const MediaRow = styled.div`
   display: flex;
-  background: ${props => props.theme.bg.wash};
-  border-top: 2px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.wash};
+  border-top: 2px solid ${theme.bg.border};
   padding: 8px 16px;
   margin-left: -24px;
   margin-bottom: -24px;
@@ -109,7 +109,7 @@ export const ComposerBase = styled.div`
     bottom: -11px;
     padding: 0;
     margin: 0;
-    color: ${props => props.theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 `;
 
@@ -131,7 +131,7 @@ export const Action = styled.div`
 
   label > div,
   label > button > div {
-    color: ${props => props.theme.text.reverse};
+    color: ${theme.text.reverse};
   }
 `;
 
@@ -144,25 +144,25 @@ export const Expander = styled.div`
   border-radius: 12px;
 
   > button > div {
-    color: ${props => props.theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   > button:hover > div {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 
   ${props =>
     props.inserting &&
     css`
-      background-color: ${props => props.theme.brand.alt};
+      background-color: ${theme.brand.alt};
       transition: ${Transition.hover.on};
 
       > button > div {
-        color: ${props => props.theme.brand.wash};
+        color: ${theme.brand.wash};
       }
 
       > button:hover > div {
-        color: ${props => props.theme.brand.wash};
+        color: ${theme.brand.wash};
       }
 
       ${Action} {
@@ -174,7 +174,7 @@ export const Expander = styled.div`
 export const EmbedUI = styled.form`
   display: flex;
   flex-direction: row;
-  background-color: ${props => props.theme.brand.alt};
+  background-color: ${theme.brand.alt};
   border-radius: 12px;
 
   label {
@@ -221,7 +221,7 @@ export const EmbedUI = styled.form`
       button {
         display: inline-block;
         background-color: transparent;
-        color: ${props => props.theme.text.reverse};
+        color: ${theme.text.reverse};
         margin-right: 16px;
         font-size: 14px;
         line-height: 1;
@@ -230,7 +230,7 @@ export const EmbedUI = styled.form`
         transition: ${Transition.hover.off};
 
         &:hover {
-          background-color: ${props => props.theme.brand.dark};
+          background-color: ${theme.brand.dark};
           border-radius: 8px;
           transition: ${Transition.hover.on};
         }

--- a/src/components/segmentedControl/index.js
+++ b/src/components/segmentedControl/index.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import { FlexRow } from '../globals';
 
@@ -6,12 +7,12 @@ export const SegmentedControl = styled(FlexRow)`
   align-self: stretch;
   margin: 0 32px;
   margin-top: 16px;
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
   align-items: stretch;
   min-height: 48px;
 
   @media (max-width: 768px) {
-    background-color: ${props => props.theme.bg.default};
+    background-color: ${theme.bg.default};
     align-self: stretch;
     margin: 0;
     margin-bottom: 2px;
@@ -41,11 +42,11 @@ export const Segment = styled(FlexRow)`
   ${props =>
     props.selected &&
     css`
-      border-bottom: 2px solid ${props => props.theme.bg.reverse};
+      border-bottom: 2px solid ${theme.bg.reverse};
     `};
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   @media (max-width: 768px) {

--- a/src/components/settingsViews/style.js
+++ b/src/components/settingsViews/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { Tooltip } from '../globals';
 
@@ -46,8 +47,8 @@ export const Column = styled.div`
 
 export const SectionCard = styled.div`
   border-radius: 4px;
-  border: 1px solid ${props => props.theme.bg.border};
-  background: ${props => props.theme.bg.default};
+  border: 1px solid ${theme.bg.border};
+  background: ${theme.bg.default};
   margin-bottom: 16px;
   padding: 16px;
   display: flex;
@@ -58,7 +59,7 @@ export const SectionCard = styled.div`
 `;
 
 export const SectionCardFooter = styled.div`
-  border-top: 1px solid ${props => props.theme.bg.border};
+  border-top: 1px solid ${theme.bg.border};
   width: calc(100% + 32px);
   margin: 16px -16px 0;
   padding: 16px 16px 0;
@@ -70,18 +71,18 @@ export const SectionCardFooter = styled.div`
 export const SectionSubtitle = styled.h4`
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-bottom: 4px;
 
   a {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
 export const SectionTitle = styled.h3`
   font-size: 18px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin-bottom: 8px;
   display: flex;
   align-items: center;
@@ -96,7 +97,7 @@ export const SectionTitleWithIcon = styled(SectionTitle)`
 export const Heading = styled.h1`
   margin-left: 16px;
   font-size: 32px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   font-weight: 600;
   line-height: 1;
 `;
@@ -104,20 +105,20 @@ export const Heading = styled.h1`
 export const Subheading = styled.h3`
   margin-left: 16px;
   font-size: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 400;
   line-height: 1.3;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
 export const StyledHeader = styled.div`
   display: flex;
   padding: 32px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
-  background: ${props => props.theme.bg.default};
+  border-bottom: 1px solid ${theme.bg.border};
+  background: ${theme.bg.default};
   width: 100%;
   align-items: center;
   flex: none;
@@ -130,8 +131,8 @@ export const StyledHeader = styled.div`
 export const StyledSubnav = styled.div`
   display: flex;
   padding: 0 32px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
-  background: ${props => props.theme.bg.default};
+  border-bottom: 1px solid ${theme.bg.border};
+  background: ${theme.bg.default};
   width: 100%;
   flex: none;
 
@@ -159,7 +160,7 @@ export const SubnavListItem = styled.li`
   font-weight: ${props => (props.active ? '500' : '400')};
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   a {
@@ -178,21 +179,23 @@ export const GrowthText = styled.span`
   color: ${props =>
     props.positive
       ? props.theme.success.default
-      : props.negative ? props.theme.warn.alt : props.theme.text.alt};
+      : props.negative
+        ? props.theme.warn.alt
+        : props.theme.text.alt};
   display: inline-block;
   margin-right: 6px;
   font-size: 14px;
 `;
 
 export const MessageIcon = styled.div`
-  color: ${props => props.theme.brand.alt};
+  color: ${theme.brand.alt};
   cursor: pointer;
   ${Tooltip} top: 2px;
 `;
 
 export const EditDropdownContainer = styled.div`
   position: relative;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -201,7 +204,7 @@ export const EditDropdownContainer = styled.div`
 
 export const Dropdown = styled.div`
   border-radius: 4px;
-  border: 1px solid ${props => props.theme.bg.border};
+  border: 1px solid ${theme.bg.border};
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
   position: absolute;
   right: 0;
@@ -214,25 +217,25 @@ export const Dropdown = styled.div`
 export const DropdownSectionDivider = styled.div`
   width: 100%;
   height: 8px;
-  background: ${props => props.theme.bg.wash};
-  border-top: 1px solid ${props => props.theme.bg.border};
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.wash};
+  border-top: 1px solid ${theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 `;
 
 export const DropdownSection = styled.div`
   padding: 12px 8px;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 
   .icon {
     margin-right: 8px;
   }
 
   &:hover {
-    background: ${props => props.theme.bg.wash};
+    background: ${theme.bg.wash};
   }
 `;
 
@@ -246,14 +249,14 @@ export const DropdownSectionText = styled.div`
 export const DropdownSectionTitle = styled.p`
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   line-height: 1.3;
 `;
 
 export const DropdownSectionSubtitle = styled.p`
   font-size: 13px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1.2;
 `;
 

--- a/src/components/stripeCardForm/style.js
+++ b/src/components/stripeCardForm/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const style = {
@@ -34,9 +35,9 @@ export const Well = styled.div`
   padding: 12px;
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
-  background: ${props => props.theme.bg.wash};
-  border: 1px solid ${props => props.theme.bg.border};
+  color: ${theme.text.alt};
+  background: ${theme.bg.wash};
+  border: 1px solid ${theme.bg.border};
   margin-top: 4px;
   flex-direction: ${props => (props.column ? 'column' : 'row')};
 

--- a/src/components/themedSection/index.js
+++ b/src/components/themedSection/index.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 import styled from 'styled-components';
 import Goop from '../goop';
@@ -17,73 +18,73 @@ export const Default = styled(FlexCol)`
   position: relative;
   flex: none;
   justify-content: center;
-  background-color: ${({ theme }) => theme.bg.default};
-  color: ${({ theme }) => theme.text.default};
+  background-color: ${theme.bg.default};
+  color: ${theme.text.default};
 `;
 
 export const Primary = styled(Default)`
-  background-color: ${({ theme }) => theme.space.dark};
+  background-color: ${theme.space.dark};
   background-image: ${({ theme }) =>
     `radial-gradient(farthest-corner at 50% 100%,
       ${hexa(theme.brand.alt, 0.75)}, ${theme.space.dark}
     )`};
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
 `;
 
 export const Brand = styled(Default)`
-  background-color: ${({ theme }) => theme.brand.default};
+  background-color: ${theme.brand.default};
   background-image: linear-gradient(
     to bottom,
     ${({ theme }) => `${theme.brand.alt}, ${theme.brand.default}`}
   );
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
 `;
 
 export const Dark = styled(Default)`
-  background-color: ${({ theme }) => theme.space.dark};
+  background-color: ${theme.space.dark};
   background-image: linear-gradient(
     to bottom,
     ${({ theme }) => `${theme.space.dark}, ${theme.brand.default}`}
   );
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
 `;
 
 export const Space = styled(Default)`
-  background-color: ${({ theme }) => theme.space.dark};
+  background-color: ${theme.space.dark};
   background-image: linear-gradient(
     to bottom,
     ${({ theme }) => `${theme.space.alt}, ${theme.space.dark}`}
   );
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
 `;
 
 export const Light = styled(Default)`
-  background-color: ${({ theme }) => theme.space.alt};
-  color: ${({ theme }) => theme.text.reverse};
+  background-color: ${theme.space.alt};
+  color: ${theme.text.reverse};
 `;
 
 export const Bright = styled(Default)`
-  background-color: ${({ theme }) => theme.brand.default};
+  background-color: ${theme.brand.default};
   background-image: linear-gradient(
     to bottom,
     ${({ theme }) => `${theme.space.alt}, ${theme.brand.default}`}
   );
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
 `;
 
 export const Grayscale = styled(Default)`
-  background-color: ${({ theme }) => theme.bg.reverse};
+  background-color: ${theme.bg.reverse};
   background-image: linear-gradient(
     to bottom,
     ${({ theme }) => `${theme.text.alt}, ${theme.bg.reverse}`}
   );
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
 `;
 
 export const Reverse = styled(Default)`
-  background-color: ${({ theme }) => theme.bg.reverse};
+  background-color: ${theme.bg.reverse};
   background-image: none;
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
 `;
 
 export const Blank = styled(Default)`

--- a/src/components/threadComposer/style.js
+++ b/src/components/threadComposer/style.js
@@ -1,4 +1,5 @@
 import styled, { keyframes } from 'styled-components';
+import theme from 'shared/theme';
 import { hexa, Transition, FlexRow, FlexCol, zIndex } from '../globals';
 
 export const Container = styled(FlexRow)`
@@ -25,7 +26,7 @@ export const Composer = styled.div`
   display: block;
   min-height: 64px;
   transition: ${Transition.hover.off};
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
 
   &:hover {
     transition: none;
@@ -71,14 +72,14 @@ export const Placeholder = styled.div`
   align-items: center;
   cursor: pointer;
   padding: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   transition: ${Transition.hover.off};
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 
   &:hover {
     transition: ${Transition.hover.on};
-    background-color: ${props => props.theme.bg.wash};
-    color: ${props => props.theme.text.alt};
+    background-color: ${theme.bg.wash};
+    color: ${theme.text.alt};
   }
 
   @media (max-width: 768px) {
@@ -103,7 +104,7 @@ export const ContentContainer = styled.div`
 
 export const Actions = styled(FlexCol)`
   background: #f8fbfe;
-  border-top: 2px solid ${props => props.theme.bg.border};
+  border-top: 2px solid ${theme.bg.border};
   padding: 8px 8px 8px 0;
   border-radius: 0 0 12px 12px;
   width: 100%;
@@ -130,10 +131,10 @@ export const Dropdowns = styled(FlexRow)`
     display: block;
     padding: 8px 12px;
     border: none;
-    border: 2px solid ${props => props.theme.bg.border};
+    border: 2px solid ${theme.bg.border};
     border-radius: 8px;
     box-shadow: none;
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
     font-weight: 600;
     font-size: 14px;
     box-sizing: border-box;
@@ -162,8 +163,8 @@ export const Dropdowns = styled(FlexRow)`
 export const ComposerUpsell = styled.div`
   position: relative;
   padding: 4px 16px;
-  background: ${props => props.theme.brand.alt};
-  border-bottom: 2px solid ${props => props.theme.brand.alt};
+  background: ${theme.brand.alt};
+  border-bottom: 2px solid ${theme.brand.alt};
   color: #fff;
   text-align: center;
 
@@ -176,11 +177,11 @@ export const ComposerUpsell = styled.div`
 export const UpsellPulse = styled.div`
   width: 10px;
   height: 10px;
-  border: 5px solid ${props => props.theme.brand.alt};
+  border: 5px solid ${theme.brand.alt};
   -webkit-border-radius: 30px;
   -moz-border-radius: 30px;
   border-radius: 30px;
-  background-color: ${props => props.theme.brand.alt};
+  background-color: ${theme.brand.alt};
   z-index: ${zIndex.composer};
   position: absolute;
   top: -4px;
@@ -217,7 +218,7 @@ const pulse = keyframes`
 `;
 
 export const UpsellDot = styled.div`
-  border: 10px solid ${props => props.theme.brand.default};
+  border: 10px solid ${theme.brand.default};
   background: transparent;
   -webkit-border-radius: 60px;
   -moz-border-radius: 60px;
@@ -280,7 +281,7 @@ export const DisconnectedWarning = styled.div`
   margin: 8px;
   border-radius: 8px;
   background: ${props => hexa(props.theme.warn.default, 0.1)};
-  color: ${props => props.theme.warn.default};
+  color: ${theme.warn.default};
   font-size: 16px;
   font-weight: 500;
 `;

--- a/src/components/threadFeed/style.js
+++ b/src/components/threadFeed/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { OutlineButton } from '../buttons';
@@ -13,13 +14,13 @@ export const FetchMoreButton = styled(OutlineButton)`
     background: #fff;
     font-size: 16px;
     font-weight: 600;
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
     border: none;
     box-shadow: none;
-    border-top: 2px solid ${props => props.theme.bg.border};
+    border-top: 2px solid ${theme.bg.border};
 
     &:hover {
-      background: ${props => props.theme.bg.wash};
+      background: ${theme.bg.wash};
       border-radius: 0;
       box-shadow: none;
     }
@@ -27,7 +28,7 @@ export const FetchMoreButton = styled(OutlineButton)`
 `;
 
 export const Divider = styled.div`
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
   width: 100%;
   display: block;
   padding-top: 24px;
@@ -43,7 +44,7 @@ export const Upsell = styled.div`
   padding: 64px 32px;
 
   a {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
     font-weight: 500;
 
     &:hover {
@@ -52,7 +53,7 @@ export const Upsell = styled.div`
   }
 
   p {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
     margin-top: 16px;
     font-size: 16px;
     line-height: 1.5;
@@ -80,7 +81,7 @@ export const Upsell = styled.div`
 export const UpsellHeader = styled.div`
   display: flex;
   align-items: center;
-  color: ${props => props.theme.brand.alt};
+  color: ${theme.brand.alt};
 
   div {
     margin-right: 8px;

--- a/src/components/threadFeedCard/style.js
+++ b/src/components/threadFeedCard/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 import Link from 'src/components/link';
 import { FlexCol, FlexRow, Transition, Gradient, zIndex } from '../globals';
 
@@ -7,11 +8,11 @@ export const StyledThreadFeedCard = styled.div`
   transition: ${Transition.hover.off};
 
   &:hover {
-    background-color: ${props => props.theme.bg.wash};
+    background-color: ${theme.bg.wash};
   }
   
   &:first-of-type {
-    border-top: 2px: ${props => props.theme.bg.default};
+    border-top: 2px: ${theme.bg.default};
   }
 `;
 
@@ -41,7 +42,7 @@ export const Title = styled.h2`
   font-size: 20px;
   line-height: 1.2;
   flex: 0 0 auto;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   pointer-events: all;
 `;
 
@@ -54,7 +55,7 @@ export const MessageCount = styled(FlexRow)`
   font-weight: 700;
   line-height: 1;
   vertical-align: middle;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
 
   div {
     margin-right: 4px;
@@ -72,7 +73,7 @@ export const Attachments = styled(FlexRow)`
 export const AuthorName = styled.span`
   font-weight: 500;
   font-size: 13px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1;
 `;
 
@@ -96,7 +97,7 @@ export const Meta = styled.span`
   font-weight: 700;
   line-height: 1;
   vertical-align: middle;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   align-items: center;
   margin-bottom: 4px;
@@ -107,7 +108,7 @@ export const Meta = styled.span`
 `;
 
 export const MetaNew = styled(Meta)`
-  color: ${({ theme }) => theme.success.default};
+  color: ${theme.success.default};
   align-self: flex-end;
 `;
 
@@ -116,7 +117,7 @@ export const Location = styled.span`
   flex: 0 0 auto;
   font-size: 13px;
   font-weight: 500;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1;
   margin-bottom: 2px;
 
@@ -125,14 +126,14 @@ export const Location = styled.span`
   }
 
   > a:hover {
-    color: ${({ theme }) => theme.brand.alt};
+    color: ${theme.brand.alt};
     text-decoration: underline;
   }
 `;
 
 export const Lock = styled.span`
   position: relative;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   top: 1px;
 `;
 
@@ -149,7 +150,7 @@ export const PinnedBanner = styled.span`
   position: absolute;
   width: 72px;
   height: 72px;
-  background-color: ${props => props.theme.special.default};
+  background-color: ${theme.special.default};
   background-image: ${props =>
     Gradient(props.theme.special.alt, props.theme.special.default)};
   transform: rotate(45deg);
@@ -161,7 +162,7 @@ export const PinnedIconWrapper = styled.span`
   position: relative;
   right: -36px;
   top: 4px;
-  color: ${props => props.theme.text.reverse};
+  color: ${theme.text.reverse};
 `;
 
 export const ParticipantHeads = styled(FlexRow)`
@@ -178,8 +179,8 @@ export const ParticipantCount = styled.span`
   border-radius: 100%;
   height: 32px;
   width: 32px;
-  color: ${props => props.theme.text.reverse};
-  background-color: ${props => props.theme.text.alt};
+  color: ${theme.text.reverse};
+  background-color: ${theme.text.alt};
   font-size: 11px;
   font-weight: 700;
   line-height: 32px;
@@ -191,7 +192,7 @@ export const ParticipantCount = styled.span`
 export const Author = styled.div`
   padding: 2px;
   border-radius: 100%;
-  border: 2px solid ${({ theme }) => theme.brand.alt};
+  border: 2px solid ${theme.brand.alt};
   pointer-events: all;
   display: flex;
   flex: none;

--- a/src/components/threadLikes/style.js
+++ b/src/components/threadLikes/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { Button } from 'src/components/buttons';
 
@@ -7,8 +8,8 @@ export const CurrentCount = styled.b`
 `;
 
 export const LikeButtonWrapper = styled(Button)`
-  background: ${props => props.theme.bg.default};
-  border: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.default};
+  border: 1px solid ${theme.bg.border};
   color: ${props =>
     props.hasReacted ? props.theme.brand.alt : props.theme.text.alt};
   padding: 4px 0 4px 8px;
@@ -22,18 +23,18 @@ export const LikeButtonWrapper = styled(Button)`
   }
 
   ${CurrentCount} {
-    background: ${props => props.theme.bg.wash};
-    border-left: 1px solid ${props => props.theme.bg.border};
+    background: ${theme.bg.wash};
+    border-left: 1px solid ${theme.bg.border};
     padding: 12px;
     margin-left: 12px;
     border-top-right-radius: 8px;
     border-bottom-right-radius: 8px;
-    color: ${props => props.theme.text.secondary};
+    color: ${theme.text.secondary};
     font-size: 14px;
   }
 
   &:hover {
-    background: ${props => props.theme.bg.default};
+    background: ${theme.bg.default};
     color: ${props =>
       props.hasReacted ? props.theme.brand.alt : props.theme.text.default};
   }

--- a/src/components/toasts/style.js
+++ b/src/components/toasts/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled, { keyframes } from 'styled-components';
 import { zIndex, Gradient } from '../globals';
@@ -57,19 +58,19 @@ const Toast = styled.div`
 `;
 
 export const ErrorToast = styled(Toast)`
-  background-color: ${props => props.theme.warn.default};
+  background-color: ${theme.warn.default};
   background-image: ${props =>
     Gradient(props.theme.warn.alt, props.theme.warn.default)};
 `;
 
 export const SuccessToast = styled(Toast)`
-  background-color: ${props => props.theme.success.default};
+  background-color: ${theme.success.default};
   background-image: ${props =>
     Gradient(props.theme.success.alt, props.theme.success.default)};
 `;
 
 export const NeutralToast = styled(Toast)`
-  background-color: ${props => props.theme.text.alt};
+  background-color: ${theme.text.alt};
   background-image: ${props =>
     Gradient(props.theme.text.placeholder, props.theme.text.alt)};
 `;

--- a/src/components/upsell/newUserUpsellStyles.js
+++ b/src/components/upsell/newUserUpsellStyles.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import ScrollRow from '../../components/scrollRow';
@@ -34,13 +35,13 @@ export const SectionHeaderNumber = styled.span`
   width: 32px;
   height: 32px;
   font-size: 16px;
-  color: ${props => props.theme.brand.default};
+  color: ${theme.brand.default};
   background: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 16px;
-  border: 2px solid ${props => props.theme.brand.default};
+  border: 2px solid ${theme.brand.default};
   font-weight: 700;
   transform: translateX(-50%);
 `;
@@ -60,7 +61,7 @@ export const FriendlyError = styled.p`
   font-size: 14px;
   margin: 16px 0;
   font-weight: 600;
-  color: ${props => props.theme.success.alt};
+  color: ${theme.success.alt};
   padding: 8px 12px;
   border: 2px solid #00d6a9;
   border-radius: 8px;

--- a/src/components/upsell/style.js
+++ b/src/components/upsell/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import {
@@ -12,7 +13,7 @@ import {
 import { Button } from 'src/components/buttons';
 
 export const Title = styled.h1`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   width: 100%;
   font-weight: 800;
   font-size: 24px;
@@ -47,7 +48,7 @@ export const Actions = styled.div`
 
 export const Subtitle = styled.h2`
   width: 100%;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
   font-size: 16px;
   line-height: 1.4;
@@ -60,7 +61,7 @@ export const Subtitle = styled.h2`
   }
 
   a {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
   }
 
   li {
@@ -73,7 +74,7 @@ export const CommunityUpsellSubtitle = styled(Subtitle)`
   text-align: left;
   padding: 0;
   font-size: 14px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 
   li {
     margin-top: 16px;
@@ -82,7 +83,7 @@ export const CommunityUpsellSubtitle = styled(Subtitle)`
 
 export const MiniSubtitle = styled(Subtitle)`
   font-weight: 600;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-size: 0.875rem;
   line-height: 1.4;
 `;
@@ -134,7 +135,7 @@ export const NullCol = styled(FlexCol)`
   align-self: center;
 
   > div {
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
     margin-bottom: 8px;
   }
 `;
@@ -152,7 +153,7 @@ export const NullRow = styled(FlexRow)`
 `;
 
 export const UpgradeError = styled.p`
-  color: ${props => props.theme.warn.default};
+  color: ${theme.warn.default};
   font-size: 14px;
   text-align: center;
   margin: 16px 0 0;
@@ -183,13 +184,13 @@ export const UpsellIconContainer = styled.div`
   justify-content: center;
   margin-bottom: 16px;
   margin-top: 32px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const SignupButton = styled(Button)`
   font-size: 18px;
   font-weight: 700;
-  color: ${props => props.theme.text.reverse};
+  color: ${theme.text.reverse};
   padding: 16px 88px;
   max-width: 100%;
   box-shadow: ${props =>
@@ -202,15 +203,15 @@ export const SignupFooter = styled.div`
   justify-content: center;
   padding: 16px;
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
-  border-top: 2px solid ${props => props.theme.bg.wash};
+  border-top: 2px solid ${theme.bg.wash};
   margin-top: 40px;
   width: 100%;
 `;
 
 export const SigninLink = styled.span`
-  color: ${props => props.theme.brand.default};
+  color: ${theme.brand.default};
   margin-left: 6px;
   cursor: pointer;
 `;
@@ -229,7 +230,7 @@ export const CodeOfConduct = styled.p`
   display: inline-block;
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   border-radius: 8px;
   margin-top: 64px;
   margin-left: 32px;
@@ -239,7 +240,7 @@ export const CodeOfConduct = styled.p`
   z-index: ${zIndex.card + 1};
 
   a {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
     font-weight: 600;
   }
 `;
@@ -273,7 +274,7 @@ export const SigninButton = styled.a`
   flex-direction: flex-row;
   align-self: flex-start;
   align-items: center;
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
   border-radius: 8px;
   padding: 8px;
   padding-right: 16px;
@@ -339,7 +340,7 @@ export const ButtonTwitter = styled(SigninButton)`
         : 'rgba(255,255,255,0.8)'};
 
   &:after {
-    color: ${props => props.theme.social.twitter.default};
+    color: ${theme.social.twitter.default};
   }
 
   &:hover {
@@ -359,7 +360,7 @@ export const ButtonFacebook = styled(SigninButton)`
         : 'rgba(255,255,255,0.8)'};
 
   &:after {
-    color: ${props => props.theme.social.facebook.default};
+    color: ${theme.social.facebook.default};
   }
 
   &:hover {
@@ -379,7 +380,7 @@ export const ButtonGoogle = styled(SigninButton)`
         : 'rgba(255,255,255,0.8)'};
 
   &:after {
-    color: ${props => props.theme.social.google.default};
+    color: ${theme.social.google.default};
   }
 
   &:hover {
@@ -396,14 +397,14 @@ export const ShareInputContainer = styled.div`
 
 export const JoinChannelContainer = styled.div`
   display: flex;
-  border: 1px solid ${props => props.theme.bg.border};
+  border: 1px solid ${theme.bg.border};
   border-radius: 4px;
   padding: 16px 24px;
   align-items: center;
   flex: 1 0 auto;
   width: calc(100% - 24px);
   margin-bottom: 12px;
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
 
   @media (max-width: 768px) {
     flex-direction: column;
@@ -427,11 +428,11 @@ export const JoinChannelContent = styled.div`
 export const JoinChannelTitle = styled.h3`
   font-size: 18px;
   font-weight: 600;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const JoinChannelSubtitle = styled.h4`
   font-size: 16px;
   font-weight: 400;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
 `;

--- a/src/components/usernameSearch/style.js
+++ b/src/components/usernameSearch/style.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { Transition } from '../globals';
@@ -16,7 +17,7 @@ export const StyledLabel = styled.label`
   font-weight: 500;
   font-size: 14px;
   letter-spacing: -0.4px;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   transition: ${Transition.hover.off};
   position: relative;
   margin-top: ${props => (props.size === 'small' ? '12px' : 0)};
@@ -51,20 +52,20 @@ export const StyledInput = styled.input`
   transition: ${Transition.hover.off};
 
   &::placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &::-webkit-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-moz-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
   &:-ms-input-placeholder {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   &:focus {
-    border-color: ${({ theme }) => theme.brand.default};
+    border-color: ${theme.brand.default};
     transition: ${Transition.hover.on};
   }
 `;

--- a/src/components/viewError/style.js
+++ b/src/components/viewError/style.js
@@ -1,11 +1,12 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 
 export const FillSpaceError = styled.div`
   display: flex;
   flex: auto;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   justify-content: center;
   align-items: center;
   flex-direction: column;
@@ -26,7 +27,7 @@ export const LargeEmoji = styled.span`
 export const Heading = styled.h3`
   font-size: ${props => (props.small ? '18px' : '24px')};
   font-weight: ${props => (props.small ? '500' : '600')};
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   max-width: 600px;
   margin-bottom: 8px;
 `;
@@ -35,7 +36,7 @@ export const Subheading = styled.h4`
   font-size: ${props => (props.small ? '14px' : '18px')};
   font-weight: ${props => (props.small ? '400' : '500')};
   line-height: 1.4;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   max-width: 540px;
   margin-bottom: ${props => (props.small ? '16px' : '32px')};
 `;

--- a/src/routes.js
+++ b/src/routes.js
@@ -117,7 +117,7 @@ const Body = styled(FlexCol)`
   width: 100vw;
   height: 100vh;
   max-height: 100vh;
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
 `;
 
 const DashboardFallback = signedOutFallback(Dashboard, Pages);

--- a/src/views/channel/components/style.js
+++ b/src/views/channel/components/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { Card } from '../../../components/card';
@@ -11,7 +12,7 @@ export const PendingUserNotificationContainer = styled(Card)`
   flex: 1;
   font-size: 14px;
   font-weight: 600;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 
   a {
     padding: 16px;
@@ -25,5 +26,5 @@ export const PendingUserCount = styled.span`
   font-size: 14px;
   font-weight: 700;
   margin-right: 12px;
-  background: ${props => props.theme.warn.default};
+  background: ${theme.warn.default};
 `;

--- a/src/views/channel/style.js
+++ b/src/views/channel/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import Card from '../../components/card';
 import { Transition, zIndex, Truncate } from '../../components/globals';
@@ -16,7 +17,7 @@ export const Grid = styled.main`
   min-width: 100%;
   max-width: 100%;
   min-height: 100vh;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
 
   @media (max-width: 1280px) {
     grid-template-columns: 240px 1fr;
@@ -132,11 +133,11 @@ export const ColumnHeading = styled.div`
   font-weight: 500;
   padding: 8px 16px 12px;
   margin-top: 24px;
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
 `;
 
 export const SearchContainer = styled(Card)`
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
   position: relative;
   z-index: ${zIndex.search};
   width: 100%;
@@ -146,7 +147,7 @@ export const SearchContainer = styled(Card)`
 
   &:hover {
     transition: none;
-    border-bottom: 2px solid ${props => props.theme.brand.alt};
+    border-bottom: 2px solid ${theme.brand.alt};
   }
 
   @media (max-width: 768px) {
@@ -161,7 +162,7 @@ export const SearchInput = styled.input`
   align-items: center;
   cursor: pointer;
   padding: 20px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   transition: ${Transition.hover.off};
   font-size: 20px;
   font-weight: 800;
@@ -171,19 +172,19 @@ export const SearchInput = styled.input`
 `;
 
 export const MessageIconContainer = styled.div`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
 export const UserListItemContainer = styled.div`
-  border-bottom: 1px solid ${props => props.theme.bg.wash};
+  border-bottom: 1px solid ${theme.bg.wash};
 `;
 
 export const CommunityContext = styled.div`
@@ -202,7 +203,7 @@ export const CommunityName = styled.h5`
   font-size: 18px;
   font-weight: 500;
   margin-left: 16px;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
 
   ${Truncate};
 `;
@@ -213,7 +214,7 @@ export const ChannelName = styled.h3`
   margin-top: 24px;
   margin-bottom: 8px;
   margin-left: 32px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 
   @media (max-width: 768px) {
     margin-left: 0;
@@ -225,7 +226,7 @@ export const ChannelDescription = styled.h4`
   font-weight: 400;
   margin-left: 32px;
   margin-bottom: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 
   @media (max-width: 768px) {
     margin-left: 0;

--- a/src/views/channelSettings/style.js
+++ b/src/views/channelSettings/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const TokenInputWrapper = styled.div`
@@ -17,8 +18,8 @@ export const TokenInputWrapper = styled.div`
     transform: translateY(-50%);
     font-size: 10px;
     text-transform: uppercase;
-    color: ${props => props.theme.text.reverse};
-    background: ${props => props.theme.text.alt};
+    color: ${theme.text.reverse};
+    background: ${theme.text.alt};
     padding: 4px 8px;
     border-radius: 4px;
     font-weight: 700;
@@ -26,25 +27,25 @@ export const TokenInputWrapper = styled.div`
 
   &:hover {
     &:after {
-      background: ${props => props.theme.success.alt};
+      background: ${theme.success.alt};
     }
   }
 `;
 
 export const MessageIconContainer = styled.div`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
 export const UserListItemContainer = styled.div`
-  border-bottom: 1px solid ${props => props.theme.bg.wash};
+  border-bottom: 1px solid ${theme.bg.wash};
 
   &:last-of-type {
     border-bottom: none;

--- a/src/views/community/style.js
+++ b/src/views/community/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { IconButton } from '../../components/buttons';
 import Card from '../../components/card';
@@ -40,7 +41,7 @@ export const CoverButton = styled(IconButton)`
 `;
 
 export const SearchContainer = styled(Card)`
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
   position: relative;
   z-index: ${zIndex.search};
   width: 100%;
@@ -50,7 +51,7 @@ export const SearchContainer = styled(Card)`
 
   &:hover {
     transition: none;
-    border-bottom: 2px solid ${props => props.theme.brand.alt};
+    border-bottom: 2px solid ${theme.brand.alt};
   }
 
   @media (max-width: 768px) {
@@ -71,7 +72,7 @@ export const SearchInput = styled.input`
   align-items: center;
   cursor: pointer;
   padding: 20px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   transition: ${Transition.hover.off};
   font-size: 20px;
   font-weight: 800;
@@ -90,11 +91,11 @@ export const StyledButton = styled(Button)`
   margin: 24px 0;
   border-radius: 0;
   background-image: none;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 
   &:hover {
     background-color: transparent;
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
     box-shadow: none;
   }
 
@@ -116,7 +117,7 @@ export const Grid = styled.main`
   min-width: 100%;
   max-width: 100%;
   min-height: 100vh;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
 
   @media (max-width: 1280px) {
     grid-template-columns: 320px 1fr;
@@ -227,12 +228,12 @@ export const ColumnHeading = styled.div`
   font-weight: 500;
   padding: 16px;
   margin-top: 16px;
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
 `;
 
 export const ToggleNotificationsContainer = styled.div`
   display: flex;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   justify-content: center;
   align-items: center;
   height: 100%;
@@ -241,17 +242,17 @@ export const ToggleNotificationsContainer = styled.div`
 `;
 
 export const MessageIconContainer = styled.div`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
 export const UserListItemContainer = styled.div`
-  border-bottom: 1px solid ${props => props.theme.bg.wash};
+  border-bottom: 1px solid ${theme.bg.wash};
 `;

--- a/src/views/communityAnalytics/components/analyticsUpsell/style.js
+++ b/src/views/communityAnalytics/components/analyticsUpsell/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const Container = styled.div`
@@ -49,7 +50,7 @@ export const Content = styled.div`
 export const Title = styled.h2`
   font-size: 32px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin-bottom: 16px;
   line-height: 1.3;
 `;
@@ -57,14 +58,14 @@ export const Title = styled.h2`
 export const Subtitle = styled.h3`
   font-size: 18px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-bottom: 4px;
 `;
 
 export const Description = styled.p`
   font-size: 20px;
   font-weight: 400;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
   max-width: 600px;
   line-height: 1.4;
 `;
@@ -74,7 +75,7 @@ export const List = styled.ul`
   margin-top: 12px;
   font-size: 20px;
   font-weight: 400;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
   max-width: 650px;
 
   li {
@@ -110,14 +111,14 @@ export const ActionRow = styled.div`
 export const CardInfo = styled.div`
   display: flex;
   align-items: center;
-  background: ${props => props.theme.bg.border};
+  background: ${theme.bg.border};
   border-radius: 6px;
   padding: 8px 12px;
   font-size: 16px;
   margin-top: 24px;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06),
     0 1px 0 rgba(255, 255, 255, 0.3);
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
   font-weight: 500;
 
   @media (max-width: 768px) {

--- a/src/views/communityAnalytics/style.js
+++ b/src/views/communityAnalytics/style.js
@@ -1,18 +1,19 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 
 export const Heading = styled.h1`
   margin-left: 16px;
   font-size: 32px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   font-weight: 800;
 `;
 
 export const Subheading = styled.h3`
   margin-left: 16px;
   font-size: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
   line-height: 1;
   margin-bottom: 8px;
@@ -21,8 +22,8 @@ export const Subheading = styled.h3`
 export const StyledHeader = styled.div`
   display: flex;
   padding: 32px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
-  background: ${props => props.theme.bg.default};
+  border-bottom: 1px solid ${theme.bg.border};
+  background: ${theme.bg.default};
   width: 100%;
   align-items: center;
 `;
@@ -35,7 +36,7 @@ export const HeaderText = styled.div`
 
 export const StyledThreadListItem = styled.div`
   display: flex;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   padding: 16px 0;
   flex-direction: column;
 
@@ -46,39 +47,39 @@ export const StyledThreadListItem = styled.div`
 `;
 export const ThreadListItemTitle = styled.h4`
   font-size: 16px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   line-height: 1.28;
   font-weight: 500;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
 export const ThreadListItemSubtitle = styled.h5`
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1.28;
   margin-top: 4px;
 
   a:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
 export const MessageIconContainer = styled.div`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
 export const UserListItemContainer = styled.div`
   padding: 0 16px;
-  border-bottom: 1px solid ${props => props.theme.bg.wash};
+  border-bottom: 1px solid ${theme.bg.wash};
 `;

--- a/src/views/communityBilling/style.js
+++ b/src/views/communityBilling/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const EmailForm = styled.form`
@@ -15,7 +16,7 @@ export const SourceContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   padding: 12px 0;
 
   &:last-of-type {
@@ -42,7 +43,7 @@ export const SourceName = styled.p`
   line-height: 1.3;
   font-size: 15px;
   font-weight: 500;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   display: flex;
   align-items: center;
 `;
@@ -50,12 +51,12 @@ export const SourceExpiration = styled.p`
   line-height: 1.3;
   font-size: 14px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const AddCardSection = styled.section`
-  background: ${props => props.theme.bg.wash};
-  border-top: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.wash};
+  border-top: 1px solid ${theme.bg.border};
   width: calc(100% + 32px);
   padding: 16px;
   margin-top: 16px;
@@ -81,7 +82,7 @@ export const LineItem = styled.div`
 export const LineItemTotal = styled(LineItem)`
   padding: 16px 0 0;
   margin-top: 16px;
-  border-top: 1px solid ${props => props.theme.bg.border};
+  border-top: 1px solid ${theme.bg.border};
 `;
 
 export const LineItemLeft = styled.div`
@@ -100,7 +101,7 @@ export const LineItemTitle = styled.p`
   line-height: 1.6;
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   display: flex;
   align-items: center;
 `;
@@ -110,7 +111,7 @@ export const LineItemDescription = styled.p`
   margin-top: 2px;
   font-size: 14px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 
   cursor: ${props => (props.link ? 'pointer' : 'auto')};
 
@@ -121,7 +122,7 @@ export const LineItemDescription = styled.p`
 
   a {
     display: block;
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
     margin-top: 4px;
   }
 `;
@@ -130,12 +131,12 @@ export const LineItemTitleTotal = styled.p`
   line-height: 1.6;
   font-size: 15px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin-top: 8px;
 `;
 export const LineItemPrice = styled.p`
   line-height: 1.6;
   font-size: 14px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;

--- a/src/views/communityLogin/style.js
+++ b/src/views/communityLogin/style.js
@@ -1,10 +1,11 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { zIndex } from 'src/components/globals';
 
 export const Title = styled.h1`
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   width: 100%;
   font-weight: 600;
   font-size: 32px;
@@ -17,7 +18,7 @@ export const Title = styled.h1`
 
 export const Subtitle = styled.h2`
   width: 100%;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
   font-size: 20px;
   line-height: 1.4;
@@ -31,7 +32,7 @@ export const Subtitle = styled.h2`
   }
 
   a {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
   }
 
   li {
@@ -53,15 +54,15 @@ export const SignupFooter = styled.div`
   justify-content: center;
   padding: 16px;
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
-  border-top: 2px solid ${props => props.theme.bg.wash};
+  border-top: 2px solid ${theme.bg.wash};
   margin-top: 40px;
   width: 100%;
 `;
 
 export const SigninLink = styled.span`
-  color: ${props => props.theme.brand.default};
+  color: ${theme.brand.default};
   margin-left: 6px;
   cursor: pointer;
 `;
@@ -80,7 +81,7 @@ export const CodeOfConduct = styled.p`
   display: inline-block;
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   border-radius: 8px;
   margin-top: 64px;
   margin-left: 32px;
@@ -90,7 +91,7 @@ export const CodeOfConduct = styled.p`
   z-index: ${zIndex.card + 1};
 
   a {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
     font-weight: 600;
   }
 `;

--- a/src/views/communityMembers/style.js
+++ b/src/views/communityMembers/style.js
@@ -1,18 +1,19 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { TextButton } from '../../components/buttons';
 
 export const Heading = styled.h1`
   margin-left: 16px;
   font-size: 32px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   font-weight: 800;
 `;
 
 export const Subheading = styled.h3`
   margin-left: 16px;
   font-size: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
   line-height: 1;
   margin-bottom: 8px;
@@ -21,8 +22,8 @@ export const Subheading = styled.h3`
 export const StyledHeader = styled.div`
   display: flex;
   padding: 32px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
-  background: ${props => props.theme.bg.default};
+  border-bottom: 1px solid ${theme.bg.border};
+  background: ${theme.bg.default};
   width: 100%;
   align-items: center;
 `;
@@ -35,7 +36,7 @@ export const HeaderText = styled.div`
 
 export const StyledThreadListItem = styled.div`
   display: flex;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   padding: 16px 0;
   flex-direction: column;
 
@@ -46,33 +47,33 @@ export const StyledThreadListItem = styled.div`
 `;
 export const ThreadListItemTitle = styled.h4`
   font-size: 16px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   line-height: 1.28;
   font-weight: 500;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
 export const ThreadListItemSubtitle = styled.h5`
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1.28;
   margin-top: 4px;
 
   a:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
 export const CustomMessageToggle = styled.h4`
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-top: 16px;
 
   &:hover {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
     cursor: pointer;
   }
 
@@ -96,7 +97,7 @@ export const Filters = styled.ul`
   margin: 0 -16px 16px;
   padding: 0 16px;
   flex: 1;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 `;
 
 export const Filter = styled.li`
@@ -115,7 +116,7 @@ export const Filter = styled.li`
     ${props => (props.active ? props.theme.text.default : 'transparent')};
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
@@ -125,14 +126,14 @@ export const SearchForm = styled.form`
   justify-content: flex-start;
   position: relative;
   flex: auto;
-  color: ${props => props.theme.brand.alt};
+  color: ${theme.brand.alt};
 
   .icon:first-of-type {
     position: absolute;
     left: -6px;
     top: 0px;
     pointer-events: none;
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
   }
 
   .icon:last-of-type {
@@ -164,7 +165,7 @@ export const SearchInput = styled.input`
   background: transparent;
 
   &:focus {
-    border-bottom: 1px solid ${props => props.theme.text.default};
+    border-bottom: 1px solid ${theme.text.default};
   }
 `;
 
@@ -175,11 +176,11 @@ export const FetchMore = styled(TextButton)`
   padding: 8px 16px;
   align-items: center;
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   cursor: pointer;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
@@ -199,8 +200,8 @@ export const TokenInputWrapper = styled.div`
     transform: translateY(-50%);
     font-size: 10px;
     text-transform: uppercase;
-    color: ${props => props.theme.text.reverse};
-    background: ${props => props.theme.text.alt};
+    color: ${theme.text.reverse};
+    background: ${theme.text.alt};
     padding: 4px 8px;
     border-radius: 4px;
     font-weight: 700;
@@ -208,7 +209,7 @@ export const TokenInputWrapper = styled.div`
 
   &:hover {
     &:after {
-      background: ${props => props.theme.success.alt};
+      background: ${theme.success.alt};
     }
   }
 `;

--- a/src/views/communitySettings/components/slack/style.js
+++ b/src/views/communitySettings/components/slack/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { hexa } from 'src/components/globals';
 
@@ -17,12 +18,12 @@ export const SlackChannelRow = styled.div`
 export const ChannelName = styled.div`
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   flex: 1 0 auto;
 `;
 
 export const StyledSelect = styled.div`
-  border: 1px solid ${props => props.theme.bg.border};
+  border: 1px solid ${theme.bg.border};
   border-radius: 4px;
   overflow: hidden;
 `;
@@ -32,17 +33,17 @@ export const Select = styled.select`
   width: 130%;
   border: none;
   box-shadow: none;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   background-image: none;
   -webkit-appearance: none;
   font-weight: 400;
   font-size: 14px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const SendsTo = styled.div`
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   flex: none;
   margin-right: 12px;
   margin-left: 4px;

--- a/src/views/communitySettings/style.js
+++ b/src/views/communitySettings/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 import Card from '../../components/card';
 import Link from 'src/components/link';
 import { FlexCol, H1, H2, H3, Span, Tooltip } from '../../components/globals';
@@ -7,14 +8,14 @@ export const ListHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
   padding-bottom: 16px;
 `;
 
 export const ListHeading = styled(H3)`
   font-weight: 800;
   font-size: 20px;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const ListContainer = styled(FlexCol)`
@@ -25,7 +26,7 @@ export const ListContainer = styled(FlexCol)`
 export const MoreLink = styled(Link)`
   font-size: 14px;
   font-weight: 700;
-  color: ${({ theme }) => theme.brand.alt};
+  color: ${theme.brand.alt};
 `;
 
 export const StyledCard = styled(Card)`
@@ -70,7 +71,7 @@ export const EmailInviteInput = styled.input`
   }
 
   &:focus {
-    border: 2px solid ${props => props.theme.brand.default};
+    border: 2px solid ${theme.brand.default};
   }
 
   @media screen and (max-width: 768px) {
@@ -83,27 +84,27 @@ export const AddRow = styled.div`
   width: 100%;
   justify-content: center;
   padding: 8px;
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
   margin-top: 8px;
   margin-bottom: 16px;
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
   border-radius: 4px;
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
     cursor: pointer;
   }
 `;
 
 export const RemoveRow = styled.div`
   margin-left: 4px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 
   &:hover {
     cursor: pointer;
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
@@ -154,7 +155,7 @@ export const CostNumber = styled(H2)`
   vertical-align: baseline;
   position: relative;
   left: -16px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 
   &:before {
     content: '$';
@@ -165,12 +166,12 @@ export const CostNumber = styled(H2)`
     font-weight: 400;
     font-size: 20px;
     letter-spacing: normal;
-    color: ${({ theme }) => theme.text.alt};
+    color: ${theme.text.alt};
   }
 
   &:after {
     content: ${props => (props.per ? `'/ ${props.per}'` : "''")};
-    color: ${({ theme }) => theme.text.alt};
+    color: ${theme.text.alt};
     position: absolute;
     font-size: 14px;
     white-space: nowrap;
@@ -182,7 +183,7 @@ export const CostNumber = styled(H2)`
 `;
 
 export const CostPer = styled(Span)`
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   position: relative;
   left: -12px;
   font-weight: 500;
@@ -190,7 +191,7 @@ export const CostPer = styled(Span)`
 `;
 
 export const CostSubtext = styled(FlexCol)`
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   flex: none;
   margin-bottom: 24px;
   justify-content: flex-start;
@@ -222,7 +223,7 @@ export const GrowthText = styled.h5`
 `;
 
 export const MessageIcon = styled.div`
-  color: ${props => props.theme.brand.alt};
+  color: ${theme.brand.alt};
   cursor: pointer;
   ${Tooltip} top: 2px;
 `;

--- a/src/views/dashboard/components/inboxThread/style.js
+++ b/src/views/dashboard/components/inboxThread/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import { zIndex, Tooltip } from 'src/components/globals';
@@ -105,8 +106,12 @@ export const CountWrapper = styled.div`
   font-size: 13px;
   color: ${props =>
     props.new
-      ? props.active ? props.theme.text.reverse : props.theme.warn.alt
-      : props.active ? props.theme.text.reverse : props.theme.text.alt};
+      ? props.active
+        ? props.theme.text.reverse
+        : props.theme.warn.alt
+      : props.active
+        ? props.theme.text.reverse
+        : props.theme.text.alt};
   font-weight: 600;
   align-items: center;
 
@@ -119,7 +124,7 @@ export const CountWrapper = styled.div`
   }
 
   a:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   ${Tooltip};

--- a/src/views/dashboard/components/newActivityIndicator.js
+++ b/src/views/dashboard/components/newActivityIndicator.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
+import theme from 'shared/theme';
 import { connect } from 'react-redux';
 import { clearActivityIndicator } from '../../../actions/newActivityIndicator';
 import styled from 'styled-components';
 
 const NewActivityBar = styled.div`
   padding: ${props => (props.refetching ? '8px' : '8px 16px')};
-  color: ${props => props.theme.brand.alt};
-  background: ${props => props.theme.bg.wash};
+  color: ${theme.brand.alt};
+  background: ${theme.bg.wash};
   font-size: 14px;
   font-weight: 600;
   display: ${props => (props.active ? 'flex' : 'none')};
@@ -15,8 +16,8 @@ const NewActivityBar = styled.div`
   align-self: center;
   padding: 12px 16px;
   height: 40px;
-  border-top: 1px solid ${props => props.theme.bg.border};
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-top: 1px solid ${theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   z-index: 10;
   position: relative;
   cursor: pointer;
@@ -31,15 +32,15 @@ const NewActivityBar = styled.div`
   }
 
   &:hover {
-    background: ${props => props.theme.brand.alt};
-    color: ${props => props.theme.text.reverse};
+    background: ${theme.brand.alt};
+    color: ${theme.text.reverse};
   }
 `;
 
 const scrollTo = (element, to, duration) => {
   if (duration < 0) return;
   const difference = to - element.scrollTop;
-  const perTick = difference / duration * 2;
+  const perTick = (difference / duration) * 2;
 
   setTimeout(() => {
     element.scrollTop = element.scrollTop + perTick;

--- a/src/views/dashboard/style.js
+++ b/src/views/dashboard/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css, keyframes } from 'styled-components';
 import {
   zIndex,
@@ -15,7 +16,7 @@ export const DashboardWrapper = styled.main`
   overflow-y: hidden;
   flex: auto;
   width: 100%;
-  box-shadow: 1px 0 0 ${props => props.theme.bg.border};
+  box-shadow: 1px 0 0 ${theme.bg.border};
 
   @media (max-width: 768px) {
     flex-direction: column;
@@ -30,8 +31,8 @@ export const InboxWrapper = styled.div`
   position: relative;
   align-self: stretch;
   flex-direction: column;
-  background: ${props => props.theme.bg.default};
-  border-right: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.default};
+  border-right: 1px solid ${theme.bg.border};
 
   @media (min-resolution: 120dpi) {
     max-width: 440px;
@@ -61,7 +62,7 @@ export const Sidebar = styled.div`
   position: relative;
   align-self: stretch;
   flex-direction: column;
-  border-right: 1px solid ${props => props.theme.bg.border};
+  border-right: 1px solid ${theme.bg.border};
 
   @media (max-width: 1280px) {
     display: none;
@@ -72,7 +73,7 @@ export const SectionTitle = styled.span`
   display: inline-block;
   font-size: 12px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-variant: small-caps;
   text-transform: lowercase;
   margin: 8px 16px;
@@ -87,7 +88,7 @@ export const ChannelsContainer = styled.div`
   padding: 4px;
 
   ${SectionTitle} {
-    color: ${props => props.theme.text.placeholder};
+    color: ${theme.text.placeholder};
     margin: 8px 8px 4px 8px;
   }
 `;
@@ -127,7 +128,7 @@ export const ChannelListItem = styled.div`
   }
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 
 `;
@@ -166,9 +167,9 @@ export const LoadingBar = styled.div`
   animation-timing-function: ease-in-out;
   background: linear-gradient(
     to right,
-    ${({ theme }) => theme.bg.wash} 10%,
+    ${theme.bg.wash} 10%,
     ${({ theme }) => hexa(theme.generic.default, 0.65)} 20%,
-    ${({ theme }) => theme.bg.wash} 30%
+    ${theme.bg.wash} 30%
   );
   animation-name: ${placeHolderShimmer};
 `;
@@ -223,10 +224,9 @@ export const CommunityListItem = styled.div`
     `};
 
   &:hover {
-    background: ${props => props.theme.bg.default};
-    color: ${props => props.theme.text.default};
-    box-shadow: 0 1px 0 ${props => props.theme.bg.border},
-      0 -1px 0 ${props => props.theme.bg.border};
+    background: ${theme.bg.default};
+    color: ${theme.text.default};
+    box-shadow: 0 1px 0 ${theme.bg.border}, 0 -1px 0 ${theme.bg.border};
 
     img {
       box-shadow: 0;
@@ -245,7 +245,7 @@ export const CommunityListScroller = styled.div`
 
 export const CommunityListWrapper = styled.div`
   flex: auto;
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
   display: grid;
   grid-template-rows: 1fr auto;
   grid-template-columns: 1fr;
@@ -258,15 +258,15 @@ export const CommunityListWrapper = styled.div`
 export const Fixed = styled.div`
   grid-area: fixed;
   width: 100%;
-  box-shadow: 0 -1px 0 ${props => props.theme.bg.border};
+  box-shadow: 0 -1px 0 ${theme.bg.border};
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
-    background: ${props => props.theme.bg.default};
+    color: ${theme.brand.alt};
+    background: ${theme.bg.default};
 
     div {
-      color: ${props => props.theme.brand.alt};
-      background: ${props => props.theme.bg.default};
+      color: ${theme.brand.alt};
+      background: ${theme.bg.default};
     }
   }
 `;
@@ -282,7 +282,7 @@ export const CommunityListAvatar = styled.img`
 `;
 
 export const FeedHeaderContainer = styled.div`
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   padding: 16px 8px;
   box-shadow: ${Shadow.low} ${props => hexa(props.theme.bg.reverse, 0.15)};
   position: relative;
@@ -299,7 +299,7 @@ export const ThreadWrapper = styled.div`
   overflow-y: hidden;
   position: relative;
   align-self: stretch;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
 
   @media (max-width: 768px) {
     display: none;
@@ -336,7 +336,7 @@ export const HeaderWrapper = styled.div`
 
 export const ThreadComposerContainer = styled.div`
   padding: 16px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 
   @media (max-width: 768px) {
     margin: 0;
@@ -346,14 +346,14 @@ export const ThreadComposerContainer = styled.div`
 export const ComposeIconContainer = styled.div`
   position: relative;
   top: 2px;
-  color: ${props => props.theme.brand.alt};
+  color: ${theme.brand.alt};
   display: flex;
   align-items: center;
   font-weight: 600;
   cursor: pointer;
 
   &:hover {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
   }
 
   div {
@@ -369,13 +369,13 @@ export const NullThreadFeed = styled.div`
   justify-content: center;
   padding: 32px;
   flex-direction: column;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
 `;
 
 export const NullHeading = styled.p`
   font-size: 18px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   text-align: center;
   margin-bottom: 8px;
 `;
@@ -391,7 +391,7 @@ export const PinIcon = styled.span`
 `;
 
 export const UpsellExploreDivider = styled.div`
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   display: block;
   width: 100%;
   margin: 16px 0 16px;
@@ -429,17 +429,17 @@ export const ClearSearch = styled.span`
   width: 16px;
   height: 16px;
   opacity: ${props => (props.isVisible ? '1' : '0')};
-  background: ${props => props.theme.text.placeholder};
+  background: ${theme.text.placeholder};
   border-radius: 50%;
   font-size: 16px;
-  color: ${props => props.theme.text.reverse};
+  color: ${theme.text.reverse};
   font-weight: 500;
   pointer-events: ${props => (props.isOpen ? 'auto' : 'none')};
   cursor: pointer;
   transition: background 0.2s;
 
   &:hover {
-    background: ${props => props.theme.text.alt};
+    background: ${theme.text.alt};
   }
 
   span {
@@ -453,8 +453,8 @@ export const SearchForm = styled.form`
   height: 32px;
   min-height: 32px;
   max-height: 32px;
-  color: ${props => props.theme.text.alt};
-  border: 1px solid ${props => props.theme.bg.border};
+  color: ${theme.text.alt};
+  border: 1px solid ${theme.bg.border};
   border-radius: 16px;
   grid-template-columns: 32px 1fr 32px;
   grid-template-rows: 1fr;
@@ -470,13 +470,13 @@ export const SearchForm = styled.form`
     css`
       border-color: transparent;
       background-color: ${props => hexa(props.theme.text.alt, 0.35)};
-      color: ${props => props.theme.text.reverse};
+      color: ${theme.text.reverse};
     `};
 
   > div:last-of-type {
     display: ${props => (props.isOpen ? 'flex' : 'none')};
-    color: ${props => props.theme.text.reverse};
-    background-color: ${props => props.theme.text.alt};
+    color: ${theme.text.reverse};
+    background-color: ${theme.text.alt};
     border-radius: 100%;
     padding: 4px;
     align-items: center;
@@ -491,8 +491,8 @@ export const OutlineButton = styled.button`
   background-color: transparent;
   font-size: 14px;
   font-weight: 700;
-  border: 2px solid ${props => props.theme.text.alt};
-  color: ${props => props.theme.text.alt};
+  border: 2px solid ${theme.text.alt};
+  color: ${theme.text.alt};
   border-radius: 8px;
   padding: 4px 12px 4px 6px;
 
@@ -505,12 +505,12 @@ export const SearchStringHeader = styled.div`
   background: #fff;
   padding: 16px;
   font-weight: 600;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 `;
 
 export const Hint = styled.span`
   font-size: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-top: 32px;
   margin-bottom: 8px;
 `;
@@ -535,14 +535,14 @@ export const HeaderActiveViewTitle = styled.h2`
   padding: 0 8px;
   font-size: 24px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   max-width: 384px;
   line-height: 1.2;
 
   ${Truncate};
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
@@ -550,7 +550,7 @@ export const HeaderActiveViewSubtitle = styled.h3`
   padding: 0 8px;
   font-size: 14px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   max-width: 384px;
   line-height: 1.2;
 
@@ -560,7 +560,7 @@ export const HeaderActiveViewSubtitle = styled.h3`
   ${Truncate};
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
@@ -574,8 +574,8 @@ export const EllipsisText = styled.div`
 `;
 
 export const PendingBadge = styled.div`
-  background: ${props => props.theme.warn.alt};
-  color: ${props => props.theme.text.reverse};
+  background: ${theme.warn.alt};
+  color: ${theme.text.reverse};
   padding: 0 8px;
   border-radius: 24px;
   font-size: 12px;

--- a/src/views/dashboardThread/style.js
+++ b/src/views/dashboardThread/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { zIndex } from '../../components/globals';
@@ -15,7 +16,7 @@ export const Container = styled.div`
 
 export const Thread = styled.div`
   display: flex;
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
   flex: auto;
   z-index: ${zIndex.chrome - 2};
   flex-direction: column;
@@ -51,7 +52,7 @@ export const NullThread = styled.div`
 export const Heading = styled.h3`
   font-size: 24px;
   font-weight: 700;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin: 48px 24px 16px;
   text-align: center;
 `;
@@ -59,7 +60,7 @@ export const Heading = styled.h3`
 export const Subheading = styled.h4`
   font-size: 18px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin: 0 48px 32px;
   max-width: 600px;
   text-align: center;

--- a/src/views/directMessages/components/style.js
+++ b/src/views/directMessages/components/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import Link from 'src/components/link';
 import { UserAvatar } from 'src/components/avatar';
@@ -37,12 +38,12 @@ export const Wrapper = styled(FlexCol)`
     bottom: 0;
     left: 16px;
     width: calc(100% - 16px);
-    border-bottom: 1px solid ${props => props.theme.bg.wash};
+    border-bottom: 1px solid ${theme.bg.wash};
   }
 
   &:hover {
     cursor: pointer;
-    background: ${props => props.theme.bg.wash};
+    background: ${theme.bg.wash};
   }
 `;
 
@@ -84,7 +85,7 @@ export const Meta = styled(H4)`
 export const Description = styled(P)`
   margin-top: 8px;
   font-weight: 400;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const MessageGroupTextContainer = styled.div`
@@ -110,7 +111,7 @@ export const Usernames = styled.span`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   font-weight: ${props => (props.isUnread ? 800 : 600)};
   line-height: 1.1;
   margin-bottom: 1px;
@@ -224,8 +225,8 @@ export const Remainder = styled.span`
   padding: 0 2px;
   font-size: 9px;
   font-weight: 700;
-  color: ${props => props.theme.text.alt};
-  background: ${props => props.theme.bg.wash};
+  color: ${theme.text.alt};
+  background: ${theme.bg.wash};
   margin: 2px 1px 1px 2px;
   overflow: hidden;
   display: flex;
@@ -246,7 +247,7 @@ export const Grow = styled.div`
   flex: 1 1 auto;
   justify-content: center;
   align-items: stretch;
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
   width: 100%;
   height: 100%;
 `;
@@ -255,7 +256,7 @@ export const ComposerInput = styled.input`
   font-size: 16px;
   padding: 15px 16px;
   width: 100%;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   position: relative;
   z-index: ${zIndex.search};
 
@@ -296,7 +297,7 @@ export const SearchResultsDropdown = styled.ul`
 export const SearchResult = styled.li`
   display: flex;
   align-items: center;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   background: ${props => (props.focused ? props.theme.bg.wash : '#fff')};
   width: 100%;
   ${Truncate()} padding: 8px 16px 8px 8px;
@@ -310,7 +311,7 @@ export const SearchResult = styled.li`
   }
 
   &:hover {
-    background: ${props => props.theme.bg.wash};
+    background: ${theme.bg.wash};
     cursor: pointer;
   }
 `;
@@ -327,14 +328,14 @@ export const SearchResultTextContainer = styled.div`
 export const SearchResultDisplayName = styled.p`
   font-size: 14px;
   font-weight: 600;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   line-height: 1.4;
 `;
 
 export const SearchResultUsername = styled.p`
   font-size: 12px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1.4;
 `;
 
@@ -342,7 +343,7 @@ export const SearchResultNull = styled.p`
   text-align: center;
   font-size: 14px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const SelectedUsersPills = styled.ul`
@@ -401,7 +402,7 @@ export const Names = styled.h2`
   display: block;
   font-weight: 800;
   font-size: 24px;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   text-align: center;
   line-height: 1.4;
 `;
@@ -410,7 +411,7 @@ export const Username = styled.h3`
   display: block;
   font-weight: 500;
   font-size: 14px;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   margin: 0;
   display: flex;
 `;

--- a/src/views/directMessages/style.js
+++ b/src/views/directMessages/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import { FlexCol, FlexRow } from '../../components/globals';
 
@@ -33,8 +34,8 @@ export const MessagesList = styled(FlexCol)`
   max-width: 400px;
   flex: 0 0 25%;
   min-width: 320px;
-  background: ${props => props.theme.bg.default};
-  border-right: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.default};
+  border-right: 1px solid ${theme.bg.border};
   flex: 1 0 auto;
   max-height: 100%;
 
@@ -82,8 +83,8 @@ export const NoThreads = MessagesContainer.extend`
 export const ComposeHeader = styled(FlexRow)`
   justify-content: flex-end;
   padding: 8px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
-  color: ${props => props.theme.brand.default};
+  border-bottom: 1px solid ${theme.bg.border};
+  color: ${theme.brand.default};
 
   @media (max-width: 768px) {
     display: none;

--- a/src/views/explore/components/communitySearchWrapper.js
+++ b/src/views/explore/components/communitySearchWrapper.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 import styled from 'styled-components';
 import Link from 'src/components/link';
@@ -32,15 +33,15 @@ const CommunitySearchWrapper = props => {
     font-weight: 700;
     font-size: 14px;
     border-radius: 12px;
-    background-color: ${props => props.theme.bg.default};
+    background-color: ${theme.bg.default};
     background-image: none;
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
     transition: ${Transition.hover.off};
     z-index: ${zIndex.card};
 
     &:hover {
-      background-color: ${props => props.theme.bg.default};
-      color: ${props => props.theme.brand.default};
+      background-color: ${theme.bg.default};
+      color: ${theme.brand.default};
       box-shadow: ${Shadow.high} ${props => hexa(props.theme.bg.reverse, 0.5)};
       transition: ${Transition.hover.on};
     }

--- a/src/views/explore/style.js
+++ b/src/views/explore/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 // $FlowFixMe
@@ -32,7 +33,7 @@ export const Wrapper = styled.main`
   align-items: stretch;
   flex: 1 0 auto;
   width: 100%;
-  background-color: ${({ theme }) => theme.bg.default};
+  background-color: ${theme.bg.default};
   overflow: auto;
   overflow-x: hidden;
   z-index: ${zIndex.base};
@@ -44,7 +45,7 @@ export const ViewTitle = styled(H1)`
   margin-top: 48px;
   font-size: 32px;
   font-weight: 900;
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
   position: relative;
   z-index: ${zIndex.base};
 
@@ -56,7 +57,7 @@ export const ViewTitle = styled(H1)`
 
 export const ViewSubtitle = styled(H2)`
   margin-left: 48px;
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
   position: relative;
   z-index: ${zIndex.base};
 
@@ -104,7 +105,7 @@ export const ViewHeader = styled(Section)`
   flex: none;
   padding: 120px 0 0 0;
   justify-content: flex-end;
-  background-color: ${({ theme }) => theme.space.dark};
+  background-color: ${theme.space.dark};
   background-image: ${({ theme }) =>
     `radial-gradient(farthest-corner at 50% 100%, ${hexa(
       theme.brand.alt,
@@ -126,7 +127,7 @@ export const SectionWithGradientTransition = styled(Section)`
 `;
 
 export const SectionTitle = styled(H2)`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   margin-left: 16px;
   font-size: 32px;
   margin-bottom: 16px;
@@ -138,7 +139,7 @@ export const SectionTitle = styled(H2)`
 `;
 
 export const SectionSubtitle = styled(H3)`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   margin-bottom: 8px;
   margin-left: 48px;
 
@@ -169,8 +170,8 @@ export const Item = styled(FlexCol)`
   padding: 16px;
   flex: 0 0 280px;
   flex-order: ${props => (props.active ? '2' : '1')};
-  background-color: ${({ theme }) => theme.bg.default};
-  color: ${({ theme }) => theme.text.default};
+  background-color: ${theme.bg.default};
+  color: ${theme.text.default};
   border-radius: 16px;
   margin-right: 24px;
   justify-content: space-between;
@@ -188,17 +189,17 @@ export const Item = styled(FlexCol)`
 
 export const ItemTitle = styled(H2)`
   font-weight: 700;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const ItemCopy = styled(P)`
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   margin: 8px 0;
 `;
 
 export const ItemMeta = styled(ItemCopy)`
   font-weight: 900;
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
 `;
 
 export const ButtonContainer = styled(FlexRow)`
@@ -212,7 +213,7 @@ export const ButtonContainer = styled(FlexRow)`
 
 export const ItemButton = styled(Button)`
   font-weight: 700;
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
   background-color: ${props =>
     props.joined ? props.theme.bg.inactive : props.theme.brand.default};
   background-image: ${props =>
@@ -276,7 +277,7 @@ export const SearchWrapper = styled(Card)`
 
 export const SearchInputWrapper = styled(FlexRow)`
   flex: auto;
-  color: ${props => props.theme.text.placeholder};
+  color: ${theme.text.placeholder};
 `;
 
 export const SearchIcon = styled(Icon)``;
@@ -313,7 +314,7 @@ export const SearchResultsDropdown = styled.ul`
   flex: auto;
   max-height: 400px;
   overflow-y: auto;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
 
   @media (max-width: 768px) {
     border-radius: 0 0 8px 8px;
@@ -334,15 +335,15 @@ export const SearchResult = styled.li`
     ${props => (props.focused ? 'transparent' : props.theme.bg.border)};
 
   &:hover {
-    background: ${props => props.theme.brand.alt};
+    background: ${theme.brand.alt};
     cursor: pointer;
 
     h2 {
-      color: ${props => props.theme.text.reverse};
+      color: ${theme.text.reverse};
     }
 
     p {
-      color: ${props => props.theme.text.reverse};
+      color: ${theme.text.reverse};
     }
   }
 
@@ -396,14 +397,14 @@ export const SearchResultNull = styled.div`
   justify-content: center;
   align-items: center;
   padding: 24px;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
   border: 0;
 
   &:hover {
     border: 0;
 
     p {
-      color: ${props => props.theme.text.alt};
+      color: ${theme.text.alt};
     }
   }
 
@@ -415,7 +416,7 @@ export const SearchResultNull = styled.div`
     text-align: center;
     font-size: 14px;
     font-weight: 400;
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
     text-align: center;
     font-size: 18px;
     font-weight: 600;
@@ -427,7 +428,7 @@ export const ListWithTitle = styled(FlexCol)`
 `;
 
 export const ListTitle = styled(H2)`
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   padding-bottom: 8px;
   padding-left: 16px;
   font-weight: 500;

--- a/src/views/explore/view.js
+++ b/src/views/explore/view.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import * as React from 'react';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
@@ -31,8 +32,8 @@ const ChartGrid = styled.div`
 const ThisSegment = styled(Segment)`
   @media (max-width: 768px) {
     &:first-of-type {
-      color: ${props => props.theme.text.alt};
-      border-bottom: 2px solid ${props => props.theme.bg.border};
+      color: ${theme.text.alt};
+      border-bottom: 2px solid ${theme.bg.border};
     }
     &:not(:first-of-type) {
       display: none;

--- a/src/views/login/style.js
+++ b/src/views/login/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import {
@@ -12,7 +13,7 @@ import {
 import { Button } from '../../components/buttons';
 
 export const Title = styled.h1`
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   width: 100%;
   font-weight: 800;
   font-size: 24px;
@@ -53,7 +54,7 @@ export const Actions = styled.div`
 
 export const Subtitle = styled.h2`
   width: 100%;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
   font-size: 16px;
   line-height: 1.4;
@@ -66,7 +67,7 @@ export const Subtitle = styled.h2`
   }
 
   a {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
   }
 
   li {
@@ -81,7 +82,7 @@ export const LargeSubtitle = styled(Subtitle)`
 
 export const MiniSubtitle = styled(Subtitle)`
   font-weight: 600;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-size: 0.875rem;
   line-height: 1.4;
 `;
@@ -127,7 +128,7 @@ export const NullRow = styled(FlexRow)`
 `;
 
 export const UpgradeError = styled.p`
-  color: ${props => props.theme.warn.default};
+  color: ${theme.warn.default};
   font-size: 14px;
   text-align: center;
   margin: 16px 0 0;
@@ -144,13 +145,13 @@ export const Profile = styled.div`
   }
 
   span {
-    background-color: ${({ theme }) => theme.success.default};
+    background-color: ${theme.success.default};
     background-image: ${({ theme }) =>
       Gradient(theme.success.alt, theme.success.default)};
     position: absolute;
     left: 75%;
     top: 48px;
-    color: ${({ theme }) => theme.text.reverse};
+    color: ${theme.text.reverse};
     font-size: 10px;
     font-weight: 800;
     padding: 2px 4px;
@@ -167,13 +168,13 @@ export const UpsellIconContainer = styled.div`
   justify-content: center;
   margin-bottom: 16px;
   margin-top: 32px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const SignupButton = styled(Button)`
   font-size: 18px;
   font-weight: 700;
-  color: ${props => props.theme.text.reverse};
+  color: ${theme.text.reverse};
   padding: 16px 88px;
   max-width: 100%;
   box-shadow: ${props =>
@@ -186,15 +187,15 @@ export const SignupFooter = styled.div`
   justify-content: center;
   padding: 16px;
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
-  border-top: 2px solid ${props => props.theme.bg.wash};
+  border-top: 2px solid ${theme.bg.wash};
   margin-top: 40px;
   width: 100%;
 `;
 
 export const SigninLink = styled.span`
-  color: ${props => props.theme.brand.default};
+  color: ${theme.brand.default};
   margin-left: 6px;
   cursor: pointer;
 `;
@@ -213,7 +214,7 @@ export const CodeOfConduct = styled.p`
   display: inline-block;
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   border-radius: 8px;
   margin-top: 64px;
   margin-left: 32px;
@@ -223,7 +224,7 @@ export const CodeOfConduct = styled.p`
   z-index: ${zIndex.card + 1};
 
   a {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
     font-weight: 600;
   }
 `;

--- a/src/views/navbar/components/profileDropdown.js
+++ b/src/views/navbar/components/profileDropdown.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
@@ -31,15 +32,15 @@ const UserProfileDropdownListItem = styled.li`
   flex: 1;
   font-size: 14px;
   font-weight: 600;
-  color: ${props => props.theme.text.alt};
-  border-bottom: 2px solid ${props => props.theme.bg.border};
-  background: ${props => props.theme.bg.default};
+  color: ${theme.text.alt};
+  border-bottom: 2px solid ${theme.bg.border};
+  background: ${theme.bg.default};
   justify-content: center;
 
   &:hover {
     cursor: pointer;
-    color: ${props => props.theme.text.default};
-    background: ${props => props.theme.bg.wash};
+    color: ${theme.text.default};
+    background: ${theme.bg.wash};
   }
 `;
 

--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import { Transition, FlexRow, hexa, zIndex } from 'src/components/globals';
@@ -111,14 +112,14 @@ export const Tab = styled(Link)`
   @media (min-width: 768px) {
     &[data-active~='true'] {
       box-shadow: inset 0 ${isDesktopApp() ? '-2px' : '-4px'} 0
-        ${({ theme }) => theme.text.reverse};
-      color: ${props => props.theme.text.reverse};
+        ${theme.text.reverse};
+      color: ${theme.text.reverse};
       transition: ${Transition.hover.on};
 
       &:hover,
       &:focus {
         box-shadow: inset 0 ${isDesktopApp() ? '-2px' : '-4px'} 0
-          ${({ theme }) => theme.text.reverse};
+          ${theme.text.reverse};
         transition: ${Transition.hover.on};
       }
     }
@@ -130,7 +131,7 @@ export const Tab = styled(Link)`
           process.env.NODE_ENV === 'production'
             ? theme.text.placeholder
             : theme.warn.border};
-      color: ${props => props.theme.text.reverse};
+      color: ${theme.text.reverse};
       transition: ${Transition.hover.on};
     }
   }
@@ -147,7 +148,7 @@ export const Tab = styled(Link)`
     align-content: center;
 
     &[data-active~='true'] {
-      color: ${props => props.theme.text.reverse};
+      color: ${theme.text.reverse};
       transition: ${Transition.hover.on};
     }
   }
@@ -169,7 +170,7 @@ export const DropTab = styled(FlexRow)`
       props.padOnHover &&
       css`
         @media (min-width: 768px) {
-          color: ${props => props.theme.text.reverse};
+          color: ${theme.text.reverse};
           padding-left: 120px;
         }
       `};
@@ -213,7 +214,7 @@ export const DropTab = styled(FlexRow)`
 export const Logo = styled(Tab)`
   grid-area: logo;
   padding: ${isDesktopApp() ? '0 32px 0 4px' : '0 24px 0 4px'};
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
   opacity: 1;
 
   ${isDesktopApp() &&
@@ -320,7 +321,7 @@ export const ProfileTab = styled(Tab)`
 export const Navatar = styled(UserAvatar)`
   margin-top: 0;
   border-radius: 100%;
-  box-shadow: 0 0 0 2px ${props => props.theme.bg.default};
+  box-shadow: 0 0 0 2px ${theme.bg.default};
 `;
 
 export const LoggedOutSection = styled(FlexRow)`
@@ -352,7 +353,7 @@ export const SigninLink = styled(Link)`
 `;
 
 export const DropdownHeader = styled(FlexRow)`
-  border-bottom: 2px solid ${({ theme }) => theme.bg.wash};
+  border-bottom: 2px solid ${theme.bg.wash};
   flex: 0 0 auto;
   align-self: stretch;
   justify-content: space-between;
@@ -360,20 +361,20 @@ export const DropdownHeader = styled(FlexRow)`
   padding: 8px 16px;
   font-weight: 500;
   font-size: 14px;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
 
   a {
     display: flex;
     align-items: center;
 
     &:hover {
-      color: ${props => props.theme.brand.alt};
+      color: ${theme.brand.alt};
     }
   }
 `;
 
 export const DropdownFooter = styled(FlexRow)`
-  border-top: 2px solid ${({ theme }) => theme.bg.wash};
+  border-top: 2px solid ${theme.bg.wash};
   flex: 0 0 32px;
   align-self: stretch;
   justify-content: center;
@@ -389,16 +390,16 @@ export const DropdownFooter = styled(FlexRow)`
     }
 
     &:hover {
-      color: ${props => props.theme.brand.alt};
-      background: ${props => props.theme.bg.wash};
+      color: ${theme.brand.alt};
+      background: ${theme.bg.wash};
     }
   }
 `;
 
 export const Notification = styled.div`
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   padding: 8px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   overflow-x: hidden;
 `;
 

--- a/src/views/newCommunity/components/createCommunityForm/style.js
+++ b/src/views/newCommunity/components/createCommunityForm/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import { FlexCol } from '../../../../components/globals';
 
@@ -24,7 +25,7 @@ export const Spacer = styled.div`
 export const CommunitySuggestionsText = styled.p`
   margin: 16px 0px 8px;
   font-size: 14px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const CommunitySuggestionsWrapper = styled.ul`
@@ -37,10 +38,10 @@ export const CommunitySuggestionsWrapper = styled.ul`
 export const CommunitySuggestion = styled.li`
   padding: 8px 12px;
   font-size: 14px;
-  background: ${props => props.theme.bg.wash};
-  color: ${props => props.theme.text.alt};
-  border-left: 1px solid ${props => props.theme.bg.border};
-  border-right: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.wash};
+  color: ${theme.text.alt};
+  border-left: 1px solid ${theme.bg.border};
+  border-right: 1px solid ${theme.bg.border};
   display: flex;
   align-items: center;
   flex: 1 0 auto;
@@ -52,24 +53,24 @@ export const CommunitySuggestion = styled.li`
   }
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   &:first-of-type {
     padding-top: 8px;
-    border-top: 1px solid ${props => props.theme.bg.border};
+    border-top: 1px solid ${theme.bg.border};
   }
 
   &:last-of-type {
     padding-bottom: 8px;
-    border-bottom: 1px solid ${props => props.theme.bg.border};
+    border-bottom: 1px solid ${theme.bg.border};
   }
 `;
 
 export const PrivacySelector = styled.div`
   display: flex;
   border-radius: 4px;
-  border: 2px solid ${props => props.theme.bg.border};
+  border: 2px solid ${theme.bg.border};
   margin-top: 16px;
   overflow: hidden;
 `;
@@ -87,12 +88,12 @@ export const PrivacyOption = styled.label`
     width: 18px;
     height: 18px;
     border-radius: 24px;
-    border: 2px solid ${props => props.theme.bg.border};
+    border: 2px solid ${theme.bg.border};
   }
 
   input:checked {
-    box-shadow: inset 0 0 0 4px ${props => props.theme.brand.alt};
-    border: 2px solid ${props => props.theme.brand.alt};
+    box-shadow: inset 0 0 0 4px ${theme.brand.alt};
+    border: 2px solid ${theme.brand.alt};
   }
 
   ${props =>
@@ -107,7 +108,7 @@ export const PrivacyOption = styled.label`
             color: ${props.theme.text.alt};
           }
         `} &:first-of-type {
-    border-right: 2px solid ${props => props.theme.bg.border};
+    border-right: 2px solid ${theme.bg.border};
   }
 `;
 

--- a/src/views/newCommunity/components/share/style.js
+++ b/src/views/newCommunity/components/share/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { zIndex } from '../../../../components/globals';
@@ -41,10 +42,10 @@ export const InputRow = styled.div`
 export const Input = styled.div`
   padding: 4px 12px;
   border-radius: 8px;
-  border: 2px solid ${props => props.theme.bg.border};
+  border: 2px solid ${theme.bg.border};
   background: #fff;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   padding-right: 72px;
   position: relative;
   display: flex;
@@ -56,7 +57,7 @@ export const Input = styled.div`
     cursor: pointer;
 
     &:after {
-      background: ${props => props.theme.bg.wash};
+      background: ${theme.bg.wash};
     }
   }
 
@@ -64,7 +65,7 @@ export const Input = styled.div`
     content: 'COPY';
     font-size: 11px;
     font-weight: 600;
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
     text-transform: uppercase;
     position: absolute;
     top: 0;
@@ -72,7 +73,7 @@ export const Input = styled.div`
     bottom: 0;
     background: #fff;
     padding: 4px 12px;
-    border-left: 2px solid ${props => props.theme.bg.border};
+    border-left: 2px solid ${theme.bg.border};
     border-radius: 0 8px 8px 0;
     z-index: ${zIndex.form + 1};
     line-height: 2.1;

--- a/src/views/newCommunity/components/stepper/style.js
+++ b/src/views/newCommunity/components/stepper/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { zIndex } from '../../../../components/globals';
@@ -13,7 +14,7 @@ export const Container = styled.div`
 export const Line = styled.span`
   position: absolute;
   height: 2px;
-  background: ${props => props.theme.bg.border};
+  background: ${theme.bg.border};
   top: 50%;
   left: 24px;
   right: 24px;

--- a/src/views/newCommunity/style.js
+++ b/src/views/newCommunity/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import Card from '../../components/card';
@@ -20,7 +21,7 @@ export const Container = styled(Card)`
 export const Actions = styled.div`
   display: flex;
   justify-content: space-between;
-  border-top: 2px solid ${props => props.theme.bg.border};
+  border-top: 2px solid ${theme.bg.border};
   padding: 24px;
   background: #fff;
   border-radius: 0 0 12px 12px;
@@ -28,7 +29,7 @@ export const Actions = styled.div`
 
 export const Title = styled.h1`
   font-weight: 900;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   font-size: 24px;
   letter-spacing: -0.1px;
   padding: 24px 24px 8px;
@@ -38,14 +39,14 @@ export const Title = styled.h1`
 export const Description = styled.h3`
   font-size: 16px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   line-height: 1.4;
   padding: 8px 24px 16px;
   text-align: ${props => (props.centered ? 'center' : 'left')};
 `;
 
 export const Divider = styled.div`
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
   width: 100%;
   display: block;
   padding-top: 24px;

--- a/src/views/newUserOnboarding/components/communitySearch/style.js
+++ b/src/views/newUserOnboarding/components/communitySearch/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import {
@@ -15,7 +16,7 @@ export const SearchWrapper = styled.div`
   position: relative;
   margin: 32px 16px;
   padding: 12px 16px;
-  border: 2px solid ${props => props.theme.bg.border};
+  border: 2px solid ${theme.bg.border};
   border-radius: 12px;
   width: 100%;
   max-width: 640px;
@@ -27,7 +28,7 @@ export const SearchWrapper = styled.div`
 
 export const SearchInputWrapper = styled(FlexRow)`
   flex: auto;
-  color: ${props => props.theme.text.placeholder};
+  color: ${theme.text.placeholder};
 `;
 
 export const SearchIcon = styled(Icon)``;
@@ -67,7 +68,7 @@ export const SearchResultsDropdown = styled.ul`
   max-height: 400px;
   overflow-y: scroll;
   z-index: ${zIndex.search};
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
 
   @media (max-width: 768px) {
     border-radius: 0 0 8px 8px;
@@ -79,21 +80,21 @@ export const SearchResult = styled.li`
   flex: auto;
   background: ${props =>
     props.focused ? props.theme.bg.wash : props.theme.bg.default};
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
   align-items: center;
   padding: 8px 16px 8px 8px;
 
   &:hover {
-    background: ${props => props.theme.bg.wash};
+    background: ${theme.bg.wash};
     cursor: pointer;
   }
 
   h2 {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   p {
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
     line-height: 1.4;
   }
 
@@ -139,14 +140,14 @@ export const SearchResultNull = styled.div`
   align-items: center;
   flex: auto;
   padding: 24px;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
   border: 0;
 
   &:hover {
     border: 0;
 
     p {
-      color: ${props => props.theme.text.alt};
+      color: ${theme.text.alt};
     }
   }
 
@@ -158,7 +159,7 @@ export const SearchResultNull = styled.div`
     text-align: center;
     font-size: 14px;
     font-weight: 400;
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
     text-align: center;
     font-size: 18px;
     font-weight: 600;
@@ -167,5 +168,5 @@ export const SearchResultNull = styled.div`
 
 export const SearchResultDescription = styled.p`
   font-size: 14px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;

--- a/src/views/newUserOnboarding/components/discoverCommunities/style.js
+++ b/src/views/newUserOnboarding/components/discoverCommunities/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import {
@@ -25,7 +26,7 @@ export const CoverPhoto = styled.div`
   position: relative;
   width: 100%;
   height: ${props => (props.large ? '320px' : '96px')};
-  background-color: ${({ theme }) => theme.brand.default};
+  background-color: ${theme.brand.default};
   background-image: url('${props => props.url}');
   background-size: cover;
   background-repeat: no-repeat;
@@ -35,7 +36,7 @@ export const CoverPhoto = styled.div`
 
 export const Container = styled.div`
   background: #fff;
-  box-shadow: inset 0 0 0 2px ${props => props.theme.bg.border};
+  box-shadow: inset 0 0 0 2px ${theme.bg.border};
   flex: 0 0 22%;
   display: flex;
   flex-direction: column;
@@ -60,13 +61,13 @@ export const ProfileAvatar = styled.img`
   margin-right: 16px;
   border-radius: 8px;
   object-fit: cover;
-  background-color: ${({ theme }) => theme.generic.default};
+  background-color: ${theme.generic.default};
   background-image: ${({ theme }) =>
     Gradient(theme.generic.alt, theme.generic.default)};
 `;
 
 export const CoverAvatar = styled(ProfileAvatar)`
-  border: 2px solid ${({ theme }) => theme.text.reverse};
+  border: 2px solid ${theme.text.reverse};
   width: 64px;
   flex: 0 0 64px;
   margin-right: 0;
@@ -75,7 +76,7 @@ export const CoverAvatar = styled(ProfileAvatar)`
 
 export const Title = styled.h3`
   font-size: 16px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   font-weight: 700;
   line-height: 1.2;
   ${Truncate} transition: ${Transition.hover.off};
@@ -91,7 +92,7 @@ export const CoverDescription = styled.p`
   margin: 0 16px 8px 16px;
   text-align: center;
   font-size: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   align-self: stretch;
   flex-direction: column;

--- a/src/views/newUserOnboarding/components/setUsername/style.js
+++ b/src/views/newUserOnboarding/components/setUsername/style.js
@@ -1,4 +1,5 @@
 // $FlowFixMe
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const Row = styled.div`
@@ -25,7 +26,7 @@ export const InputLabel = styled.h3`
   text-align: center;
   font-size: 20px;
   font-weight: 600;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin-bottom: 8px;
 `;
 
@@ -33,7 +34,7 @@ export const InputSubLabel = styled.h4`
   text-align: center;
   font-size: 16px;
   font-weight: 600;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-bottom: 16px;
   line-height: 1.4;
 `;

--- a/src/views/newUserOnboarding/style.js
+++ b/src/views/newUserOnboarding/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { Button } from '../../components/buttons';
@@ -41,11 +42,11 @@ export const IconContainer = styled.div`
   align-items: center;
   justify-content: center;
   margin-bottom: 16px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const Title = styled.h1`
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   width: 100%;
   line-height: 1.2;
   padding: 0;
@@ -63,7 +64,7 @@ export const Title = styled.h1`
 export const Subtitle = styled.h2`
   width: 100%;
   max-width: 640px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   font-weight: 500;
   font-size: 20px;
   line-height: 1.4;
@@ -80,7 +81,7 @@ export const Emoji = styled.h3`
 export const ContinueButton = styled(Button)`
   font-size: 18px;
   font-weight: 700;
-  color: ${props => props.theme.text.reverse};
+  color: ${theme.text.reverse};
   padding: 16px 88px;
   max-width: 100%;
   box-shadow: ${props =>
@@ -90,9 +91,9 @@ export const ContinueButton = styled(Button)`
 
 export const CreateUpsellContainer = styled.div`
   margin-top: 32px;
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
   padding: ${props => (props.extra ? '32px 32px 116px' : '32px')};
-  border-top: 2px solid ${props => props.theme.bg.border};
+  border-top: 2px solid ${theme.bg.border};
   width: calc(100% + 64px);
   margin-bottom: -32px;
   margin-left: -32px;
@@ -112,8 +113,8 @@ export const StickyRow = styled.div`
   pointer-events: ${props => (props.hasJoined ? 'auto' : 'none')};
   left: 0;
   right: 0;
-  background: ${props => props.theme.bg.default};
-  border-top: 2px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.default};
+  border-top: 2px solid ${theme.bg.border};
   z-index: ${zIndex.fullscreen + 1};
   transition: bottom 0.3s ease-in-out, opacity 0.3s ease-in-out;
   -webkit-transform: translate3d(0, 0, 0);

--- a/src/views/notifications/style.js
+++ b/src/views/notifications/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import {
@@ -49,7 +50,7 @@ export const SegmentedNotificationCard = styled(Card)`
 export const ContentHeading = styled.h2`
   font-size: 20px;
   font-weight: 700;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   margin: 8px 0;
 `;
 
@@ -66,7 +67,7 @@ export const ContentWash = styled(Content)`
   margin: 0;
   background-color: ${props => hexa(props.theme.bg.wash, 0.75)};
   border-radius: ${props => (props.mini ? '0' : '0 0 8px 8px')};
-  border-top: 1px solid ${props => props.theme.bg.border};
+  border-top: 1px solid ${theme.bg.border};
   padding: 8px;
   padding-top: 0;
 `;
@@ -108,7 +109,7 @@ export const ChatMessage = styled.p`
   padding: 12px 16px;
   border-radius: 16px;
   font-size: 14px;
-  background-color: ${({ theme }) => theme.generic.alt};
+  background-color: ${theme.generic.alt};
   background-image: ${({ theme }) =>
     Gradient(theme.generic.alt, theme.generic.default)};
   float: left;
@@ -119,10 +120,10 @@ export const ChatMessage = styled.p`
 export const NotificationListRow = styled(FlexCol)`
   padding: 16px;
   padding-top: 12px;
-  border-bottom: 1px solid ${({ theme }) => theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   justify-content: center;
   align-items: flex-start;
-  color: ${({ theme }) => theme.text.default};
+  color: ${theme.text.default};
   position: relative;
   z-index: ${zIndex.card};
   flex: none;
@@ -179,41 +180,41 @@ export const ContextRow = styled(FlexRow)`
 `;
 
 export const SuccessContext = styled(ContextRow)`
-  color: ${({ theme }) => theme.success.alt};
+  color: ${theme.success.alt};
 `;
 
 export const SpecialContext = styled(ContextRow)`
-  color: ${({ theme }) => theme.special.default};
+  color: ${theme.special.default};
 `;
 
 export const ReactionContext = styled(ContextRow)`
-  color: ${({ theme }) => theme.warn.alt};
+  color: ${theme.warn.alt};
 `;
 
 export const JoinContext = styled(ContextRow)`
-  color: ${({ theme }) => theme.space.default};
+  color: ${theme.space.default};
 `;
 
 export const RequestContext = styled(ContextRow)`
-  color: ${({ theme }) => theme.special.alt};
+  color: ${theme.special.alt};
 `;
 
 export const ApprovedContext = styled(ContextRow)`
-  color: ${({ theme }) => theme.success.default};
+  color: ${theme.success.default};
 `;
 
 export const ThreadContext = styled(ContextRow)`
-  color: ${({ theme }) => theme.brand.alt};
+  color: ${theme.brand.alt};
   margin: 0 16px;
   margin-bottom: 16px;
 `;
 
 export const ThreadReactionContext = styled(ContextRow)`
-  color: ${({ theme }) => theme.brand.alt};
+  color: ${theme.brand.alt};
 `;
 
 export const CreatedContext = styled(ContextRow)`
-  color: ${({ theme }) => theme.brand.alt};
+  color: ${theme.brand.alt};
   margin: 0 16px;
   margin-bottom: 16px;
 `;
@@ -221,7 +222,7 @@ export const CreatedContext = styled(ContextRow)`
 export const TextContent = styled.p`
   font-size: 14px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   pointer-events: ${props => (props.pointer ? 'all' : 'none')};
   line-height: 1.4;
   padding-right: 16px;
@@ -229,10 +230,10 @@ export const TextContent = styled.p`
 
   a {
     font-weight: 600;
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
 
     &:hover {
-      color: ${props => props.theme.brand.alt};
+      color: ${theme.brand.alt};
       text-decoration: underline;
     }
   }
@@ -255,7 +256,7 @@ export const BubbleGroupContainer = styled(FlexCol)`
 export const Timestamp = styled.span`
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.placeholder};
+  color: ${theme.text.placeholder};
 `;
 
 export const AttachmentsWash = styled(FlexCol)`
@@ -280,7 +281,7 @@ export const RequestCard = styled(Card)`
 
 export const CloseRequest = styled(IconButton)`
   margin-left: 8px;
-  color: ${props => props.theme.text.placeholder};
+  color: ${theme.text.placeholder};
 `;
 
 export const ButtonsRow = styled.div`
@@ -310,7 +311,7 @@ export const ChannelCard = styled.div`
   border-radius: 8px;
   box-shadow: ${Shadow.low} ${({ theme }) => hexa(theme.text.default, 0.1)};
   margin: 8px;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   display: flex;
   justify-content: space-between;
 
@@ -326,13 +327,13 @@ export const ChannelName = styled.p`
   padding: 16px 8px 16px 0;
   font-size: 16px;
   font-weight: 500;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   ${Truncate};
 `;
 
 export const ToggleNotificationsContainer = styled.div`
   display: flex;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   justify-content: center;
   align-items: center;
   height: 100%;

--- a/src/views/pages/faq/style.js
+++ b/src/views/pages/faq/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const PrivacyTermsList = styled.ul`
@@ -9,7 +10,7 @@ export const PrivacyTermsList = styled.ul`
   li {
     font-size: 20px;
     font-weight: 400;
-    color: ${props => props.theme.text.secondary};
+    color: ${theme.text.secondary};
     line-height: 1.4;
     margin-top: 12px;
   }

--- a/src/views/pages/features/style.js
+++ b/src/views/pages/features/style.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import theme from 'shared/theme';
 import { SvgWrapper } from 'src/components/icons';
 
 /* eslint no-eval: 0 */
@@ -28,7 +29,7 @@ export const TextContent = styled.div`
   grid-area: copy;
   justify-self: center;
   z-index: 1;
-  text-shadow: 0 0 4px ${props => props.theme.bg.default};
+  text-shadow: 0 0 4px ${theme.bg.default};
   max-width: 560px;
 
   > a {
@@ -220,7 +221,7 @@ export const FeatureName = styled.span`
         font-size: 12px;
         background-color: ${props =>
           props.bright ? props.theme.success.alt : props.theme.space.dark};
-        color: ${props => props.theme.text.reverse};
+        color: ${theme.text.reverse};
         padding: 4px 8px;
         border-radius: 16px;
         position: relative;
@@ -234,7 +235,7 @@ export const FeatureName = styled.span`
 
 export const EtcName = styled(FeatureName)`
   font-size: 20px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   line-height: 1.2;
 `;
 

--- a/src/views/pages/pricing/style.js
+++ b/src/views/pages/pricing/style.js
@@ -192,7 +192,7 @@ export const Subsection = styled.div`
 export const SectionTitle = styled.h3`
   font-size: 24px;
   font-weight: 600;
-  color: ${theme.text.primary};
+  color: ${theme.text.default};
   line-height: 1.3;
   margin-bottom: 16px;
 `;

--- a/src/views/pages/pricing/style.js
+++ b/src/views/pages/pricing/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { Button, TextButton } from 'src/components/buttons';
 import { hexa, zIndex } from 'src/components/globals';
@@ -68,11 +69,11 @@ export const Copy = styled.p`
   }
 
   a {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
     text-decoration: underline;
 
     &:hover {
-      color: ${props => props.theme.brand.dark};
+      color: ${theme.brand.dark};
     }
   }
 
@@ -191,7 +192,7 @@ export const Subsection = styled.div`
 export const SectionTitle = styled.h3`
   font-size: 24px;
   font-weight: 600;
-  color: ${props => props.theme.text.primary};
+  color: ${theme.text.primary};
   line-height: 1.3;
   margin-bottom: 16px;
 `;
@@ -199,7 +200,7 @@ export const SectionTitle = styled.h3`
 export const SectionSubtitle = styled.h4`
   font-size: 22px;
   font-weight: 600;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
   line-height: 1.4;
   margin: 16px 0;
 `;
@@ -207,7 +208,7 @@ export const SectionSubtitle = styled.h4`
 export const SectionDescription = styled.p`
   font-size: 20px;
   font-weight: 400;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
   line-height: 1.4;
 
   & + & {
@@ -215,7 +216,7 @@ export const SectionDescription = styled.p`
   }
 
   a {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
     font-weight: 500;
   }
 `;
@@ -229,7 +230,7 @@ export const Highlight = styled.span`
 
 export const Divider = styled.div`
   height: 1px;
-  background: ${props => props.theme.bg.border};
+  background: ${theme.bg.border};
   width: calc(100% + 64px);
   display: inline-block;
   margin: 64px -32px 0px;
@@ -247,7 +248,7 @@ export const PlanSection = styled.div`
   flex-direction: column;
   padding: 32px;
   box-shadow: 0 8px 32px ${props => hexa(props.theme.brand.alt, 0.25)};
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
   border-radius: 8px;
   max-width: 480px;
   z-index: 1;
@@ -310,7 +311,7 @@ export const CommunityCard = styled.div`
   grid-column-gap: 16px;
   align-items: center;
   grid-template-areas: 'avatar title button';
-  border-bottom: 1px solid ${props => props.theme.bg.wash};
+  border-bottom: 1px solid ${theme.bg.wash};
   padding-bottom: 16px;
 
   &:last-of-type {
@@ -352,7 +353,7 @@ export const CommunityListRow = styled(CommunityListGrid)`
     padding-bottom: 0;
     padding: 16px;
     border-radius: 8px;
-    background-color: ${props => props.theme.bg.default};
+    background-color: ${theme.bg.default};
   }
 `;
 
@@ -360,7 +361,7 @@ export const CommunityCardName = styled.h6`
   grid-area: title;
   font-size: 18px;
   font-weight: 600;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const CommunityListActions = styled.div`
@@ -397,13 +398,13 @@ export const CommunityCardButton = styled.button`
   padding: 8px 16px;
   font-size: 18px;
   font-weight: 600;
-  color: ${props => props.theme.text.alt};
-  background: ${props => props.theme.bg.wash};
+  color: ${theme.text.alt};
+  background: ${theme.bg.wash};
   transition: color 0.2s cubic-bezier(0.77, 0, 0.175, 1);
   width: 100%;
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
     cursor: pointer;
     transition: color 0.2s cubic-bezier(0.77, 0, 0.175, 1);
   }
@@ -424,7 +425,7 @@ export const ExtraContent = styled.div`
   margin-top: 32px;
   padding-top: 8px;
   padding-bottom: 16px;
-  border-top: 1px solid ${props => props.theme.bg.border};
+  border-top: 1px solid ${theme.bg.border};
 `;
 
 export const PriceTable = styled.div`
@@ -443,14 +444,14 @@ export const PriceTable = styled.div`
 export const PlanPrice = styled.h3`
   font-size: 24px;
   font-weight: 600;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin-bottom: 8px;
 `;
 
 export const PlanDescription = styled.p`
   font-size: 20px;
   font-weight: 400;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
   line-height: 1.3;
 `;
 
@@ -459,7 +460,7 @@ export const BusinessPlanSection = styled.div`
   display: flex;
   padding: 24px 32px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.03), 0 2px 6px rgba(0, 0, 0, 0.06);
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   border-radius: 8px;
 
   @media (max-width: 1024px) {
@@ -527,7 +528,7 @@ export const FeatureWrapper = styled.div`
   padding: 16px 0;
   align-items: center;
   grid-column-gap: 16px;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 
   &:last-of-type {
     border-bottom: 0;
@@ -554,7 +555,7 @@ export const FeatureTitle = styled.p`
   font-weight: 500;
   line-height: 1.2;
   margin-top: -1px;
-  color: ${props => props.theme.text.secondary};
+  color: ${theme.text.secondary};
 `;
 
 export const FeatureDescription = styled.p`
@@ -562,7 +563,7 @@ export const FeatureDescription = styled.p`
   font-size: 16px;
   font-weight: 400;
   line-height: 1.5;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   padding-right: 24px;
   margin-top: 8px;
 `;

--- a/src/views/pages/style.js
+++ b/src/views/pages/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import Link from '../../components/link';
 import { Button } from '../../components/buttons';
@@ -22,7 +23,7 @@ export const Page = styled.main`
   grid-template-areas: 'content';
   overflow: auto;
   overflow-x: hidden;
-  background-color: ${({ theme }) => theme.bg.default};
+  background-color: ${theme.bg.default};
 `;
 
 export const Wrapper = styled(FlexCol)`
@@ -32,7 +33,7 @@ export const Wrapper = styled(FlexCol)`
   min-width: 100vw;
   width: 100%;
   max-width: 100vw;
-  background-color: ${({ theme }) => theme.bg.default};
+  background-color: ${theme.bg.default};
   overflow: hidden;
   z-index: ${zIndex.base};
 `;
@@ -142,29 +143,29 @@ export const PrimaryCTA = styled(Button)`
   font-weight: 700;
   font-size: 16px;
   border-radius: 12px;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
   background-image: none;
-  color: ${props => props.theme.brand.alt};
+  color: ${theme.brand.alt};
   transition: ${Transition.hover.off};
   z-index: ${zIndex.card};
 
   &:hover {
-    background-color: ${props => props.theme.bg.default};
-    color: ${props => props.theme.brand.default};
+    background-color: ${theme.bg.default};
+    color: ${theme.brand.default};
     box-shadow: ${Shadow.high} ${props => hexa(props.theme.bg.reverse, 0.5)};
     transition: ${Transition.hover.on};
   }
 `;
 
 export const SecondaryCTA = styled(PrimaryCTA)`
-  color: ${props => props.theme.text.reverse};
+  color: ${theme.text.reverse};
   background-color: transparent;
   border: 2px solid transparent;
 
   &:hover {
-    color: ${props => props.theme.text.reverse};
+    color: ${theme.text.reverse};
     background-color: transparent;
-    border-color: ${props => props.theme.bg.default};
+    border-color: ${theme.bg.default};
     box-shadow: 0 0 8px 4px ${props => hexa(props.theme.bg.default, 0.5)};
   }
 `;
@@ -176,7 +177,7 @@ export const SignInButton = styled.a`
   flex-direction: flex-row;
   align-self: flex-start;
   align-items: center;
-  color: ${({ theme }) => theme.text.reverse};
+  color: ${theme.text.reverse};
   border-radius: 8px;
   padding: 8px;
   padding-right: 16px;
@@ -239,7 +240,9 @@ export const ButtonTwitter = styled(Button)`
   color: ${props =>
     props.whitebg
       ? props.theme.social.twitter.default
-      : props.preferred ? '#fff' : 'rgba(255,255,255,0.8)'};
+      : props.preferred
+        ? '#fff'
+        : 'rgba(255,255,255,0.8)'};
 
   &:hover {
     color: ${props =>
@@ -253,7 +256,9 @@ export const ButtonFacebook = styled(Button)`
   color: ${props =>
     props.whitebg
       ? props.theme.social.facebook.default
-      : props.preferred ? '#fff' : 'rgba(255,255,255,0.8)'};
+      : props.preferred
+        ? '#fff'
+        : 'rgba(255,255,255,0.8)'};
 
   &:hover {
     color: ${props =>
@@ -267,7 +272,9 @@ export const ButtonGoogle = styled(Button)`
   color: ${props =>
     props.whitebg
       ? props.theme.social.google.default
-      : props.preferred ? '#fff' : 'rgba(255,255,255,0.8)'};
+      : props.preferred
+        ? '#fff'
+        : 'rgba(255,255,255,0.8)'};
 
   &:hover {
     color: ${props =>
@@ -282,8 +289,8 @@ export const Footer = styled.div`
   flex: auto;
   position: relative;
   padding: 32px;
-  background-color: ${({ theme }) => theme.bg.reverse};
-  color: ${({ theme }) => theme.text.reverse};
+  background-color: ${theme.bg.reverse};
+  color: ${theme.text.reverse};
 `;
 
 export const FooterGrid = styled.div`
@@ -313,7 +320,7 @@ export const FooterSection = styled.div`
   font-size: 16px;
 
   span {
-    color: ${props => props.theme.text.alt};
+    color: ${theme.text.alt};
     font-weight: 700;
   }
 `;
@@ -337,7 +344,7 @@ export const LinkSection = styled(FooterSection)`
       height: 2px;
       width: 0%;
       opacity: 0;
-      background-color: ${props => props.theme.text.reverse};
+      background-color: ${theme.text.reverse};
       transition: opacity 0.2s ease-in-out, width 0.2s ease-in-out;
     }
 
@@ -400,8 +407,8 @@ export const LinkBlock = styled(Link)`
     border-radius: 12px;
 
     &:hover {
-      background-color: ${({ theme }) => theme.bg.default};
-      color: ${({ theme }) => theme.text.default};
+      background-color: ${theme.bg.default};
+      color: ${theme.text.default};
       transition: ${Transition.hover.on};
     }
   }
@@ -442,8 +449,8 @@ export const LinkBlockA = styled.a`
     border-radius: 12px;
 
     &:hover {
-      background-color: ${({ theme }) => theme.bg.default};
-      color: ${({ theme }) => theme.text.default};
+      background-color: ${theme.bg.default};
+      color: ${theme.text.default};
       transition: ${Transition.hover.on};
     }
   }
@@ -498,14 +505,14 @@ export const Tabs = styled.div`
     props.dark &&
     css`
       button {
-        color: ${props => props.theme.brand.alt};
+        color: ${theme.brand.alt};
         background-image: none;
-        background-color: ${props => props.theme.bg.default};
+        background-color: ${theme.bg.default};
 
         &:hover {
-          color: ${props => props.theme.brand.default};
-          background-color: ${props => props.theme.bg.default};
-          box-shadow: 0 0 16px ${props => props.theme.brand.border};
+          color: ${theme.brand.default};
+          background-color: ${theme.bg.default};
+          box-shadow: 0 0 16px ${theme.brand.border};
         }
       }
     `};
@@ -517,14 +524,22 @@ export const Tab = styled(Link)`
   font-weight: ${props => (props.selected ? '700' : '500')};
   color: ${props =>
     props.selected
-      ? props.dark ? props.theme.text.reverse : props.theme.text.default
-      : props.dark ? props.theme.text.reverse : props.theme.text.alt};
+      ? props.dark
+        ? props.theme.text.reverse
+        : props.theme.text.default
+      : props.dark
+        ? props.theme.text.reverse
+        : props.theme.text.alt};
 
   &:hover {
     color: ${props =>
       props.selected
-        ? props.dark ? props.theme.text.reverse : props.theme.text.default
-        : props.dark ? props.theme.text.reverse : props.theme.text.alt};
+        ? props.dark
+          ? props.theme.text.reverse
+          : props.theme.text.default
+        : props.dark
+          ? props.theme.text.reverse
+          : props.theme.text.alt};
     text-shadow: ${props =>
       props.dark ? `0 0 32px ${hexa(props.theme.text.reverse, 0.75)}` : 'none'};
   }
@@ -571,11 +586,11 @@ export const DropdownLink = styled(Link)`
 `;
 
 export const LogoLink = styled(DropdownLink)`
-  color: ${props => props.theme.text.placeholder};
+  color: ${theme.text.placeholder};
   margin-bottom: 16px;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 
@@ -585,13 +600,13 @@ export const AuthLink = styled(DropdownLink)`
   padding: 16px 0;
   font-weight: 700;
   border-top: none;
-  color: ${props => props.theme.text.reverse};
+  color: ${theme.text.reverse};
   background-image: ${props =>
     Gradient(props.theme.brand.alt, props.theme.brand.default)};
   justify-content: center;
 
   &:hover {
-    color: ${props => props.theme.text.reverse};
+    color: ${theme.text.reverse};
     text-shadow: 0 0 32px ${props => hexa(props.theme.text.reverse, 0.5)};
   }
 `;
@@ -608,8 +623,8 @@ export const MenuContainer = styled.div`
   height: 100vh;
   width: 300px;
   padding: 16px;
-  color: ${props => props.theme.brand.alt};
-  background-color: ${props => props.theme.bg.default};
+  color: ${theme.brand.alt};
+  background-color: ${theme.bg.default};
   background-image: ${props =>
     Gradient(props.theme.bg.default, props.theme.bg.wash)};
   box-shadow: ${Shadow.high} ${props => hexa(props.theme.bg.reverse, 0.25)};
@@ -691,14 +706,14 @@ export const AuthTab = styled.div`
     ${props =>
       props.dark &&
       css`
-        color: ${props => props.theme.brand.alt};
+        color: ${theme.brand.alt};
         background-image: none;
-        background-color: ${props => props.theme.bg.default};
+        background-color: ${theme.bg.default};
 
         &:hover {
-          color: ${props => props.theme.brand.default};
-          background-color: ${props => props.theme.bg.default};
-          box-shadow: 0 0 16px ${props => props.theme.brand.border};
+          color: ${theme.brand.default};
+          background-color: ${theme.bg.default};
+          box-shadow: 0 0 16px ${theme.brand.border};
         }
       `};
   }

--- a/src/views/pages/terms/style.js
+++ b/src/views/pages/terms/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 
 export const PrivacyTermsList = styled.ul`
@@ -9,7 +10,7 @@ export const PrivacyTermsList = styled.ul`
   li {
     font-size: 20px;
     font-weight: 400;
-    color: ${props => props.theme.text.secondary};
+    color: ${theme.text.secondary};
     line-height: 1.4;
     margin-top: 12px;
   }

--- a/src/views/pages/view.js
+++ b/src/views/pages/view.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import React from 'react';
 import styled from 'styled-components';
 import Link from 'src/components/link';
@@ -99,7 +100,7 @@ export const Overview = (props: Props) => {
   const ThisSecondaryCTA = styled(SecondaryCTA)`
     margin-left: 16px;
     font-size: 16px;
-    border: 2px solid ${props => props.theme.text.reverse};
+    border: 2px solid ${theme.text.reverse};
 
     @media (max-width: 768px) {
       margin-left: 0;
@@ -206,13 +207,13 @@ export const Centralized = (props: Props) => {
 
   const ThisPrimaryCTA = styled(PrimaryCTA)`
     margin-top: 32px;
-    background-color: ${props => props.theme.brand.alt};
+    background-color: ${theme.brand.alt};
     background-image: ${props =>
       Gradient(props.theme.brand.alt, props.theme.brand.default)};
-    color: ${props => props.theme.text.reverse};
+    color: ${theme.text.reverse};
 
     &:hover {
-      color: ${props => props.theme.text.reverse};
+      color: ${theme.text.reverse};
     }
   `;
 
@@ -352,14 +353,14 @@ export const Chat = (props: Props) => {
   `;
 
   const ThisPrimaryCTA = styled(PrimaryCTA)`
-    background-color: ${props => props.theme.brand.alt};
+    background-color: ${theme.brand.alt};
     background-image: ${props =>
       Gradient(props.theme.brand.alt, props.theme.brand.default)};
-    color: ${props => props.theme.text.reverse};
+    color: ${theme.text.reverse};
     margin-top: 32px;
 
     &:hover {
-      color: ${props => props.theme.text.reverse};
+      color: ${theme.text.reverse};
     }
   `;
 
@@ -510,7 +511,7 @@ export const Yours = (props: Props) => {
   const ThisSecondaryCTA = styled(SecondaryCTA)`
     margin-left: 16px;
     font-size: 16px;
-    border: 2px solid ${props => props.theme.text.reverse};
+    border: 2px solid ${theme.text.reverse};
 
     @media (max-width: 768px) {
       margin-left: 0;
@@ -520,10 +521,10 @@ export const Yours = (props: Props) => {
 
   const ThisPrimaryCTA = styled(PrimaryCTA)`
     font-size: 16px;
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
 
     &:hover {
-      color: ${props => props.theme.brand.alt};
+      color: ${theme.brand.alt};
       box-shadow: ${Shadow.high} #000;
     }
   `;
@@ -565,7 +566,7 @@ export const Yours = (props: Props) => {
     min-width: 320px;
     flex: none;
     box-shadow: 0 8px 16px #000;
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
     position: relative;
     padding: 24px;
     transition: ${Transition.hover.off};
@@ -573,11 +574,11 @@ export const Yours = (props: Props) => {
     margin-left: 32px;
 
     &:hover {
-      box-shadow: 0 0px 32px ${props => props.theme.brand.alt};
+      box-shadow: 0 0px 32px ${theme.brand.alt};
       transition: ${Transition.hover.on};
 
       > div {
-        color: ${props => props.theme.brand.alt};
+        color: ${theme.brand.alt};
         transition: ${Transition.hover.on};
       }
     }
@@ -606,14 +607,14 @@ export const Yours = (props: Props) => {
     }
 
     span {
-      color: ${props => props.theme.text.alt};
+      color: ${theme.text.alt};
       font-weight: 400;
       margin-left: 4px;
     }
   `;
 
   const Rule = styled(HorizontalRule)`
-    color: ${props => props.theme.brand.border};
+    color: ${theme.brand.border};
     transition: ${Transition.hover.off};
 
     hr {

--- a/src/views/search/style.js
+++ b/src/views/search/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import theme from 'shared/theme';
 
 export const View = styled.div`
   display: flex;
@@ -10,12 +11,12 @@ export const View = styled.div`
 `;
 
 export const SearchWrapper = styled.div`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   align-items: center;
   flex: none;
   transition: all 0.2s;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   position: relative;
 
   .icon {
@@ -35,11 +36,11 @@ export const SearchInput = styled.input`
   display: flex;
   flex: 1;
   transition: color 0.2s;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   padding-right: 40px;
 
   &:focus {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
@@ -50,13 +51,13 @@ export const ClearSearch = styled.span`
   display: flex;
   justify-content: center;
   align-items: center;
-  background: ${props => props.theme.bg.border};
+  background: ${theme.bg.border};
   border-radius: 50%;
   font-size: 20px;
   position: absolute;
   right: 4px;
   top: 50%;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   transform: translate(-4px, -50%);
   font-weight: 500;
   pointer-events: ${props => (props.isOpen ? 'auto' : 'none')};
@@ -64,8 +65,8 @@ export const ClearSearch = styled.span`
   transition: background 0.2s, color 0.2s;
 
   &:hover {
-    background: ${props => props.theme.text.alt};
-    color: ${props => props.theme.text.reverse};
+    background: ${theme.text.alt};
+    color: ${theme.text.reverse};
   }
 
   span {
@@ -78,7 +79,7 @@ export const SearchStringHeader = styled.div`
   background: #fff;
   padding: 16px;
   font-weight: 600;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
 `;
 
 export const SearchForm = styled.form`

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled, { css } from 'styled-components';
 import Link from 'src/components/link';
 import { UserAvatar, CommunityAvatar } from 'src/components/avatar';
@@ -22,7 +23,7 @@ export const ThreadViewContainer = styled.div`
   height: 100%;
   max-height: ${props => (props.constrain ? 'calc(100% - 48px)' : '100%')};
   max-width: 1024px;
-  background-color: ${({ theme }) => theme.bg.wash};
+  background-color: ${theme.bg.wash};
   margin: ${props =>
     props.threadViewContext === 'fullscreen' ? '0 auto' : '0'};
 
@@ -34,12 +35,11 @@ export const ThreadViewContainer = styled.div`
 `;
 
 export const ThreadContentView = styled(FlexCol)`
-  background-color: ${({ theme }) => theme.bg.default};
+  background-color: ${theme.bg.default};
   ${props =>
     !props.slider &&
     css`
-      box-shadow: -1px 0 0 ${props => props.theme.bg.border},
-        1px 0 0 ${props => props.theme.bg.border};
+      box-shadow: -1px 0 0 ${theme.bg.border}, 1px 0 0 ${theme.bg.border};
     `} overflow-y: auto;
   overflow-x: visible;
   max-width: 100%;
@@ -55,7 +55,7 @@ export const ThreadContentView = styled(FlexCol)`
 `;
 
 export const ThreadSidebarView = styled(FlexCol)`
-  background-color: ${({ theme }) => theme.bg.wash};
+  background-color: ${theme.bg.wash};
   overflow: hidden;
   min-width: 320px;
   max-width: 320px;
@@ -82,7 +82,7 @@ export const Content = styled(FlexRow)`
   width: 100%;
   max-width: 1024px;
   margin: 0 auto;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
 `;
 
 export const Input = styled(FlexRow)`
@@ -122,7 +122,7 @@ export const DetailViewWrapper = styled(FlexCol)`
   align-items: center;
 
   @media (max-width: 768px) {
-    background-color: ${({ theme }) => theme.bg.default};
+    background-color: ${theme.bg.default};
     background-image: none;
   }
 `;
@@ -199,12 +199,12 @@ export const DropWrap = styled(FlexCol)`
   width: 32px;
   height: 32px;
   position: relative;
-  color: ${({ theme }) => theme.text.placeholder};
+  color: ${theme.text.placeholder};
   transition: ${Transition.hover.off};
   margin: 0 8px;
 
   &:hover {
-    color: ${({ theme }) => theme.bg.border};
+    color: ${theme.bg.border};
     transition: ${Transition.hover.on};
   }
 
@@ -221,13 +221,13 @@ export const FlyoutRow = styled(FlexRow)`
   button {
     width: 100%;
     justify-content: flex-start;
-    border-top: 1px solid ${props => props.theme.bg.wash};
+    border-top: 1px solid ${theme.bg.wash};
     border-radius: 0;
     transition: none;
   }
 
   button:hover {
-    background: ${props => props.theme.bg.wash};
+    background: ${theme.bg.wash};
     transition: none;
   }
 
@@ -263,7 +263,7 @@ export const FlyoutRow = styled(FlexRow)`
 
 export const Byline = styled.div`
   font-weight: 400;
-  color: ${({ theme }) => theme.brand.alt};
+  color: ${theme.brand.alt};
   display: flex;
   margin-bottom: 24px;
   align-items: center;
@@ -288,17 +288,17 @@ export const AuthorNameNoLink = styled.div`
 export const AuthorName = styled(H3)`
   font-weight: 500;
   max-width: 100%;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin-right: 4px;
   font-size: 14px;
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
 export const AuthorUsername = styled.span`
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -314,7 +314,7 @@ export const ReputationRow = styled.div``;
 
 export const Location = styled(FlexRow)`
   font-weight: 500;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   font-size: 14px;
   margin-top: -16px;
   margin-left: -16px;
@@ -322,20 +322,20 @@ export const Location = styled(FlexRow)`
   align-self: flex-start;
 
   &:hover > div {
-    color: ${({ theme }) => theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 
   > div {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   > span {
     padding: 0 4px;
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   > a:hover {
-    color: ${({ theme }) => theme.brand.alt};
+    color: ${theme.brand.alt};
     text-decoration: underline;
   }
 
@@ -348,7 +348,7 @@ export const Timestamp = styled.span`
   font-weight: 400;
   margin: 8px 0;
   font-size: 16px;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   display: inline-block;
 `;
 
@@ -370,7 +370,7 @@ export const NullMessagesWrapper = styled.div`
   padding: 32px;
   padding-top: 64px;
   flex: 1;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   flex-direction: column;
   opacity: 0.8;
 
@@ -382,7 +382,7 @@ export const NullMessagesWrapper = styled.div`
 export const NullCopy = styled.h5`
   font-size: 18px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   margin-top: 16px;
   text-align: center;
   max-width: 600px;
@@ -423,7 +423,7 @@ export const ShareButtons = styled.div`
 `;
 
 export const ShareButton = styled.span`
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   background: none;
 
@@ -455,7 +455,7 @@ export const CommunityHeader = styled.div`
   box-shadow: ${Shadow.low} ${props => hexa(props.theme.bg.reverse, 0.15)};
   flex: 0 0 64px;
   align-self: stretch;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
 
   @media (max-width: 728px) {
     padding: 16px;
@@ -466,7 +466,7 @@ export const CommunityHeaderName = styled.h3`
   font-size: 16px;
   font-weight: 600;
   margin-right: 8px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   line-height: 16px;
 `;
 
@@ -476,10 +476,10 @@ export const CommunityHeaderSubtitle = styled.span`
   font-size: 12px;
   margin-top: 4px;
   line-height: 12px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 
   > a:hover {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
   }
 `;
 
@@ -490,13 +490,13 @@ export const ThreadSubtitle = styled(CommunityHeaderSubtitle)`
   line-height: 1.5;
 
   a:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
 export const CommunityHeaderChannelTag = styled.div`
-  color: ${props => props.theme.text.reverse};
-  background: ${props => props.theme.warn.alt};
+  color: ${theme.text.reverse};
+  background: ${theme.warn.alt};
   border-radius: 20px;
   padding: 0 12px;
   font-size: 11px;
@@ -506,7 +506,7 @@ export const CommunityHeaderChannelTag = styled.div`
   align-items: center;
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 
   @media (max-width: 728px) {
@@ -530,10 +530,10 @@ export const CommunityHeaderMetaCol = styled.div`
 
 export const PillLink = styled(Link)`
   font-size: 12px;
-  box-shadow: 0 0 0 1px ${props => props.theme.bg.border};
-  background: ${props => props.theme.bg.wash};
+  box-shadow: 0 0 0 1px ${theme.bg.border};
+  background: ${theme.bg.wash};
   font-weight: ${props => '400'};
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   display: flex;
   flex: none;
   height: 20px;
@@ -546,14 +546,14 @@ export const PillLink = styled(Link)`
   pointer-events: auto;
 
   &:hover {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
   }
 `;
 
 export const PillLinkPinned = styled.div`
-  background: ${props => props.theme.special.wash};
-  border: 1px solid ${props => props.theme.special.border};
-  color: ${props => props.theme.special.dark};
+  background: ${theme.special.wash};
+  border: 1px solid ${theme.special.border};
+  color: ${theme.special.dark};
   display: flex;
   height: 20px;
   border-radius: 4px;
@@ -595,8 +595,8 @@ export const ActionBarContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: ${props => props.theme.bg.wash};
-  border: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.wash};
+  border: 1px solid ${theme.bg.border};
   border-left: 0;
   border-right: 0;
   padding: 6px 32px;
@@ -617,14 +617,14 @@ export const WatercoolerActionBarContainer = styled(ActionBarContainer)`
 `;
 
 export const FollowButton = styled(Button)`
-  background: ${props => props.theme.bg.default};
-  border: 1px solid ${props => props.theme.bg.border};
-  color: ${props => props.theme.text.alt};
+  background: ${theme.bg.default};
+  border: 1px solid ${theme.bg.border};
+  color: ${theme.text.alt};
   padding: 4px;
 
   &:hover {
-    background: ${props => props.theme.bg.default};
-    color: ${props => props.theme.text.default};
+    background: ${theme.bg.default};
+    color: ${theme.text.default};
   }
 
   @media (max-width: 768px) {
@@ -634,8 +634,8 @@ export const FollowButton = styled(Button)`
 
 export const SidebarSection = styled.div`
   margin: 8px 16px;
-  background: ${props => props.theme.bg.default};
-  border: 1px solid ${props => props.theme.bg.border};
+  background: ${theme.bg.default};
+  border: 1px solid ${theme.bg.border};
   border-radius: 4px;
   display: flex;
   flex-direction: column;
@@ -652,18 +652,18 @@ export const SidebarSectionTitle = styled.h3`
   margin: 16px 16px 8px;
   font-size: 15px;
   font-weight: 500;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
 `;
 
 export const SidebarSectionBody = styled.p`
   margin: 0 16px 16px;
   font-size: 14px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   white-space: pre-wrap;
 
   a {
-    color: ${props => props.theme.text.default};
+    color: ${theme.text.default};
 
     &:hover {
       text-decoration: underline;
@@ -711,8 +711,8 @@ export const SidebarCommunityProfile = styled.img`
   left: 50%;
   transform: translateX(-50%);
   top: 48px;
-  background: ${props => props.theme.bg.default};
-  border: 2px solid ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
+  border: 2px solid ${theme.bg.default};
 `;
 export const SidebarCommunityName = styled(SidebarSectionTitle)`
   text-align: center;
@@ -732,11 +732,11 @@ export const SidebarRelatedThreadList = styled.ul`
 
 export const SidebarRelatedThread = styled.li`
   font-size: 14px;
-  border-top: 1px solid ${props => props.theme.bg.wash};
+  border-top: 1px solid ${theme.bg.wash};
 
   &:hover {
     a {
-      background-color: ${props => props.theme.bg.wash};
+      background-color: ${theme.bg.wash};
     }
   }
 
@@ -759,7 +759,7 @@ export const SidebarRelatedThread = styled.li`
 export const RelatedTitle = styled.p``;
 export const RelatedCount = styled.p`
   font-size: 13px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const Label = styled.p`
@@ -769,7 +769,7 @@ export const Label = styled.p`
 export const WatercoolerDescription = styled.h4`
   font-size: 18px;
   font-weight: 400;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
   text-align: center;
   line-height: 1.4;
   margin: 0;
@@ -781,7 +781,7 @@ export const WatercoolerIntroContainer = styled.div`
   align-items: center;
   justify-content: center;
   padding: 32px 32px 36px;
-  background: ${props => props.theme.bg.default};
+  background: ${theme.bg.default};
   flex: auto;
   flex-direction: column;
 `;
@@ -790,7 +790,7 @@ export const WatercoolerTitle = styled.h3`
   text-align: center;
   font-size: 22px;
   font-weight: 500;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   margin-bottom: 8px;
 `;
 

--- a/src/views/threadSlider/style.js
+++ b/src/views/threadSlider/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled, { css } from 'styled-components';
 // $FlowFixMe
@@ -61,10 +62,10 @@ export const Close = styled(Link)`
   display: flex;
   align-items: center;
   flex: 1;
-  border-bottom: 1px solid ${props => props.theme.bg.border};
+  border-bottom: 1px solid ${theme.bg.border};
   padding: 8px 16px;
   flex: 1 0 auto;
-  background: ${props => props.theme.bg.wash};
+  background: ${theme.bg.wash};
   max-height: 48px;
   justify-content: flex-end;
 `;
@@ -76,11 +77,11 @@ export const CloseButton = styled.span`
   width: 32px;
   height: 32px;
   border-radius: 32px;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;
 
 export const CloseLabel = styled.span`
   font-size: 14px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
+  color: ${theme.text.alt};
 `;

--- a/src/views/titlebar/style.js
+++ b/src/views/titlebar/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 // $FlowFixMe
 import styled from 'styled-components';
 import { hexa, Shadow, FlexRow, zIndex } from '../../components/globals';
@@ -13,8 +14,8 @@ export const TitleBar = styled(FlexRow)`
   grid-template-areas: 'left center right';
   grid-column-gap: 16px;
   padding: ${isDesktopApp() ? '32px 8px 0' : '0 8px'};
-  background-color: ${({ theme }) => theme.bg.reverse};
-  color: ${({ theme }) => theme.text.reverse};
+  background-color: ${theme.bg.reverse};
+  color: ${theme.text.reverse};
   min-height: ${isDesktopApp() ? '80px' : '48px'};
   height: ${isDesktopApp() ? '80px' : '48px'};
   max-height: ${isDesktopApp() ? '80px' : '48px'};

--- a/src/views/user/style.js
+++ b/src/views/user/style.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { FlexRow, FlexCol } from '../../components/globals';
 import Card from '../../components/card';
@@ -9,7 +10,7 @@ export const Row = styled(FlexRow)`
   padding: 8px 16px;
   align-items: center;
   width: 100%;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
 
   div {
     margin-top: 2px;
@@ -23,8 +24,8 @@ export const Row = styled(FlexRow)`
   }
 
   &:hover {
-    background-color: ${({ theme }) => theme.brand.alt};
-    color: ${({ theme }) => theme.text.reverse};
+    background-color: ${theme.brand.alt};
+    color: ${theme.text.reverse};
   }
 `;
 
@@ -32,7 +33,7 @@ export const Col = styled(FlexCol)`
   width: 100%;
 
   a + a > div {
-    border-top: 2px solid ${({ theme }) => theme.bg.wash};
+    border-top: 2px solid ${theme.bg.wash};
   }
 `;
 
@@ -41,7 +42,7 @@ export const RowLabel = styled.span`
 `;
 
 export const SearchContainer = styled(Card)`
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
   position: relative;
   z-index: ${zIndex.search};
   width: 100%;
@@ -51,7 +52,7 @@ export const SearchContainer = styled(Card)`
 
   &:hover {
     transition: none;
-    border-bottom: 2px solid ${props => props.theme.brand.alt};
+    border-bottom: 2px solid ${theme.brand.alt};
   }
 
   @media (max-width: 768px) {
@@ -66,7 +67,7 @@ export const SearchInput = styled.input`
   align-items: center;
   cursor: pointer;
   padding: 20px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   transition: ${Transition.hover.off};
   font-size: 20px;
   font-weight: 800;
@@ -85,7 +86,7 @@ export const Grid = styled.main`
   min-width: 100%;
   max-width: 100%;
   min-height: 100vh;
-  background-color: ${props => props.theme.bg.default};
+  background-color: ${theme.bg.default};
 
   @media (max-width: 1028px) {
     grid-template-columns: 320px 1fr;
@@ -190,7 +191,7 @@ export const ColumnHeading = styled.div`
   font-weight: 500;
   padding: 8px 16px 12px;
   margin-top: 24px;
-  border-bottom: 2px solid ${props => props.theme.bg.border};
+  border-bottom: 2px solid ${theme.bg.border};
 
   + div {
     padding: 8px 16px;

--- a/src/views/userSettings/components/downloadDataForm.js
+++ b/src/views/userSettings/components/downloadDataForm.js
@@ -1,4 +1,5 @@
 // @flow
+import theme from 'shared/theme';
 import * as React from 'react';
 import styled from 'styled-components';
 import {
@@ -12,11 +13,11 @@ const Link = styled.a`
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
-  color: ${props => props.theme.brand.default};
+  color: ${theme.brand.default};
   padding: 12px 16px;
 
   &:hover {
-    color: ${props => props.theme.brand.alt};
+    color: ${theme.brand.alt};
   }
 `;
 

--- a/src/views/userSettings/style.js
+++ b/src/views/userSettings/style.js
@@ -1,10 +1,11 @@
 // @flow
+import theme from 'shared/theme';
 import styled from 'styled-components';
 import { FlexRow, FlexCol } from 'src/components/globals';
 
 export const EmailListItem = styled.div`
   padding: 8px 0 16px;
-  border-bottom: 2px solid ${props => props.theme.bg.wash};
+  border-bottom: 2px solid ${theme.bg.wash};
 
   &:last-of-type {
     border-bottom: none;
@@ -41,12 +42,12 @@ export const Form = styled.form`
 
 export const Description = styled.p`
   font-size: 14px;
-  color: ${props => props.theme.text.default};
+  color: ${theme.text.default};
   padding: 8px 0 16px;
   line-height: 1.4;
 
   a {
-    color: ${props => props.theme.brand.default};
+    color: ${theme.brand.default};
   }
 `;
 
@@ -59,7 +60,7 @@ export const Actions = styled(FlexRow)`
   margin-top: 24px;
   justify-content: flex-start;
   flex-direction: row-reverse;
-  border-top: 1px solid ${props => props.theme.bg.border};
+  border-top: 1px solid ${theme.bg.border};
   padding-top: 16px;
 
   button + button {
@@ -80,8 +81,8 @@ export const GeneralNotice = styled.span`
   padding: 8px 12px;
   font-size: 12px;
   font-weight: 500;
-  color: ${props => props.theme.text.alt};
-  background: ${props => props.theme.bg.wash};
+  color: ${theme.text.alt};
+  background: ${theme.bg.wash};
   border-radius: 4px;
   margin-top: 24px;
   line-height: 1.4;
@@ -103,21 +104,21 @@ export const ImageInputWrapper = styled(FlexCol)`
 
 export const Location = styled(FlexRow)`
   font-weight: 500;
-  color: ${({ theme }) => theme.text.alt};
+  color: ${theme.text.alt};
   font-size: 14px;
   margin-bottom: 8px;
 
   > div {
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   > span {
     padding: 0 4px;
-    color: ${({ theme }) => theme.text.placeholder};
+    color: ${theme.text.placeholder};
   }
 
   > a:hover {
-    color: ${({ theme }) => theme.brand.alt};
+    color: ${theme.brand.alt};
     text-decoration: underline;
   }
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

styled-components has a fast path built-in: when styles don't have any function interpolations, we never recompute them since they can't change.  This leads to big performance gains when re-rendering the same components over and over and over, e.g. on Spectrum when switching between threads in the inbox. (reuses the same components, but with different props)

This patch was done automatically, and moves all of our simple function interpolations in the form of ${props => props.theme.x} to static interpolations that just do ${theme.x}. This allows us to hit the fast path with many more components, making the app re-render faster. This is most noticeable in the dashboard when switching threads.

/cc @uberbryn @brianlovin this would be good to be aware of for any future components