### PR TITLE
Increment community member counts on pending user joins

### DIFF
--- a/api/models/usersCommunities.js
+++ b/api/models/usersCommunities.js
@@ -478,6 +478,8 @@ export const approvePendingMemberInCommunity = async (
         context: { communityId },
       });
 
+      incrementMemberCount(communityId);
+
       return result.changes[0].new_val;
     });
 };


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

Closes #4273 - if you were pending at the time of joining with the token, we weren't incrementing the count properly