### PR TITLE
Fix bad community member count

### DIFF
--- a/api/migrations/20181023160027-update-denormalized-member-counts.js
+++ b/api/migrations/20181023160027-update-denormalized-member-counts.js
@@ -1,0 +1,39 @@
+exports.up = function(r, conn) {
+  return Promise.all([
+    r
+      .table('communities')
+      .update(
+        {
+          memberCount: r
+            .table('usersCommunities')
+            .getAll(r.row('id'), { index: 'communityId' })
+            .filter(row => row('isMember').eq(true))
+            .count()
+            .default(1),
+        },
+        {
+          nonAtomic: true,
+        }
+      )
+      .run(conn),
+    r
+      .table('channels')
+      .update(
+        {
+          memberCount: r
+            .table('usersChannels')
+            .getAll(r.row('id'), { index: 'channelId' })
+            .filter(row => row('isMember').eq(true))
+            .count()
+            .default(1),
+        },
+        {
+          nonAtomic: true,
+        }
+      )
+      .run(conn),
+  ]).catch(err => console.error(err));
+};
+exports.down = function(r, conn) {
+  return Promise.resolve();
+};

--- a/api/models/channel.js
+++ b/api/models/channel.js
@@ -195,7 +195,7 @@ const createChannel = ({ input }: CreateChannelInput, userId: string): Promise<D
         slug,
         isPrivate,
         isDefault: isDefault ? true : false,
-        memberCount: 1,
+        memberCount: 0,
       },
       { returnChanges: true }
     )

--- a/api/models/community.js
+++ b/api/models/community.js
@@ -240,7 +240,7 @@ export const createCommunity = ({ input }: CreateCommunityInput, user: DBUser): 
         creatorId: user.id,
         administratorEmail: user.email,
         isPrivate,
-        memberCount: 1,
+        memberCount: 0,
       },
       { returnChanges: true }
     )

--- a/cypress/integration/thread/view_spec.js
+++ b/cypress/integration/thread/view_spec.js
@@ -71,9 +71,7 @@ describe('sidebar components on thread view', () => {
 
     it('should render', () => {
       // loaded login upsell in sidebar
-      cy.get('[data-cy="thread-sidebar-login"]')
-        .scrollIntoView()
-        .should('not.be.visible');
+      cy.get('[data-cy="thread-sidebar-login"]').should('not.be.visible');
 
       // loaded community info
       cy.get('[data-cy="thread-sidebar-community-info"]')
@@ -100,9 +98,7 @@ describe('sidebar components on thread view', () => {
 
     it('should render', () => {
       // loaded login upsell in sidebar
-      cy.get('[data-cy="thread-sidebar-login"]')
-        .scrollIntoView()
-        .should('not.be.visible');
+      cy.get('[data-cy="thread-sidebar-login"]').should('not.be.visible');
 
       // loaded community info
       cy.get('[data-cy="thread-sidebar-community-info"]')

--- a/cypress/integration/thread/view_spec.js
+++ b/cypress/integration/thread/view_spec.js
@@ -1,4 +1,3 @@
-// @flow
 import data from '../../../shared/testing/data';
 import { toPlainText, toState } from '../../../shared/draft-utils';
 import constants from '../../../api/migrations/seed/default/constants';

--- a/cypress/integration/thread/view_spec.js
+++ b/cypress/integration/thread/view_spec.js
@@ -1,3 +1,4 @@
+// @flow
 import data from '../../../shared/testing/data';
 import { toPlainText, toState } from '../../../shared/draft-utils';
 import constants from '../../../api/migrations/seed/default/constants';
@@ -42,18 +43,24 @@ describe('sidebar components on thread view', () => {
 
     it('should render', () => {
       // loaded login upsell in sidebar
-      cy.get('[data-cy="thread-sidebar-login"]').should('be.visible');
-
-      // loaded community info
-      cy.get('[data-cy="thread-sidebar-community-info"]').should('be.visible');
-
-      // loaded join button which directs to login
-      cy
-        .get('[data-cy="thread-sidebar-join-login-button"]')
+      cy.get('[data-cy="thread-sidebar-login"]')
+        .scrollIntoView()
         .should('be.visible');
 
+      // loaded community info
+      cy.get('[data-cy="thread-sidebar-community-info"]')
+        .scrollIntoView()
+        .should('be.visible');
+
+      // loaded join button which directs to login
+      cy.get('[data-cy="thread-sidebar-join-login-button"]').should(
+        'be.visible'
+      );
+
       // loaded more conversations component
-      cy.get('[data-cy="thread-sidebar-more-threads"]').should('be.visible');
+      cy.get('[data-cy="thread-sidebar-more-threads"]')
+        .scrollIntoView()
+        .should('be.visible');
     });
   });
 
@@ -65,18 +72,24 @@ describe('sidebar components on thread view', () => {
 
     it('should render', () => {
       // loaded login upsell in sidebar
-      cy.get('[data-cy="thread-sidebar-login"]').should('not.be.visible');
+      cy.get('[data-cy="thread-sidebar-login"]')
+        .scrollIntoView()
+        .should('not.be.visible');
 
       // loaded community info
-      cy.get('[data-cy="thread-sidebar-community-info"]').should('be.visible');
+      cy.get('[data-cy="thread-sidebar-community-info"]')
+        .scrollIntoView()
+        .should('be.visible');
 
       // loaded join button which directs to login
-      cy
-        .get('[data-cy="thread-sidebar-join-community-button"]')
+      cy.get('[data-cy="thread-sidebar-join-community-button"]')
+        .scrollIntoView()
         .should('be.visible');
 
       // loaded more conversations component
-      cy.get('[data-cy="thread-sidebar-more-threads"]').should('be.visible');
+      cy.get('[data-cy="thread-sidebar-more-threads"]')
+        .scrollIntoView()
+        .should('be.visible');
     });
   });
 
@@ -88,18 +101,24 @@ describe('sidebar components on thread view', () => {
 
     it('should render', () => {
       // loaded login upsell in sidebar
-      cy.get('[data-cy="thread-sidebar-login"]').should('not.be.visible');
+      cy.get('[data-cy="thread-sidebar-login"]')
+        .scrollIntoView()
+        .should('not.be.visible');
 
       // loaded community info
-      cy.get('[data-cy="thread-sidebar-community-info"]').should('be.visible');
+      cy.get('[data-cy="thread-sidebar-community-info"]')
+        .scrollIntoView()
+        .should('be.visible');
 
       // loaded join button which directs to login
-      cy
-        .get('[data-cy="thread-sidebar-view-community-button"]')
+      cy.get('[data-cy="thread-sidebar-view-community-button"]')
+        .scrollIntoView()
         .should('be.visible');
 
       // loaded more conversations component
-      cy.get('[data-cy="thread-sidebar-more-threads"]').should('be.visible');
+      cy.get('[data-cy="thread-sidebar-more-threads"]')
+        .scrollIntoView()
+        .should('be.visible');
     });
   });
 });
@@ -125,9 +144,9 @@ describe('public thread', () => {
       // thread author info loaded
       cy.contains(publicThreadAuthor.name);
       cy.contains(publicThreadAuthor.username);
-      cy
-        .get(`[href*="/users/${publicThreadAuthor.username}"]`)
-        .should('be.visible');
+      cy.get(`[href*="/users/${publicThreadAuthor.username}"]`).should(
+        'be.visible'
+      );
     });
   });
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

**Run database migrations (delete if no migration was added)**
YES

@mxstbr we can't init communities and channels with a member count of 1 because we immediately call `createOwnerInCommunity` and `createOwnerInChannel` after the creation. This has been resulting in new communities having a member count of 2.

Also copy/pasted the old migration to backfill bad data.