### PR TITLE
Add "Trending" and "Latest" tabs to community views

### DIFF
--- a/shared/graphql/fragments/community/communityThreadConnection.js
+++ b/shared/graphql/fragments/community/communityThreadConnection.js
@@ -36,7 +36,7 @@ export default gql`
     watercooler {
       ...threadInfo
     }
-    threadConnection(first: 10, after: $after) {
+    threadConnection(first: 10, after: $after, sort: $sort) {
       pageInfo {
         hasNextPage
         hasPreviousPage

--- a/shared/graphql/queries/community/getCommunityThreadConnection.js
+++ b/shared/graphql/queries/community/getCommunityThreadConnection.js
@@ -15,7 +15,11 @@ export type GetCommunityThreadConnectionType = {
 };
 
 const LoadMoreThreads = gql`
-  query loadMoreCommunityThreads($after: String, $id: ID) {
+  query loadMoreCommunityThreads(
+    $after: String
+    $id: ID
+    $sort: CommunityThreadConnectionSort
+  ) {
     community(id: $id) {
       ...communityInfo
       ...communityThreadConnection
@@ -27,7 +31,11 @@ const LoadMoreThreads = gql`
 `;
 
 export const getCommunityThreadConnectionQuery = gql`
-  query getCommunityThreadConnection($id: ID, $after: String) {
+  query getCommunityThreadConnection(
+    $id: ID
+    $after: String
+    $sort: CommunityThreadConnectionSort
+  ) {
     community(id: $id) {
       ...communityInfo
       ...communityThreadConnection
@@ -137,10 +145,19 @@ const getCommunityThreadConnectionOptions = {
         }),
     },
   }),
-  options: ({ id, after }: { id: string, after?: ?string }) => ({
+  options: ({
+    id,
+    after,
+    sort,
+  }: {
+    id: string,
+    after?: ?string,
+    sort?: ?string,
+  }) => ({
     variables: {
       id,
       after: after || null,
+      sort,
     },
     fetchPolicy: 'cache-and-network',
   }),

--- a/src/views/community/index.js
+++ b/src/views/community/index.js
@@ -73,7 +73,7 @@ type Props = {
 
 type State = {
   showComposerUpsell: boolean,
-  selectedView: 'threads' | 'search' | 'members',
+  selectedView: 'trending-threads' | 'threads' | 'search' | 'members',
   isLeavingCommunity: boolean,
 };
 
@@ -84,7 +84,7 @@ class CommunityView extends React.Component<Props, State> {
     this.state = {
       isLeavingCommunity: false,
       showComposerUpsell: false,
-      selectedView: 'threads',
+      selectedView: 'trending-threads',
     };
   }
 
@@ -333,11 +333,19 @@ class CommunityView extends React.Component<Props, State> {
                 </DesktopSegment>
 
                 <Segment
+                  segmentLabel="trending-threads"
+                  onClick={() => this.handleSegmentClick('trending-threads')}
+                  selected={selectedView === 'trending-threads'}
+                >
+                  Trending
+                </Segment>
+
+                <Segment
                   segmentLabel="threads"
                   onClick={() => this.handleSegmentClick('threads')}
                   selected={selectedView === 'threads'}
                 >
-                  Threads
+                  Latest
                 </Segment>
 
                 <DesktopSegment
@@ -381,8 +389,8 @@ class CommunityView extends React.Component<Props, State> {
                   </ErrorBoundary>
                 )}
 
-              {// thread list
-              selectedView === 'threads' && (
+              {(selectedView === 'threads' ||
+                selectedView === 'trending-threads') && (
                 <CommunityThreadFeed
                   viewContext="communityProfile"
                   slug={communitySlug}
@@ -394,6 +402,9 @@ class CommunityView extends React.Component<Props, State> {
                   isNewAndOwned={isNewAndOwned}
                   community={community}
                   pinnedThreadId={community.pinnedThreadId}
+                  sort={
+                    selectedView === 'trending-threads' ? 'trending' : 'latest'
+                  }
                 />
               )}
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Community views will show trending threads by default, with an extra tab to switch back to latest threads! Currently testing on alpha.spectrum.chat to see how it feels