### PR TITLE
Fix explore perf + nits

### DIFF
--- a/shared/graphql/queries/community/getCommunities.js
+++ b/shared/graphql/queries/community/getCommunities.js
@@ -42,11 +42,9 @@ export const getCommunitiesBySlugsQuery = gql`
   query getCommunitiesBySlugs($slugs: [LowercaseString]) {
     communities(slugs: $slugs) {
       ...communityInfo
-      ...communityMetaData
     }
   }
   ${communityInfoFragment}
-  ${communityMetaDataFragment}
 `;
 
 const getCommunitiesBySlugOptions = {
@@ -67,11 +65,9 @@ const getCommunitiesByCuratedContentTypeQuery = gql`
   query getCommunitiesCollection($curatedContentType: String) {
     communities(curatedContentType: $curatedContentType) {
       ...communityInfo
-      ...communityMetaData
     }
   }
   ${communityInfoFragment}
-  ${communityMetaDataFragment}
 `;
 
 const getCommunitiesByCuratedContentTypeOptions = {

--- a/src/components/profile/style.js
+++ b/src/components/profile/style.js
@@ -106,7 +106,7 @@ export const Subtitle = styled.div`
 `;
 
 export const Description = styled.div`
-  font-size: 14px;
+  font-size: 16px;
   color: ${theme.text.alt};
   padding: 0 16px 16px;
   line-height: 1.4;
@@ -248,7 +248,7 @@ export const CoverLink = styled(ProfileHeaderLink)`
 
 export const CoverTitle = styled(Title)`
   font-size: 20px;
-  margin-top: 8px;
+  margin-top: 16px;
   text-align: center;
 `;
 
@@ -259,8 +259,8 @@ export const CoverSubtitle = styled(Subtitle)`
 `;
 
 export const CoverDescription = styled(Description)`
-  text-align: center;
   flex: auto;
+  margin-top: 8px;
 `;
 
 // had a hard time targeting the ChannelListItem component, so this is a janky way to get the overrides I needed.

--- a/src/views/explore/components/search.js
+++ b/src/views/explore/components/search.js
@@ -276,7 +276,8 @@ class Search extends React.Component<Props, State> {
                               </SearchResultName>
                               {community.metaData && (
                                 <SearchResultMetadata>
-                                  {community.metaData.members} members
+                                  {community.metaData.members.toLocaleString()}{' '}
+                                  members
                                 </SearchResultMetadata>
                               )}
                             </SearchResultMetaWrapper>

--- a/src/views/thread/components/sidebar.js
+++ b/src/views/thread/components/sidebar.js
@@ -51,7 +51,6 @@ type Props = {
   },
   toggleCommunityMembership: Function,
   dispatch: Dispatch<Object>,
-  threadViewLoading?: boolean,
 };
 
 const MARKDOWN_LINK = /(?:\[(.*?)\]\((.*?)\))/g;
@@ -66,7 +65,6 @@ const renderDescriptionWithLinks = text => {
 class Sidebar extends React.Component<Props> {
   render() {
     const {
-      threadViewLoading,
       thread,
       currentUser,
       location,


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

When we changed the way member counts were queried, it killed the perf of the explore page and also the user onboarding explore page. This is all caused by slow fetches on member counts. I've removed them from the queries since we never actually use those member counts on those views.

Once we have a caching solution figured out we can reintroduce this.

This brings the load time for the explore page from 10s+ to <1s on my machine.