### PR TITLE
Preload important JS bundles while browser idle

### DIFF
--- a/hyperion/renderer/browser-shim.js
+++ b/hyperion/renderer/browser-shim.js
@@ -20,3 +20,4 @@ global.navigator = {
 global.CSS = {
   escape: require('css.escape'),
 };
+global.IS_SERVER = true;

--- a/src/helpers/p-queue.js
+++ b/src/helpers/p-queue.js
@@ -1,0 +1,90 @@
+// based on https://github.com/zeit/next.js/blob/82d56e063aad12ac8fee5b9d5ed24ccf725b1a5b/packages/next-server/lib/p-queue.js
+// with adapted code style
+// which is itself based on https://github.com/sindresorhus/p-queue (MIT)
+// modified for browser support
+
+class Queue {
+  constructor() {
+    this._queue = [];
+  }
+  enqueue(run) {
+    this._queue.push(run);
+  }
+  dequeue() {
+    return this._queue.shift();
+  }
+  get size() {
+    return this._queue.length;
+  }
+}
+
+export default class PQueue {
+  constructor(opts) {
+    opts = Object.assign(
+      {
+        concurrency: Infinity,
+        queueClass: Queue,
+      },
+      opts
+    );
+
+    if (opts.concurrency < 1) {
+      throw new TypeError(
+        'Expected `concurrency` to be a number from 1 and up'
+      );
+    }
+
+    this.queue = new opts.queueClass(); // eslint-disable-line new-cap
+    this._pendingCount = 0;
+    this._concurrency = opts.concurrency;
+    this._resolveEmpty = () => {};
+  }
+  _next() {
+    this._pendingCount--;
+
+    if (this.queue.size > 0) {
+      this.queue.dequeue()();
+    } else {
+      this._resolveEmpty();
+    }
+  }
+  add(fn, opts) {
+    return new Promise((resolve, reject) => {
+      const run = () => {
+        this._pendingCount++;
+
+        fn().then(
+          val => {
+            resolve(val);
+            this._next();
+          },
+          err => {
+            reject(err);
+            this._next();
+          }
+        );
+      };
+
+      if (this._pendingCount < this._concurrency) {
+        run();
+      } else {
+        this.queue.enqueue(run, opts);
+      }
+    });
+  }
+  onEmpty() {
+    return new Promise(resolve => {
+      const existingResolve = this._resolveEmpty;
+      this._resolveEmpty = () => {
+        existingResolve();
+        resolve();
+      };
+    });
+  }
+  get size() {
+    return this.queue.size;
+  }
+  get pending() {
+    return this._pendingCount;
+  }
+}

--- a/src/helpers/p-queue.js
+++ b/src/helpers/p-queue.js
@@ -1,9 +1,12 @@
+// @flow
 // based on https://github.com/zeit/next.js/blob/82d56e063aad12ac8fee5b9d5ed24ccf725b1a5b/packages/next-server/lib/p-queue.js
-// with adapted code style
+// with adapted code style and flow types added
 // which is itself based on https://github.com/sindresorhus/p-queue (MIT)
 // modified for browser support
 
 class Queue {
+  _queue: Array<mixed>;
+
   constructor() {
     this._queue = [];
   }
@@ -13,17 +16,25 @@ class Queue {
   dequeue() {
     return this._queue.shift();
   }
-  get size() {
+  size() {
     return this._queue.length;
   }
 }
 
+type Options = {
+  concurrency: number,
+};
+
 export default class PQueue {
-  constructor(opts) {
+  queue: any;
+  _pendingCount: number;
+  _concurrency: number;
+  _resolveEmpty: Function;
+
+  constructor(opts: Options) {
     opts = Object.assign(
       {
         concurrency: Infinity,
-        queueClass: Queue,
       },
       opts
     );
@@ -34,7 +45,7 @@ export default class PQueue {
       );
     }
 
-    this.queue = new opts.queueClass(); // eslint-disable-line new-cap
+    this.queue = new Queue();
     this._pendingCount = 0;
     this._concurrency = opts.concurrency;
     this._resolveEmpty = () => {};
@@ -42,13 +53,13 @@ export default class PQueue {
   _next() {
     this._pendingCount--;
 
-    if (this.queue.size > 0) {
+    if (this.queue.size() > 0) {
       this.queue.dequeue()();
     } else {
       this._resolveEmpty();
     }
   }
-  add(fn, opts) {
+  add<R>(fn: () => Promise<R>): Promise<R> {
     return new Promise((resolve, reject) => {
       const run = () => {
         this._pendingCount++;
@@ -68,11 +79,11 @@ export default class PQueue {
       if (this._pendingCount < this._concurrency) {
         run();
       } else {
-        this.queue.enqueue(run, opts);
+        this.queue.enqueue(run);
       }
     });
   }
-  onEmpty() {
+  onEmpty(): Promise<void> {
     return new Promise(resolve => {
       const existingResolve = this._resolveEmpty;
       this._resolveEmpty = () => {
@@ -81,10 +92,10 @@ export default class PQueue {
       };
     });
   }
-  get size() {
-    return this.queue.size;
+  size() {
+    return this.queue.size();
   }
-  get pending() {
+  pending() {
     return this._pendingCount;
   }
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -154,43 +154,46 @@ const ComposerFallback = signedOutFallback(Composer, () => (
   <Login redirectPath={`${CLIENT_URL}/new/thread`} />
 ));
 
-// Preload the important routes when browser is idle and users has been using the app
+// On the client, preload the important routes when browser is idle and users has been using the app
 // for > 5s (i.e. all the data should hopefully have been loaded)
-const preload = [
-  FullscreenThreadView,
-  CommunityView,
-  CommunityLoginView,
-  UserView,
-  ChannelView,
-  Dashboard,
-  Notifications,
-];
-requestAnimationFrame(() => {
-  // Fallback to setTimeout for older browsers with no requestIdleCallback support
-  const idle = window.requestIdleCallback || window.setTimeout;
-  const queue = new PromiseQueue({
-    concurrency: 2,
-  });
-  idle(() => {
-    // Wait 5 seconds to make sure the data has loaded
-    setTimeout(() => {
-      preload.forEach(bundle => {
-        queue
-          .add(() => {
-            return new Promise(res => {
-              idle(() => {
-                bundle
-                  .preload()
-                  .then(res)
-                  .catch(err => console.error(err));
+if (!global || global.IS_SERVER !== true) {
+  const preload = [
+    FullscreenThreadView,
+    CommunityView,
+    CommunityLoginView,
+    UserView,
+    ChannelView,
+    Dashboard,
+    Notifications,
+  ];
+
+  requestAnimationFrame(() => {
+    // Fallback to setTimeout for older browsers with no requestIdleCallback support
+    const idle = window.requestIdleCallback || window.setTimeout;
+    const queue = new PromiseQueue({
+      concurrency: 2,
+    });
+    idle(() => {
+      // Wait 5 seconds to make sure the data has loaded
+      setTimeout(() => {
+        preload.forEach(bundle => {
+          queue
+            .add(() => {
+              return new Promise(res => {
+                idle(() => {
+                  bundle
+                    .preload()
+                    .then(res)
+                    .catch(err => console.error(err));
+                });
               });
-            });
-          })
-          .catch(err => console.error(err));
-      });
-    }, 5000);
+            })
+            .catch(err => console.error(err));
+        });
+      }, 5000);
+    });
   });
-});
+}
 
 type Props = {
   currentUser: ?GetUserType,


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This should help perceived performance when clicking between pages a lot! This is what our ServiceWorker used to do out of the box and made the app feel faster—now we just do it via `react-loadable`.

Based on Next's implementation (h/t @timneutkens) and https://nolanlawson.com/2018/09/25/accurately-measuring-layout-on-the-web/