### PR TITLE
Remove apollo engine

### DIFF
--- a/api/apollo-server.js
+++ b/api/apollo-server.js
@@ -141,8 +141,8 @@ const server = new ProtectedApolloServer({
   },
   maxFileSize: 25 * 1024 * 1024, // 25MB
   engine: false,
-  tracing: true,
-  cacheControl: true,
+  tracing: false,
+  cacheControl: false,
   validationRules: [depthLimit(10)],
 });
 

--- a/api/index.js
+++ b/api/index.js
@@ -75,34 +75,7 @@ app.use(errorHandler);
 const httpServer = createServer(app);
 apolloServer.installSubscriptionHandlers(httpServer);
 
-// Start API wrapped in Apollo Engine
-const engine = new ApolloEngine({
-  logging: {
-    level: 'WARN',
-  },
-  apiKey: process.env.APOLLO_ENGINE_API_KEY,
-  // Only send perf data to the remote server in production
-  reporting: {
-    disabled: process.env.NODE_ENV !== 'production',
-    hostname: process.env.NOW_URL || undefined,
-    privateHeaders: ['authorization', 'Authorization', 'AUTHORIZATION'],
-  },
-  queryCache: {
-    // Don't cache logged-in user responses
-    privateFullQueryStore: 'disabled',
-  },
-  sessionAuth: {
-    cookie: 'session',
-    // TODO(@mxstbr): Ping Apollo to note that we need both of those
-    // header: 'Authorization'
-  },
-});
-
-engine.listen({
-  port: PORT,
-  httpServer: httpServer,
-  graphqlPaths: ['/api'],
-});
+httpServer.listen(PORT);
 
 debug(`GraphQL API running at http://localhost:${PORT}/api`);
 


### PR DESCRIPTION
We don't use it anymore and it's blocking errors from the API being logged.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api