### PR TITLE
Store the full user data in the session cookie

### DIFF
--- a/api/authentication.js
+++ b/api/authentication.js
@@ -56,24 +56,25 @@ const init = () => {
   // to avoid having to go to the db on every single request. We have to handle both
   // cases here, as more and more users use Spectrum again we go to the db less and less
   passport.deserializeUser((data, done) => {
-    // Fast path: try to JSON.parse the data
-    // if it works, we got the user data, yay!
+    // Fast path: try to JSON.parse the data if it works, we got the user data, yay!
     try {
       const user = JSON.parse(data);
-      done(null, user);
-      return null;
-      // Slow path: data is the legacy stuff (just the userID), so we have to go to the db to get the full data
-    } catch (err) {
-      return getUser({ id: data })
-        .then(user => {
-          done(null, user);
-          return null;
-        })
-        .catch(err => {
-          done(err);
-          return null;
-        });
-    }
+      // Make sure more than the user ID is in the data by checking any other required
+      // field for existance
+      if (user.id && user.createdAt) {
+        return done(null, user);
+      }
+      // Ignore JSON parsing errors
+    } catch (err) {}
+
+    // Slow path: data is just the userID (legacy), so we have to go to the db to get the full data
+    getUser({ id: data })
+      .then(user => {
+        done(null, user);
+      })
+      .catch(err => {
+        done(err);
+      });
   });
 
   // Set up Twitter login

--- a/api/index.js
+++ b/api/index.js
@@ -82,6 +82,7 @@ app.use('/', (req: express$Request, res: express$Response) => {
 import type { Loader } from './loaders/types';
 export type GraphQLContext = {
   user: DBUser,
+  updateCookieUserData: (data: DBUser) => Promise<void>,
   loaders: {
     [key: string]: Loader,
   },

--- a/api/mutations/message/addMessage.js
+++ b/api/mutations/message/addMessage.js
@@ -321,7 +321,7 @@ export default requireAuth(async (_: any, args: Input, ctx: GraphQLContext) => {
       await addCommunityMember(
         {},
         { input: { communityId: thread.communityId } },
-        { user: user, loaders: loaders }
+        ctx
       );
   }
 

--- a/api/routes/api/graphql.js
+++ b/api/routes/api/graphql.js
@@ -6,6 +6,7 @@ import UserError from '../../utils/UserError';
 import createLoaders from '../../loaders/';
 import createErrorFormatter from '../../utils/create-graphql-error-formatter';
 import schema from '../../schema';
+import type { DBUser } from 'shared/types';
 
 export default graphqlExpress(req => {
   const loaders = createLoaders();
@@ -20,6 +21,10 @@ export default graphqlExpress(req => {
     engine: false,
     context: {
       loaders,
+      updateCookieUserData: (data: DBUser) =>
+        new Promise((res, rej) =>
+          req.login(data, err => (err ? rej(err) : res()))
+        ),
       user: currentUser,
     },
     validationRules: [

--- a/api/utils/session-store.js
+++ b/api/utils/session-store.js
@@ -17,6 +17,17 @@ export const getUserIdFromReq = (req: any): Promise<?string> =>
         return res(null);
       }
 
-      return res(req.session.passport.user);
+      // NOTE(@mxstbr): `req.session.passport.user` used to be just the userID, but is now the full user data
+      // JSON.stringified to avoid having to go to the db on every single request. We have to handle both
+      // cases here to get the ID.
+      let id;
+      try {
+        const user = JSON.parse(req.session.passport.user);
+        id = user.id;
+      } catch (err) {
+        id = req.session.passport.user;
+      }
+
+      return res(id);
     });
   });


### PR DESCRIPTION
### Problem

Right now on every single request to the API we do a db query to get the full user data from the userID which is stored in the session cookie.

That's a big issue. Not only does it mean increased pressure on our database, but it slows down every single request you make to the API -even if the code doesn't even need the full user data!

### First Try Solution

My first idea was to replace `req.user` (express) and `context.user` (graphql) with just the user ID and nothing else. In 99% of cases we only use `user.id` and nothing else!

While that would work, those remaining 1% of cases would be timeconsuming to resolve and would require pretty brittle changes. (how can we make sure we've updated everything? we can't)

### Solution

Instead I realized I can just `JSON.stringify` the entire user data to the cookie—that way we just put the entire user data in `req.user` and `context.user` without a db query at all! :tada:

This requires almost no changes and should help reduce pressure and increase performance for every single request you make to the API.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api