### PR TITLE
Force usage of punycode v1.4.1 to remove Node shims from browser bundle

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -160,5 +160,6 @@ module.exports = function override(config, env) {
       })
     );
   }
+  config.node = false;
   return rewireStyledComponents(config, env, { ssr: true });
 };

--- a/package.json
+++ b/package.json
@@ -199,7 +199,8 @@
     "draft-js": "npm:draft-js-fork-mxstbr",
     "jest-environment-node": "22.4.3",
     "jest": "22.4.3",
-    "fbjs": "0.8.16"
+    "fbjs": "0.8.16",
+    "punycode": "1.4.1"
   },
   "scripts": {
     "start": "cross-env NODE_ENV=production node build-hyperion/main.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9939,17 +9939,10 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-
-punycode@2.x.x, punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-
-punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
+punycode@1.3.2, punycode@1.4.1, punycode@2.x.x, punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1, punycode@^2.1.0:
   version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
 q@^1.1.2:
   version "1.5.1"


### PR DESCRIPTION
One of our dependencies was using punycode 2.0.0, but they dropped
support for browsers in v2, causing webpack to include Node browser
shims in our bundle (unnecessarily).

This fixes it by a) setting config.node = false, which should mean this
can never happen again hopefully, and b) force downgrading to punycode
1.4.1

I've also submitted an upstream PR to downgrade, but this is good
enough for now!


<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)