### PR TITLE
Remove unused access token authentication

### DIFF
--- a/api/routes/auth/create-signin-routes.js
+++ b/api/routes/auth/create-signin-routes.js
@@ -10,7 +10,6 @@
 import passport from 'passport';
 import { URL } from 'url';
 import isSpectrumUrl from '../../utils/is-spectrum-url';
-import { signCookie, getCookies } from 'shared/cookie-utils';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
 const FALLBACK_URL = IS_PROD
@@ -35,10 +34,6 @@ export const createSigninRoutes = (
       // Attach the redirectURL and authType to the session so we have it in the /auth/twitter/callback route
       // $FlowIssue
       req.session.redirectUrl = url;
-      if (req.query.authType === 'token') {
-        // $FlowIssue
-        req.session.authType = 'token';
-      }
 
       return passport.authenticate(strategy, strategyOptions)(req, ...rest);
     },
@@ -55,27 +50,6 @@ export const createSigninRoutes = (
           : new URL(FALLBACK_URL);
         redirectUrl.searchParams.append('authed', 'true');
 
-        // Add the session cookies to the query params if token authentication
-        if (
-          // $FlowIssue
-          req.session.authType === 'token' &&
-          req.session.passport &&
-          req.session.passport.user
-        ) {
-          const cookies = getCookies({ userId: req.session.passport.user });
-
-          redirectUrl.searchParams.append(
-            'accessToken',
-            signCookie(
-              `session=${cookies.session}; session.sig=${
-                cookies['session.sig']
-              }`
-            )
-          );
-        }
-
-        // $FlowIssue
-        req.session.authType = undefined;
         // Delete the redirectURL from the session again so we don't redirect
         // to the old URL the next time around
         // $FlowIssue

--- a/api/routes/middlewares/index.js
+++ b/api/routes/middlewares/index.js
@@ -1,5 +1,4 @@
 import { Router } from 'express';
-import jwt from 'jsonwebtoken';
 
 const middlewares = Router();
 
@@ -13,17 +12,6 @@ if (process.env.NODE_ENV === 'production' && !process.env.FORCE_DEV) {
   const raven = require('shared/middlewares/raven').default;
   middlewares.use(raven);
 }
-
-middlewares.use((req, res, next) => {
-  if (req.headers && req.headers.authorization) {
-    const token = req.headers.authorization.replace(/^\s*Bearer\s*/, '');
-    try {
-      const decoded = jwt.verify(token, process.env.API_TOKEN_SECRET);
-      if (decoded.cookie) req.headers.cookie = decoded.cookie;
-    } catch (err) {}
-  }
-  next();
-});
 
 // Cross origin request support
 import cors from 'shared/middlewares/cors';


### PR DESCRIPTION
This was only used for the mobile apps, so this is no longer necessary.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api