### PR TITLE
DB lookup on mutations for banned and deleted users

### DIFF
--- a/api/utils/permissions.js
+++ b/api/utils/permissions.js
@@ -26,8 +26,14 @@ export const channelSlugIsBlacklisted = (slug: string): boolean => {
 };
 
 // prettier-ignore
-export const isAuthedResolver = (resolver: Function) => (obj: any, args: any, context: GraphQLContext, info: any) => {
+export const isAuthedResolver = (resolver: Function) => async (obj: any, args: any, context: GraphQLContext, info: any) => {
   if (!context.user || !context.user.id) {
+    return new UserError('You must be signed in to do this')
+  }
+
+  const user = await context.loaders.user.load(context.user.id)
+
+  if (!user || user.bannedAt || user.deletedAt) {
     return new UserError('You must be signed in to do this')
   }
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

@mxstbr I think this is the best move right now. The `requireAuth` wrapper mostly only happens on mutations, not queries, so this won't have any performance impact on reads and client speed.