### PR TITLE
Fix cover photo uploads breaking

### DIFF
--- a/api/mutations/user/editUser.js
+++ b/api/mutations/user/editUser.js
@@ -1,4 +1,5 @@
 // @flow
+import Raven from 'shared/raven';
 import type { GraphQLContext } from '../../';
 import type { EditUserInput } from '../../models/user';
 import UserError from '../../utils/UserError';
@@ -47,11 +48,17 @@ export default requireAuth(
       }
     }
 
-    await updateCookieUserData({
-      ...(await getUser({ id: currentUser.id })),
-      ...args.input,
-      file: undefined,
+    return editUser(args, user.id).then(async res => {
+      await updateCookieUserData({
+        ...res,
+      }).catch(err => {
+        Raven.captureException(
+          new Error(`Error updating cookie user data: ${err.message}`)
+        );
+        return res;
+      });
+
+      return res;
     });
-    return editUser(args, user.id);
   }
 );


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

Closes #4076, although there's still a problem with caching on the client. But this at least lets new photos to be uploaded and set as user fields.