### PR TITLE
Disable alpha deployments via ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,23 +118,23 @@ jobs:
           name: Build desktop apps
           command: yarn run build:desktop
 
-  deploy_alpha:
-    <<: *js_defaults
-    docker:
-      - image: circleci/node:8-browsers
-    steps:
-      - attach_workspace:
-          at: ~/spectrum
-      - run: *build-api
-      - run:
-          name: Deploy and alias API
-          command: |
-            cd build-api
-            npx now-cd --alias "alpha=api.alpha.spectrum.chat" --team space-program
-            cd ..
-      - run:
-          name: Deploy and alias Hyperion
-          command: npx now-cd --alias "alpha=hyperion.alpha.spectrum.chat" --team space-program
+  # deploy_alpha:
+    # <<: *js_defaults
+    # docker:
+      # - image: circleci/node:8-browsers
+    # steps:
+      # - attach_workspace:
+          # at: ~/spectrum
+      # - run: *build-api
+      # - run:
+          # name: Deploy and alias API
+          # command: |
+            # cd build-api
+            # npx now-cd --alias "alpha=api.alpha.spectrum.chat" --team space-program
+            # cd ..
+      # - run:
+          # name: Deploy and alias Hyperion
+          # command: npx now-cd --alias "alpha=hyperion.alpha.spectrum.chat" --team space-program
 
   # Run eslint, flow etc.
   test_static_js:


### PR DESCRIPTION
It's getting really bothersome to always have extra deploys floating around with the bad `apialphaspectrum.chat` aliases. Disabling for now until it's fixed downstream.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing
