### PR TITLE
Fix DMThread.snippet database performance

### DIFF
--- a/api/loaders/directMessageThread.js
+++ b/api/loaders/directMessageThread.js
@@ -1,7 +1,7 @@
 // @flow
 import { getDirectMessageThreads } from '../models/directMessageThread';
 import { getMembersInDirectMessageThreads } from '../models/usersDirectMessageThreads';
-import { getLastMessages } from '../models/message';
+import { getLastMessageOfThreads } from '../models/message';
 import createLoader from './create-loader';
 import type { Loader } from './types';
 
@@ -15,8 +15,8 @@ export const __createDirectMessageParticipantsLoader = createLoader(
 );
 
 export const __createDirectMessageSnippetLoader = createLoader(
-  threads => getLastMessages(threads),
-  'group'
+  threads => getLastMessageOfThreads(threads),
+  'threadId'
 );
 
 export default () => {

--- a/api/queries/directMessageThread/snippet.js
+++ b/api/queries/directMessageThread/snippet.js
@@ -14,9 +14,8 @@ export default async (
   const canViewThread = await canViewDMThread(user.id, id, loaders);
   if (!canViewThread) return null;
 
-  return loaders.directMessageSnippet.load(id).then(results => {
-    if (!results) return 'No messages yet...';
-    const message = results.reduction;
+  return loaders.directMessageSnippet.load(id).then(message => {
+    if (!message) return 'No messages yet...';
     if (message.messageType === 'media') return '📷 Photo';
     return message.messageType === 'draftjs'
       ? toPlainText(toState(JSON.parse(message.content.body)))


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

<!-- If there are UI changes please share mobile and desktop screenshots or recordings. -->
Previously this was reading through every. single. message. in every.  single. DM thread. of the user when loading /messages to get the snippets.

You can imagine how performant that was :sweat_smile:

This fixes it by using an existing index to only load the latest message very quickly, reducing reads/sec from (dmthreadamount with a max of 25 * dmthreadmessageamount) to (dmthreadamount with a max of 25)! If you have 25 DM threads with 100 messages each, before you'd be doing at least 2500 reads, now you're doing 25 👍 