### PR TITLE
Faster unit test fails in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,9 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/spectrum
+      - run:
+          name: Run Unit Tests
+          command: yarn run test:ci
       - run: yarn run db:migrate
       - run: yarn run db:seed
       - run: *setup-and-build-web
@@ -108,9 +111,6 @@ jobs:
       - run: *start-web
       # Wait for the API and webserver to start
       - run: ./node_modules/.bin/wait-on http://localhost:3000 http://localhost:3001
-      - run:
-          name: Run Unit Tests
-          command: yarn run test:ci
       - run:
           name: Build desktop apps
           command: yarn run build:desktop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,11 +112,11 @@ jobs:
       # Wait for the API and webserver to start
       - run: ./node_modules/.bin/wait-on http://localhost:3000 http://localhost:3001
       - run:
-          name: Build desktop apps
-          command: yarn run build:desktop
-      - run:
           name: Run E2E Tests
           command: test $CYPRESS_RECORD_KEY && yarn run test:e2e -- --record || yarn run test:e2e
+      - run:
+          name: Build desktop apps
+          command: yarn run build:desktop
 
   deploy_alpha:
     <<: *js_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,11 +100,11 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/spectrum
+      - run: yarn run db:migrate
+      - run: yarn run db:seed
       - run:
           name: Run Unit Tests
           command: yarn run test:ci
-      - run: yarn run db:migrate
-      - run: yarn run db:seed
       - run: *setup-and-build-web
       - run: *build-api
       - run: *start-api


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

----

- Runs unit tests before building and starting the API and web app in CI—they aren't needed for the unit tests, and it means if there's an issue with the unit tests we'll know about it more quickly
- Builds the desktop apps after running e2e tests in CI—the desktop app builds are usually fine, whereas e2e tests fail more often so we want to more quickly know if it happened

