### PR TITLE
Hotfix to account for user object as user id

### DIFF
--- a/api/models/user.js
+++ b/api/models/user.js
@@ -19,7 +19,14 @@ const getUser = async (input: GetUserInput): Promise<?DBUser> => {
 
     // hotfix a malformed payload that is a stringified full user object
     if (userId[0] === '{') {
-      userId = JSON.parse(userId).id;
+      const userObj = JSON.parse(userId);
+      userId = userObj.id;
+      if (userId === undefined) {
+        console.log({
+          error: 'Undefined userId in getUser',
+          data: input,
+        });
+      }
     }
 
     return await getUserById(userId);
@@ -491,7 +498,14 @@ const setUserOnline = (id: string, isOnline: boolean): DBUser => {
 
   let userId = id;
   if (id[0] === '{') {
-    userId = JSON.parse(id).id;
+    const userObj = JSON.parse(id);
+    userId = userObj.id;
+    if (userId === undefined) {
+      console.log({
+        error: 'Undefined userId in setUserOnline',
+        data: id,
+      });
+    }
   }
 
   data.isOnline = isOnline;

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -14,7 +14,17 @@ type GetUserInput = {
 };
 
 const getUser = async (input: GetUserInput): Promise<?DBUser> => {
-  if (input.id) return await getUserById(input.id);
+  if (input.id) {
+    let userId = input.id;
+
+    // hotfix a malformed payload that is a stringified full user object
+    if (userId[0] === '{') {
+      userId = JSON.parse(userId).id;
+    }
+
+    return await getUserById(userId);
+  }
+
   if (input.username) return await getUserByUsername(input.username);
   return null;
 };
@@ -479,11 +489,16 @@ const editUser = (args: EditUserInput, userId: string): Promise<DBUser> => {
 const setUserOnline = (id: string, isOnline: boolean): DBUser => {
   let data = {};
 
+  let userId = id;
+  if (id[0] === '{') {
+    userId = JSON.parse(id).id;
+  }
+
   data.isOnline = isOnline;
   data.lastSeen = new Date();
   return db
     .table('users')
-    .get(id)
+    .get(userId)
     .update(data, { returnChanges: 'always' })
     .run()
     .then(result => {

--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -92,7 +92,13 @@ passport.serializeUser((user, done) => {
 });
 
 passport.deserializeUser((id, done) => {
-  getUser({ id })
+  let userId = id;
+  // hotfix a case where the cookie contained a full user object as a string
+  // and was passing it as the userid to the db request
+  if (id[0] === '{') {
+    userId = JSON.parse(id).id;
+  }
+  getUser({ id: userId })
     .then(user => {
       done(null, user);
     })

--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -96,7 +96,14 @@ passport.deserializeUser((id, done) => {
   // hotfix a case where the cookie contained a full user object as a string
   // and was passing it as the userid to the db request
   if (id[0] === '{') {
-    userId = JSON.parse(id).id;
+    const userObj = JSON.parse(id);
+    userId = userObj.id;
+    if (userId === undefined) {
+      console.log({
+        error: 'Undefined userId in passport deserialization',
+        data: id,
+      });
+    }
   }
   getUser({ id: userId })
     .then(user => {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Hot deploying this to prod.

During the previous prod cut which contained #3944, the entire stringified user object was being passed to a db `.get()` which returned a db error. This hotfix makes a guess if the cookie's deserialized string is an entire user object, in which case we parse it and only send the id to the db as expected