### PR TITLE
Only cache js for an hour

### DIFF
--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -16,7 +16,7 @@ import toobusy from 'shared/middlewares/toobusy';
 import addSecurityMiddleware from 'shared/middlewares/security';
 
 const PORT = process.env.PORT || 3006;
-const SEVEN_DAYS = 604800;
+const ONE_HOUR = 3600;
 
 const app = express();
 
@@ -152,7 +152,7 @@ app.use(
         // (the filename changes if the file content changes, so we can cache these forever)
         res.setHeader(
           'Cache-Control',
-          `max-age=${SEVEN_DAYS}, s-maxage=${SEVEN_DAYS}`
+          `max-age=${ONE_HOUR}, s-maxage=${ONE_HOUR}`
         );
       }
     },
@@ -165,7 +165,7 @@ app.get('/static/js/:name', (req: express$Request, res, next) => {
     if (existingFile.indexOf('.html') === -1) {
       res.setHeader(
         'Cache-Control',
-        `max-age=${SEVEN_DAYS}, s-maxage=${SEVEN_DAYS}`
+        `max-age=${ONE_HOUR}, s-maxage=${ONE_HOUR}`
       );
     }
     return res.sendFile(


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Going to admin ship this to see if it helps, idea being that if this is working properly we get some short-term benefits (1hr cache) but if things are busted it's only a one-hour bust instead of 7 days, at least until we sort out some more caching mechanics.