### PR TITLE
Show total rep in desktop navbar

### DIFF
--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -23,6 +23,7 @@ import {
   Navatar,
   SkipLink,
   SigninLink,
+  Reputation,
 } from './style';
 import { track, events } from 'src/helpers/analytics';
 import { isViewingMarketingPage } from 'src/helpers/is-viewing-marketing-page';
@@ -232,7 +233,13 @@ class Navbar extends React.Component<Props, State> {
               to={currentUser ? `/users/${currentUser.username}` : '/'}
               onClick={() => this.trackNavigationClick('profile')}
             >
+              {currentUser && (
+                <Reputation>
+                  <Icon glyph="rep" /> {currentUser.totalReputation}
+                </Reputation>
+              )}
               <Navatar
+                style={{ gridArea: 'label' }}
                 user={currentUser}
                 size={32}
                 showHoverProfile={false}

--- a/src/views/navbar/style.js
+++ b/src/views/navbar/style.js
@@ -211,6 +211,13 @@ export const DropTab = styled(FlexRow)`
   }
 `;
 
+export const Reputation = styled.div`
+  display: flex;
+  grid-area: icon;
+  align-items: center;
+  padding-right: 16px;
+`;
+
 export const Logo = styled(Tab)`
   grid-area: logo;
   padding: ${isDesktopApp() ? '0 32px 0 4px' : '0 24px 0 4px'};


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

@brianlovin needs a UI review, this is what it currently looks like:

![screenshot 2018-11-21 at 12 31 06](https://user-images.githubusercontent.com/7525670/48838725-860b7380-ed89-11e8-8f2c-01d9d955502c.png)

![screenshot 2018-11-21 at 12 31 15](https://user-images.githubusercontent.com/7525670/48838727-87d53700-ed89-11e8-86d7-113a640471ba.png)

I'd also love to showcase "growth-in-past-xyz-days" somehow next to it (think a green arrow up), but we don't currently expose that information from the API. Future enhancement though for sure!