### PR TITLE
Don't re-render desktop navbar on inbox thread change

### DIFF
--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -51,6 +51,7 @@ class Navbar extends React.Component<Props, State> {
 
   shouldComponentUpdate(nextProps, nextState) {
     const currProps = this.props;
+    const isMobile = window && window.innerWidth <= 768;
 
     // If the update was caused by the focus on the skip link
     if (nextState.isSkipLinkFocused !== this.state.isSkipLinkFocused)
@@ -60,8 +61,9 @@ class Navbar extends React.Component<Props, State> {
     if (currProps.location.pathname !== nextProps.location.pathname)
       return true;
 
-    // if route query params change
-    if (currProps.location.search !== nextProps.location.search) return true;
+    // if route query params change we need to re-render on mobile
+    if (isMobile && currProps.location.search !== nextProps.location.search)
+      return true;
 
     // Had no user, now have user or user changed
     if (nextProps.currentUser !== currProps.currentUser) return true;
@@ -74,15 +76,17 @@ class Navbar extends React.Component<Props, State> {
       nextProps.notificationCounts.notifications;
     if (newDMNotifications || newNotifications) return true;
 
-    // if the user is mobile and is viewing a thread or DM thread, re-render
-    // the navbar when they exit the thread
-    const { thread: thisThreadParam } = queryString.parse(
-      currProps.history.location.search
-    );
-    const { thread: nextThreadParam } = queryString.parse(
-      nextProps.history.location.search
-    );
-    if (thisThreadParam !== nextThreadParam) return true;
+    if (isMobile) {
+      // if the user is mobile and is viewing a thread or DM thread, re-render
+      // the navbar when they exit the thread
+      const { thread: thisThreadParam } = queryString.parse(
+        currProps.history.location.search
+      );
+      const { thread: nextThreadParam } = queryString.parse(
+        nextProps.history.location.search
+      );
+      if (thisThreadParam !== nextThreadParam) return true;
+    }
 
     return false;
   }


### PR DESCRIPTION
This is quite an expensive re-render and totally unnecessary on desktop since the navbar doesn't change at all. Makes switching threads in the inbox feel quite a bit faster!

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)