### PR TITLE
Let workflows pass again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,10 +213,10 @@ workflows:
             - checkout_environment
 
       # Deployment
-      - deploy_alpha:
-          requires:
-            - test_static_js
-            - test_web
-          filters:
-            branches:
-              only: alpha
+      # - deploy_alpha:
+          # requires:
+            # - test_static_js
+            # - test_web
+          # filters:
+            # branches:
+              # only: alpha


### PR DESCRIPTION
I forgot to comment this last bit out when disabling alpha deploys, causing us to get build failed notifications even though builds pass.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing