### PR TITLE
Fix static JS file browser caching

### DIFF
--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -142,7 +142,7 @@ app.use(
     index: false,
     setHeaders: (res, path) => {
       // Don't cache the serviceworker in the browser
-      if (path.indexOf('sw.js')) {
+      if (path.indexOf('sw.js') > -1) {
         res.setHeader('Cache-Control', 'no-store, no-cache');
         return;
       }
@@ -159,10 +159,15 @@ app.use(
 app.get('/static/js/:name', (req: express$Request, res, next) => {
   if (!req.params.name) return next();
   const existingFile = jsFiles.find(file => file.startsWith(req.params.name));
-  if (existingFile)
+  if (existingFile) {
+    res.setHeader(
+      'Cache-Control',
+      `max-age=${SEVEN_DAYS}, s-maxage=${SEVEN_DAYS}`
+    );
     return res.sendFile(
       path.resolve(__dirname, '..', 'build', 'static', 'js', req.params.name)
     );
+  }
   // Match the first part of the file name, i.e. from "UserSettings.asdf123.chunk.js" match "UserSettings"
   const match = req.params.name.match(/(\w+?)\..+js/i);
   if (!match) return next();


### PR DESCRIPTION
This logic accidentally made it so that we weren't browser caching any of the static files even though we should...

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)