### PR TITLE
Perf improvements for daily and weekly digests

### DIFF
--- a/api/migrations/20181024173616-indexes-for-digests.js
+++ b/api/migrations/20181024173616-indexes-for-digests.js
@@ -1,0 +1,31 @@
+exports.up = function(r, conn) {
+  return Promise.all([
+    r
+      .table('usersSettings')
+      .indexCreate(
+        'weeklyDigestEmail',
+        r.row('notifications')('types')('weeklyDigest')('email')
+      )
+      .run(conn),
+    r
+      .table('usersSettings')
+      .indexCreate(
+        'dailyDigestEmail',
+        r.row('notifications')('types')('dailyDigest')('email')
+      )
+      .run(conn),
+  ]);
+};
+
+exports.down = function(r, conn) {
+  return Promise.all([
+    r
+      .table('usersSettings')
+      .indexDrop('weeklyDigestEmail')
+      .run(conn),
+    r
+      .table('usersSettings')
+      .indexDrop('dailyDigestEmail')
+      .run(conn),
+  ]);
+};

--- a/chronos/models/community.js
+++ b/chronos/models/community.js
@@ -32,15 +32,9 @@ export const getCommunitiesWithMinimumMembers = (
   communityIds: Array<string>
 ) => {
   return db
-    .table('usersCommunities')
-    .getAll(...communityIds, { index: 'communityId' })
-    .group('communityId')
-    .ungroup()
-    .filter(row =>
-      row('reduction')
-        .count()
-        .gt(min)
-    )
-    .map(row => row('group'))
+    .table('communities')
+    .filter(row => row('memberCount').ge(min))
+    .filter(community => community.hasFields('deletedAt').not())
+    .map(row => row('id'))
     .run();
 };

--- a/chronos/models/coreMetrics.js
+++ b/chronos/models/coreMetrics.js
@@ -77,7 +77,6 @@ export const getCount = (table: string, filter: mixed) => {
   if (filter) {
     return db
       .table(table)
-      .filter(filter)
       .filter(row => db.not(row.hasFields('deletedAt')))
       .count()
       .run();

--- a/chronos/models/usersSettings.js
+++ b/chronos/models/usersSettings.js
@@ -1,42 +1,14 @@
 // @flow
 const { db } = require('./db');
 
-export const getUsersForDigest = (
-  timeframe: string
-): Promise<Array<Object>> => {
-  let range;
-  switch (timeframe) {
-    case 'daily': {
-      range = 'dailyDigest';
-      break;
-    }
-    case 'weekly': {
-      range = 'weeklyDigest';
-      break;
-    }
-  }
-
-  return (
-    db
-      .table('usersSettings')
-      .filter(row => row('notifications')('types')(range)('email').eq(true))
-      .eqJoin('userId', db.table('users'))
-      .zip()
-      .pluck(['userId', 'email', 'firstName', 'name', 'username', 'lastSeen'])
-      // save some processing time by making sure the user has an email address
-      .filter(row => row('email').ne(null))
-      // save some processing time by making sure the user has a username
-      .filter(row => row.hasFields('username').and(row('username').ne(null)))
-      // save some processing time by making sure the user was active in the last month
-      .filter(row =>
-        row
-          .hasFields('lastSeen')
-          .and(
-            row('lastSeen').during(db.now().sub(60 * 60 * 24 * 30), db.now())
-          )
-      )
-      .pluck(['userId', 'email', 'firstName', 'name', 'username'])
-      .distinct()
-      .run()
-  );
+// prettier-ignore
+export const getUsersForDigest = (timeframe: string): Promise<Array<Object>> => {
+  let range = timeframe === 'daily' ? 'dailyDigest' : 'weeklyDigest';
+  return db
+    .table('usersSettings')
+    .getAll(true, { index: `${range}Email` })
+    .eqJoin('userId', db.table('users'))
+    .zip()
+    .pluck(['userId', 'email', 'firstName', 'name', 'username'])
+    .run()
 };

--- a/chronos/queues/coreMetrics/index.js
+++ b/chronos/queues/coreMetrics/index.js
@@ -72,14 +72,6 @@ export default async () => {
   // 13
   const dmThreads = await getCount('directMessageThreads');
 
-  // 14
-  const threadMessages = await getCount('messages', { threadType: 'story' });
-
-  // 15
-  const dmMessages = await getCount('messages', {
-    threadType: 'directMessageThread',
-  });
-
   const coreMetrics = {
     dau,
     wau,
@@ -97,8 +89,6 @@ export default async () => {
     communities,
     threads,
     dmThreads,
-    threadMessages,
-    dmMessages,
   };
 
   try {

--- a/chronos/queues/digests/index.js
+++ b/chronos/queues/digests/index.js
@@ -37,6 +37,7 @@ export default async (job: DigestJob) => {
     debug('\n ❌ No threads found for this digest');
     return;
   }
+
   debug('\n ⚙️ Fetched threads for digest');
 
   const threadsWithData = await attachDataToThreads(threads);
@@ -44,6 +45,7 @@ export default async (job: DigestJob) => {
     debug('\n ❌ No threads with data eligible for this digest');
     return;
   }
+
   debug('\n ⚙️ Processed threads with data');
 
   // 2
@@ -60,6 +62,8 @@ export default async (job: DigestJob) => {
 
   // 4
   const usersPromises = users.map(user => {
+    if (!user.email || !user.username) return null;
+
     try {
       return addQueue(
         PROCESS_INDIVIDUAL_DIGEST,
@@ -72,12 +76,13 @@ export default async (job: DigestJob) => {
     } catch (err) {
       debug(err);
       Raven.captureException(err);
+      return null;
     }
   });
 
   debug('\n ⚙️ Created individual jobs for each users digest');
   try {
-    return Promise.all(usersPromises);
+    return Promise.all(usersPromises.filter(Boolean));
   } catch (err) {
     debug('❌ Error in job:\n');
     debug(err);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- chronos

**Run database migrations (delete if no migration was added)**
YES

cc @mxstbr for review. This is incremental, we still have some performance issues calculating our core metrics entries for each day. One of the rough queries is trying to determine the number of messages vs direct messages that exist in the messages table. Right now we're doing a `.table('messages').filter({ threadType: 'story' })` which is filtering on...every record in that db :P

Not sure if we reallly want to index against that so that we can run the coreMetrics job...what do you think? If you feel that's useful I'll add the indexes, otherwise maybe we consider removing some the more expensive fields from the core metrics records?

Regardless, this PR should lighten up a ton of load on the `usersCommunities` and `usersSettings` tables with each digest.