### PR TITLE
Dont track specific auth-bound routes with postmark

### DIFF
--- a/email-templates/mentionInMessage.html
+++ b/email-templates/mentionInMessage.html
@@ -464,7 +464,7 @@
                             <table cellpadding="0" cellspacing="0" class="reply-body">
                               <tr width="100%" cellpadding="0" cellspacing="0">
                                 <td valign="middle">
-                                  <a href="https://spectrum.chat/thread/{{data.thread.id}}" class="block">
+                                  <a data-pm-no-track href="https://spectrum.chat/thread/{{data.thread.id}}" class="block">
                                     <p>{{data.message.content.body}}</p>
                                   </a>
                                 </td>
@@ -478,7 +478,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-actions">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/thread/{{data.thread.id}}" class="button">
+                            <a data-pm-no-track href="https://spectrum.chat/thread/{{data.thread.id}}" class="button">
                               View conversation
                             </a>
                           </td>

--- a/email-templates/mentionInThread.html
+++ b/email-templates/mentionInThread.html
@@ -429,7 +429,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-title">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/thread/{{data.thread.id}}" class="block">
+                            <a data-pm-no-track href="https://spectrum.chat/thread/{{data.thread.id}}" class="block">
                               <h3>{{data.thread.content.title}}</h3>
                             </a>
                           </td>
@@ -441,7 +441,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-body">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/thread/{{../id}}" class="block">
+                            <a data-pm-no-track href="https://spectrum.chat/thread/{{../id}}" class="block">
                               <p>{{.}}</p>
                             </a>
                           </td>
@@ -452,7 +452,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-actions">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/thread/{{data.thread.id}}" class="button">
+                            <a data-pm-no-track href="https://spectrum.chat/thread/{{data.thread.id}}" class="button">
                               View conversation
                             </a>
                           </td>

--- a/email-templates/newDirectMessage.html
+++ b/email-templates/newDirectMessage.html
@@ -39,10 +39,6 @@
       color: #7b16ff;
       font-weight: bold;
       text-decoration: none;
-
-      &:hover {
-        text-decoration: underline;
-      }
     }
 
     a img {
@@ -245,11 +241,6 @@
       word-break: keep-all;
       white-space: nowrap;
       font-size: 16px;
-
-      &:hover {
-        text-decoration: none;
-        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
-      }
     }
 
     .button.feed {
@@ -420,7 +411,7 @@
                       <table class="attributes post" width="100%" cellpadding="0" cellspacing="0">
                         <tr>
                           <td>
-                            <a href="https://spectrum.chat/{{thread.path}}"><h2 class="title">{{thread.content.title}}</h2></a>
+                            <a data-pm-no-track href="https://spectrum.chat/{{thread.path}}"><h2 class="title">{{thread.content.title}}</h2></a>
                           </td>
                         </tr>
 
@@ -429,7 +420,7 @@
                               <table>
                                 <tr>
                                   <td valign="top">
-                                    <a href="https://spectrum.chat/{{thread.path}}">
+                                    <a data-pm-no-track href="https://spectrum.chat/{{thread.path}}">
                                       <img class="avatar" src="{{user.profilePhoto}}" />
                                     </a>
                                   </td>
@@ -437,12 +428,12 @@
                                     <table>
                                       <tr>
                                         <td>
-                                          <a href="https://spectrum.chat/{{thread.path}}"><span class="name">{{user.name}}</span></a>
+                                          <a data-pm-no-track href="https://spectrum.chat/{{thread.path}}"><span class="name">{{user.name}}</span></a>
                                         </td>
                                       </tr>
                                       <tr>
                                         <td>
-                                          <a href="https://spectrum.chat/{{thread.path}}"><p class="reply">{{{message.content.body}}}</p></a>
+                                          <a data-pm-no-track href="https://spectrum.chat/{{thread.path}}"><p class="reply">{{{message.content.body}}}</p></a>
                                         </td>
                                       </tr>
                                     </table>
@@ -454,7 +445,7 @@
 
                           <tr>
                             <td>
-                              <a class="feed button" href="https://spectrum.chat/{{thread.path}}">Go to conversation</a>
+                              <a data-pm-no-track class="feed button" href="https://spectrum.chat/{{thread.path}}">Go to conversation</a>
                             </td>
                           </tr>
                       </table>

--- a/email-templates/newRepliesInThreads.html
+++ b/email-templates/newRepliesInThreads.html
@@ -494,7 +494,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-title">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/thread/{{id}}" class="block">
+                            <a data-pm-no-track href="https://spectrum.chat/thread/{{id}}" class="block">
                               <h3>{{content.title}}</h3>
                             </a>
                           </td>
@@ -525,7 +525,7 @@
                               <table cellpadding="0" cellspacing="0" class="reply-body">
                                 <tr width="100%" cellpadding="0" cellspacing="0">
                                   <td valign="middle">
-                                    <a href="https://spectrum.chat/thread/{{../id}}" class="block">
+                                    <a data-pm-no-track href="https://spectrum.chat/thread/{{../id}}" class="block">
                                       {{{content.body}}}
                                     </a>
                                   </td>
@@ -540,7 +540,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-actions multi">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/thread/{{id}}" class="button">
+                            <a data-pm-no-track href="https://spectrum.chat/thread/{{id}}" class="button">
                               View conversation
                             </a>
                           </td>

--- a/email-templates/newThreadNotification.html
+++ b/email-templates/newThreadNotification.html
@@ -429,7 +429,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-title">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/thread/{{data.thread.id}}" class="block">
+                            <a data-pm-no-track href="https://spectrum.chat/thread/{{data.thread.id}}" class="block">
                               <h3>{{data.thread.content.title}}</h3>
                             </a>
                           </td>
@@ -441,7 +441,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-body">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/thread/{{../../id}}" class="block">
+                            <a data-pm-no-track href="https://spectrum.chat/thread/{{../../id}}" class="block">
                               <p>{{.}}</p>
                             </a>
                           </td>
@@ -452,7 +452,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-actions">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/thread/{{data.thread.id}}" class="button">
+                            <a data-pm-no-track href="https://spectrum.chat/thread/{{data.thread.id}}" class="button">
                               {{data.primaryActionLabel}}
                             </a>
                           </td>

--- a/email-templates/privateChannelRequestApproved.html
+++ b/email-templates/privateChannelRequestApproved.html
@@ -356,7 +356,7 @@
                   <!-- Body content -->
                   <tr>
                     <td class="content-cell">
-                      <p>Your request to join the <a href="https://spectrum.chat/{{data.community.slug}}/{{data.channel.slug}}">{{data.channel.name}} channel</a> in the <a href="https://spectrum.chat/{{data.community.slug}}">{{data.community.name}} community</a> was approved! You can now join any conversations happening in this channel.</p>
+                      <p>Your request to join the <a data-pm-no-track href="https://spectrum.chat/{{data.community.slug}}/{{data.channel.slug}}">{{data.channel.name}} channel</a> in the <a href="https://spectrum.chat/{{data.community.slug}}">{{data.community.name}} community</a> was approved! You can now join any conversations happening in this channel.</p>
                     </td>
                   </tr>
 
@@ -365,7 +365,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-actions multi">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/{{data.community.slug}}/{{data.channel.slug}}" class="button">
+                            <a data-pm-no-track href="https://spectrum.chat/{{data.community.slug}}/{{data.channel.slug}}" class="button">
                               View Channel
                             </a>
                           </td>

--- a/email-templates/privateChannelRequestSent.html
+++ b/email-templates/privateChannelRequestSent.html
@@ -365,7 +365,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-actions multi">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/{{data.community.slug}}/{{data.channel.slug}}/settings" class="button">
+                            <a data-pm-no-track href="https://spectrum.chat/{{data.community.slug}}/{{data.channel.slug}}/settings" class="button">
                               Go to channel settings
                             </a>
                           </td>

--- a/email-templates/privateCommunityRequestApproved.html
+++ b/email-templates/privateCommunityRequestApproved.html
@@ -355,7 +355,7 @@
                   <!-- Body content -->
                   <tr>
                     <td class="content-cell">
-                      <p>Your request to join the <a href="https://spectrum.chat/{{data.community.slug}}">{{data.community.name}} community</a> was approved! You can now join any conversations happening in this community.</p>
+                      <p>Your request to join the <a data-pm-no-track href="https://spectrum.chat/{{data.community.slug}}">{{data.community.name}} community</a> was approved! You can now join any conversations happening in this community.</p>
                     </td>
                   </tr>
 
@@ -364,7 +364,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-actions multi">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/{{data.community.slug}}" class="button">
+                            <a data-pm-no-track href="https://spectrum.chat/{{data.community.slug}}" class="button">
                               View Community
                             </a>
                           </td>

--- a/email-templates/privateCommunityRequestSent.html
+++ b/email-templates/privateCommunityRequestSent.html
@@ -356,7 +356,7 @@
                   <!-- Body content -->
                   <tr>
                     <td class="content-cell">
-                      <p><a href="https://spectrum.chat/users/{{data.user.username}}">{{data.user.name}}</a> has requested to join the <a href="https://spectrum.chat/{{data.community.slug}}">{{data.community.name}} community</a>. You can approve or block this request in your community settings.</p>
+                      <p><a data-pm-no-track href="https://spectrum.chat/users/{{data.user.username}}">{{data.user.name}}</a> has requested to join the <a href="https://spectrum.chat/{{data.community.slug}}">{{data.community.name}} community</a>. You can approve or block this request in your community settings.</p>
                     </td>
                   </tr>
 
@@ -365,7 +365,7 @@
                       <table width="100%" cellpadding="0" cellspacing="0" class="thread-actions multi">
                         <tr width="100%" cellpadding="0" cellspacing="0">
                           <td valign="middle">
-                            <a href="https://spectrum.chat/{{data.community.slug}}/settings/members?filter=pending" class="button">
+                            <a data-pm-no-track href="https://spectrum.chat/{{data.community.slug}}/settings/members?filter=pending" class="button">
                               Go to community settings
                             </a>
                           </td>


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

Hey @mxstbr, ya know how I sent that video where every time I clicked on an email notification for DM thread it would take me to the login view? Well it turns out it's because Postmark was hijacking the url so that it could track clicks. That hijacked url would redirect but for some reason wouldn't authenticate the user properly. We can opt out of this tracking on a link-by-link-basis (https://postmarkapp.com/developer/user-guide/tracking-links); I've added this for all auth-sensitive links: threads, private communities, private channels, dms. This should fix the problem!