### PR TITLE
Load 25 messages per page in a thread

### DIFF
--- a/api/queries/thread/messageConnection.js
+++ b/api/queries/thread/messageConnection.js
@@ -53,22 +53,22 @@ export default (
   if (cursor) debug(`cursor: ${cursor}`);
 
   let options = {
-    // Default first/last to 50 if their counterparts after/before are provided
+    // Default first/last to 25 if their counterparts after/before are provided
     // so users can query messageConnection(after: "cursor") or (before: "cursor")
     // without any more options
-    first: first ? first : after ? 50 : null,
-    last: last ? last : before ? 50 : null,
+    first: first ? first : after ? 25 : null,
+    last: last ? last : before ? 25 : null,
     // Set after/before to the cursor depending on which one was requested by the user
     after: after ? cursor : null,
     before: before ? cursor : null,
   };
 
   // If we didn't get any arguments at all (i.e messageConnection {})
-  // then just fetch the first 50 messages
+  // then just fetch the first 25 messages
   // $FlowIssue
   if (Object.keys(options).every(key => !options[key])) {
     options = {
-      first: 50,
+      first: 25,
     };
   }
 

--- a/shared/graphql/queries/thread/getThreadMessageConnection.js
+++ b/shared/graphql/queries/thread/getThreadMessageConnection.js
@@ -53,30 +53,30 @@ export const getThreadMessageConnectionOptions = {
       first: null,
     };
 
-    // if the thread has less than 50 messages, just load all of them
-    if (thread.messageCount <= 50) {
+    // if the thread has less than 25 messages, just load all of them
+    if (thread.messageCount <= 25) {
       variables.after = null;
       variables.before = null;
       // $FlowFixMe
-      variables.last = 50;
+      variables.last = 25;
     }
 
-    if (thread.messageCount > 50) {
-      //if the thread has more than 50 messages, we'll likely only want to load the latest 50
+    if (thread.messageCount > 25) {
+      //if the thread has more than 25 messages, we'll likely only want to load the latest 25
       // **unless** the current user hasn't seen the thread before
       // $FlowFixMe
-      variables.last = 50;
+      variables.last = 25;
       if (!thread.currentUserLastSeen) {
         variables.last = null;
       }
     }
 
-    // if it's a watercooler thread only ever load the 50 most recent messages
+    // if it's a watercooler thread only ever load the 25 most recent messages
     if (props.isWatercooler) {
       variables.before = null;
       variables.after = null;
       //$FlowFixMe
-      variables.last = 50;
+      variables.last = 25;
     }
 
     // if a user is visiting a url like /thread/:id#:messageId we can extract
@@ -90,7 +90,7 @@ export const getThreadMessageConnectionOptions = {
         variables.after = params.m;
         variables.last = null;
         // $FlowFixMe
-        variables.first = 50;
+        variables.first = 25;
       }
     }
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

There's really no reason to load 50 messages at once, that's way overboard and blocks slow networks forever. You barely see 10 and we load them in as you scroll pretty aggressively anyway...