### PR TITLE
Fully deprecate attachments on thread model

### DIFF
--- a/api/migrations/20181027050052-remove-attachments-from-thread-model.js
+++ b/api/migrations/20181027050052-remove-attachments-from-thread-model.js
@@ -1,0 +1,13 @@
+exports.up = function(r, conn) {
+  return Promise.all([
+    r
+      .table('threads')
+      .update({
+        attachments: r.literal(),
+      })
+      .run(conn),
+  ]).catch(err => console.error(err));
+};
+exports.down = function(r, conn) {
+  return Promise.resolve();
+};

--- a/api/migrations/seed/default/messages.js
+++ b/api/migrations/seed/default/messages.js
@@ -7,7 +7,6 @@ module.exports = [
   {
     id: '1',
     threadId: 'thread-1',
-    attachments: [],
     content: {
       body: JSON.stringify({
         blocks: [
@@ -32,7 +31,6 @@ module.exports = [
   {
     id: '2',
     threadId: 'thread-1',
-    attachments: [],
     content: {
       body: JSON.stringify(
         toJSON(fromPlainText('This is the second message!'))
@@ -46,7 +44,6 @@ module.exports = [
   {
     id: '3',
     threadId: 'thread-1',
-    attachments: [],
     content: {
       body: JSON.stringify(
         toJSON(fromPlainText('The next one is an emoji-only one :scream:'))
@@ -60,7 +57,6 @@ module.exports = [
   {
     id: '4',
     threadId: 'thread-1',
-    attachments: [],
     content: {
       body: JSON.stringify(toJSON(fromPlainText('🎉'))),
     },
@@ -73,7 +69,6 @@ module.exports = [
   {
     id: '5',
     threadId: 'thread-2',
-    attachments: [],
     content: {
       body: JSON.stringify({
         blocks: [
@@ -98,7 +93,6 @@ module.exports = [
   {
     id: '6',
     threadId: 'thread-2',
-    attachments: [],
     content: {
       body: JSON.stringify(
         toJSON(fromPlainText('This is the second message!'))
@@ -112,7 +106,6 @@ module.exports = [
   {
     id: '7',
     threadId: 'thread-2',
-    attachments: [],
     content: {
       body: JSON.stringify(
         toJSON(fromPlainText('The next one is an emoji-only one :scream:'))
@@ -126,7 +119,6 @@ module.exports = [
   {
     id: '8',
     threadId: 'thread-2',
-    attachments: [],
     content: {
       body: JSON.stringify(toJSON(fromPlainText('🎉'))),
     },
@@ -141,7 +133,6 @@ module.exports = [
     id: '9',
     threadId: 'dm-1',
     threadType: 'directMessageThread',
-    attachments: [],
     content: {
       body: JSON.stringify(
         toJSON(fromPlainText('Direct message thread message!'))
@@ -155,7 +146,6 @@ module.exports = [
     id: '10',
     threadId: 'dm-1',
     threadType: 'directMessageThread',
-    attachments: [],
     content: {
       body: JSON.stringify(toJSON(fromPlainText('A second one'))),
     },
@@ -167,7 +157,6 @@ module.exports = [
     id: '11',
     threadId: 'dm-1',
     threadType: 'directMessageThread',
-    attachments: [],
     content: {
       body: JSON.stringify(toJSON(fromPlainText('A third one'))),
     },
@@ -179,7 +168,6 @@ module.exports = [
     id: '12',
     threadId: 'dm-1',
     threadType: 'directMessageThread',
-    attachments: [],
     content: {
       body: JSON.stringify(toJSON(fromPlainText('A fourth one'))),
     },
@@ -191,7 +179,6 @@ module.exports = [
     id: '13',
     threadId: 'dm-1',
     threadType: 'directMessageThread',
-    attachments: [],
     content: {
       body: JSON.stringify(toJSON(fromPlainText('A fifth one'))),
     },

--- a/api/migrations/seed/default/threads.js
+++ b/api/migrations/seed/default/threads.js
@@ -33,7 +33,6 @@ module.exports = [
         toJSON(fromPlainText('This is it, we got a thread here'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE),
@@ -65,7 +64,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 1),
@@ -97,7 +95,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 2),
@@ -130,7 +127,6 @@ module.exports = [
         toJSON(fromPlainText('This is it, we got a thread here'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE),
@@ -162,7 +158,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 1),
@@ -194,7 +189,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 2),
@@ -226,7 +220,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 2),
@@ -259,7 +252,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 2),
@@ -291,7 +283,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 2),
@@ -322,7 +313,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 2),
@@ -352,7 +342,6 @@ module.exports = [
       title: 'Deleted thread',
       body: JSON.stringify(toJSON(fromPlainText('This is a deleted thread'))),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 2),
@@ -386,7 +375,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 2),
@@ -420,7 +408,6 @@ module.exports = [
         toJSON(fromPlainText('This is just another thread'))
       ),
     },
-    attachments: [],
     edits: [
       {
         timestamp: new Date(DATE + 2),

--- a/api/migrations/seed/generate.js
+++ b/api/migrations/seed/generate.js
@@ -181,7 +181,6 @@ const generateThread = (communityId, channelId, creatorId) => {
     communityId,
     isPublished: faker.random.boolean(),
     content,
-    attachments: [],
     type: 'DRAFTJS',
     lastActive: faker.date.between(createdAt, new Date()),
     edits: [
@@ -244,7 +243,6 @@ const generateMessage = (senderId, threadId, threadType) => {
     content: {
       body: casual.text(),
     },
-    attachments: [],
     messageType: 'text',
     timestamp: faker.date.past(2),
   };

--- a/api/models/thread.js
+++ b/api/models/thread.js
@@ -534,18 +534,12 @@ export const deleteThread = (threadId: string, userId: string): Promise<Boolean>
 
 type File = FileUpload;
 
-type Attachment = {
-  attachmentType: string,
-  data: string,
-};
-
 export type EditThreadInput = {
   threadId: string,
   content: {
     title: string,
     body: ?string,
   },
-  attachments?: ?Array<Attachment>,
   filesToUpload?: ?Array<File>,
 };
 
@@ -558,11 +552,9 @@ export const editThread = (input: EditThreadInput, userId: string, shouldUpdate:
     .update(
       {
         content: input.content,
-        attachments: input.attachments,
         modifiedAt: shouldUpdate ? new Date() : null,
         edits: db.row('edits').append({
           content: db.row('content'),
-          attachments: db.row('attachments'),
           timestamp: new Date(),
         }),
       },

--- a/api/mutations/thread/editThread.js
+++ b/api/mutations/thread/editThread.js
@@ -78,27 +78,12 @@ export default requireAuth(async (_: any, args: Input, ctx: GraphQLContext) => {
     );
   }
 
-  let attachments = [];
-  // if the thread came in with attachments
-  if (input.attachments) {
-    // iterate through them and construct a new attachment object
-    input.attachments.map(attachment => {
-      attachments.push({
-        attachmentType: attachment.attachmentType,
-        data: JSON.parse(attachment.data),
-      });
-
-      return null;
-    });
-  }
-
   const newInput = Object.assign({}, input, {
     ...input,
     content: {
       ...input.content,
       title: input.content.title.trim(),
     },
-    attachments,
   });
 
   // $FlowIssue

--- a/api/mutations/thread/publishThread.js
+++ b/api/mutations/thread/publishThread.js
@@ -31,11 +31,6 @@ const threadBodyToPlainText = (body: any): string =>
 const MEMBER_SPAM_LMIT = 3;
 const SPAM_TIMEFRAME = 60 * 10;
 
-type Attachment = {
-  attachmentType: string,
-  data: string,
-};
-
 type File = FileUpload;
 
 export type PublishThreadInput = {
@@ -47,7 +42,6 @@ export type PublishThreadInput = {
       title: string,
       body?: string,
     },
-    attachments?: ?Array<Attachment>,
     filesToUpload?: ?Array<File>,
   },
 };
@@ -256,17 +250,6 @@ export default requireAuth(
       }
     }
 
-    /*
-    If the thread has attachments, we have to iterate through each attachment and JSON.parse() the data payload. This is because we want a generic data shape in the graphQL layer like this:
-
-    {
-      attachmentType: enum String
-      data: String
-    }
-
-    But when we get the data onto the client we JSON.parse the `data` field so that we can have any generic shape for attachments in the future.
-  */
-
     let threadObject = Object.assign(
       {},
       {
@@ -277,21 +260,6 @@ export default requireAuth(
         },
       }
     );
-    // if the thread has attachments
-    if (thread.attachments) {
-      // iterate through them and construct a new attachment object
-      const attachments = thread.attachments.map(attachment => {
-        return {
-          attachmentType: attachment.attachmentType,
-          data: JSON.parse(attachment.data),
-        };
-      });
-
-      // create a new thread object, overriding the attachments field with our new array
-      threadObject = Object.assign({}, threadObject, {
-        attachments,
-      });
-    }
 
     // $FlowFixMe
     const dbThread: DBThread = await publishThread(threadObject, user.id);

--- a/api/queries/thread/attachments.js
+++ b/api/queries/thread/attachments.js
@@ -1,11 +1,9 @@
 // @flow
+/*
+
+Deprecated Oct 26 2018 by @brian
+
+*/
 import type { DBThread } from 'shared/types';
 
-export default ({ attachments }: DBThread) =>
-  attachments &&
-  attachments.map(attachment => {
-    return {
-      attachmentType: attachment.attachmentType,
-      data: JSON.stringify(attachment.data),
-    };
-  });
+export default () => [];

--- a/api/test/channel/mutations/deleteChannel.test.js
+++ b/api/test/channel/mutations/deleteChannel.test.js
@@ -56,7 +56,6 @@ const DEFAULT_THREADS = [
       title: 'The first thread! 🎉',
       body: '',
     },
-    attachments: [],
     edits: [],
     modifiedAt: new Date(DATE),
     lastActive: new Date(DATE),
@@ -73,7 +72,6 @@ const DEFAULT_THREADS = [
       title: 'Another thread',
       body: '',
     },
-    attachments: [],
     edits: [],
     modifiedAt: new Date(DATE + 1),
     lastActive: new Date(DATE + 1),
@@ -90,7 +88,6 @@ const DEFAULT_THREADS = [
       title: 'Yet another thread',
       body: '',
     },
-    attachments: [],
     edits: [],
     modifiedAt: new Date(DATE + 2),
     lastActive: new Date(DATE + 2),
@@ -140,8 +137,8 @@ const variables = {
 it('should delete a channel if user is owner', async () => {
   const query = /* GraphQL */ `
     mutation deleteChannel($channelId: ID!) {
-      deleteChannel (channelId: $channelId)
-    },
+      deleteChannel(channelId: $channelId)
+    }
   `;
 
   const context = {
@@ -157,8 +154,8 @@ it('should delete a channel if user is owner', async () => {
 it('should not delete a channel if user is not owner', async () => {
   const query = /* GraphQL */ `
     mutation deleteChannel($channelId: ID!) {
-      deleteChannel (channelId: $channelId)
-    },
+      deleteChannel(channelId: $channelId)
+    }
   `;
 
   const context = {
@@ -174,8 +171,8 @@ it('should not delete a channel if user is not owner', async () => {
 it('should not delete a channel if user is not signed in', async () => {
   const query = /* GraphQL */ `
     mutation deleteChannel($channelId: ID!) {
-      deleteChannel (channelId: $channelId)
-    },
+      deleteChannel(channelId: $channelId)
+    }
   `;
 
   expect.assertions(1);
@@ -187,8 +184,8 @@ it('should not delete a channel if user is not signed in', async () => {
 it('should not delete the general channel', async () => {
   const query = /* GraphQL */ `
     mutation deleteChannel($channelId: ID!) {
-      deleteChannel (channelId: $channelId)
-    },
+      deleteChannel(channelId: $channelId)
+    }
   `;
 
   const context = {
@@ -215,8 +212,8 @@ it('should delete all threads in the deleted channel', async () => {
 
   const query = /* GraphQL */ `
     mutation deleteChannel($channelId: ID!) {
-      deleteChannel (channelId: $channelId)
-    },
+      deleteChannel(channelId: $channelId)
+    }
   `;
 
   const context = {

--- a/api/types/Thread.js
+++ b/api/types/Thread.js
@@ -65,11 +65,12 @@ const Thread = /* GraphQL */ `
     ): ThreadMessagesConnection! @cost(complexity: 1, multipliers: ["first"])
     messageCount: Int @cost(complexity: 1)
     author: ThreadParticipant! @cost(complexity: 2)
-    attachments: [Attachment]
     watercooler: Boolean
     currentUserLastSeen: Date @cost(complexity: 1)
     reactions: ThreadReactions @cost(complexity: 1)
 
+    attachments: [Attachment]
+      @deprecated(reason: "Attachments no longer used for link previews")
     isCreator: Boolean @deprecated(reason: "Use Thread.isAuthor instead")
     creator: User! @deprecated(reason: "Use Thread.author instead")
   }

--- a/api/utils/file-storage.js
+++ b/api/utils/file-storage.js
@@ -6,13 +6,13 @@ import type { FileUpload, EntityTypes } from 'shared/types';
 const { FILE_STORAGE } = process.env;
 
 const getUploadImageFn = () => {
-  switch (FILE_STORAGE) {
-    case 'local':
-      return require('./file-system').uploadImage;
-    case 's3':
-    default:
-      return require('./s3').uploadImage;
-  }
+  // switch (FILE_STORAGE) {
+  //   case 'local':
+  //     return require('./file-system').uploadImage;
+  //   case 's3':
+  //   default:
+  return require('./s3').uploadImage;
+  // }
 };
 
 const uploadImageFn = getUploadImageFn();

--- a/api/utils/file-storage.js
+++ b/api/utils/file-storage.js
@@ -6,13 +6,13 @@ import type { FileUpload, EntityTypes } from 'shared/types';
 const { FILE_STORAGE } = process.env;
 
 const getUploadImageFn = () => {
-  // switch (FILE_STORAGE) {
-  //   case 'local':
-  //     return require('./file-system').uploadImage;
-  //   case 's3':
-  //   default:
-  return require('./s3').uploadImage;
-  // }
+  switch (FILE_STORAGE) {
+    case 'local':
+      return require('./file-system').uploadImage;
+    case 's3':
+    default:
+      return require('./s3').uploadImage;
+  }
 };
 
 const uploadImageFn = getUploadImageFn();


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

Closes #4136 

The reason that image uploads broke was because of https://github.com/withspectrum/spectrum/pull/4126, but for a very non-obvious reason. When a thread is published, the order of operations is this:

1. Thread object is created in the db
2. If the input args for the graphql mutation contain files to upload, we upload each url to s3
  2a. If no input files are detected, the db thread is returned to the client normally
3. For the returned s3 urls, we mutate the draftjs thread content to insert the s3 urls
4. With the mutated draftjs content, we perform an `editThread` with the new draftjs body 
5. We return the edited thread to the client

The problem was in step number 4 above. The `editThread` returned this gnarly error:
```
{ result:
   { changes: [ [Object] ],
     deleted: 0,
     errors: 1,
     first_error:
      'No attribute `attachments` in object: /* thread content */'
     inserted: 0,
     replaced: 0,
     skipped: 0,
     unchanged: 0 } }
```

In https://github.com/withspectrum/spectrum/pull/4126 I'd removed the attachments field from the arguments passed into `editThread` which caused this `.update` in the db to fail.

This PR fully finishes the work in #4126 to remove attachments entirely from the thread model. If we revisit this in the future we can use this as reference for reconstructing the functionality in a better way, but for now it makes sense to entirely remove the complexity from the codebase to avoid any confusion about what attachments are (and the fact that #4126 removed them from being used at all on the client)

Note: A migration will need to be run after this to remove the `attachments` field from historical threads in the db. You cool with this @mxstbr ?