### PR TITLE
Add refetching indicators

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "react-modal": "^3.6.1",
     "react-popper": "^1.0.2",
     "react-redux": "^5.0.2",
+    "react-redux-loading-bar": "^4.1.0",
     "react-router": "^4.0.0-beta.7",
     "react-router-dom": "^4.3.1",
     "react-textarea-autosize": "^6.1.0",

--- a/shared/graphql/index.js
+++ b/shared/graphql/index.js
@@ -6,12 +6,13 @@ import {
   InMemoryCache,
   IntrospectionFragmentMatcher,
 } from 'apollo-cache-inmemory';
-import { split } from 'apollo-link';
+import { ApolloLink, split } from 'apollo-link';
 import { WebSocketLink } from 'apollo-link-ws';
 import { getMainDefinition } from 'apollo-utilities';
 import introspectionQueryResultData from './schema.json';
 import getSharedApolloClientOptions from './apollo-client-options';
 import { IS_PROD, API_URI, WS_URI } from './constants';
+import RefetchCountLink from './refetch-count-link';
 
 // Fixes a bug with ReactNative, see https://github.com/facebook/react-native/issues/9599
 if (typeof global.self === 'undefined') {
@@ -90,7 +91,7 @@ export const createClient = (options?: CreateClientOptions = {}) => {
   );
 
   return new ApolloClient({
-    link,
+    link: new RefetchCountLink().concat(link),
     // eslint-disable-next-line
     cache: window.__DATA__ ? cache.restore(window.__DATA__) : cache,
     ssrForceFetchDelay: 100,

--- a/shared/graphql/index.js
+++ b/shared/graphql/index.js
@@ -21,6 +21,8 @@ if (typeof global.self === 'undefined') {
 
 type CreateClientOptions = {
   token?: ?string,
+  onRefetching: Function,
+  onRefetchFinished: Function,
 };
 
 // Websocket link for subscriptions
@@ -91,22 +93,13 @@ export const createClient = (options?: CreateClientOptions = {}) => {
   );
 
   return new ApolloClient({
-    link: new RefetchCountLink().concat(link),
+    link: new RefetchCountLink({
+      onRefetching: options.onRefetching,
+      onRefetchFinished: options.onRefetchFinished,
+    }).concat(link),
     // eslint-disable-next-line
     cache: window.__DATA__ ? cache.restore(window.__DATA__) : cache,
     ssrForceFetchDelay: 100,
     queryDeduplication: true,
   });
-};
-
-const client = createClient();
-
-export { client };
-
-export const clearApolloStore = () => {
-  try {
-    client.resetStore();
-  } catch (e) {
-    console.error('error clearing store');
-  }
 };

--- a/shared/graphql/refetch-count-link.js
+++ b/shared/graphql/refetch-count-link.js
@@ -1,0 +1,50 @@
+// @flow
+import { ApolloLink } from 'apollo-link';
+import type { Operation } from 'apollo-client';
+import type { Observable } from 'zen-observable';
+
+class RefetchCountLink extends ApolloLink {
+  constructor() {
+    super();
+    this.queries = {};
+    this.loading = 0;
+  }
+
+  request<I: Operation>(operation: I, forward: (op: I) => Observable) {
+    const operationType = operation.query.definitions.find(
+      def => def.kind === 'OperationDefinition'
+    ).operation;
+    if (operationType === 'subscription') return forward(operation);
+
+    const observable = forward(operation);
+    const key = operation.toKey();
+    if (!this.queries[key]) {
+      this.queries[key] = true;
+      return observable;
+    }
+    const self = this;
+    self.loading++;
+    console.log(
+      `Refetching a query. Refetching ${self.loading} queries right now`
+    );
+
+    observable.subscribe({
+      error() {
+        self.loading--;
+        console.log(
+          `Refetching query errored. Refetching ${
+            self.loading
+          } queries right now`
+        );
+      },
+      complete() {
+        self.loading--;
+        console.log(`Refetched query, refetching ${self.loading} queries`);
+      },
+    });
+
+    return observable;
+  }
+}
+
+export default RefetchCountLink;

--- a/src/actions/authentication.js
+++ b/src/actions/authentication.js
@@ -3,18 +3,10 @@ import { setUser, unsetUser } from 'src/helpers/analytics';
 export const logout = () => {
   // no longer track analytics
   unsetUser();
-
-  import('shared/graphql')
-    .then(module => module.clearApolloStore)
-    .then(clearApolloStore => {
-      // clear Apollo's query cache
-      clearApolloStore();
-      // redirect to home page
-      window.location.href =
-        process.env.NODE_ENV === 'production'
-          ? '/auth/logout'
-          : 'http://localhost:3001/auth/logout';
-    });
+  window.location.href =
+    process.env.NODE_ENV === 'production'
+      ? '/auth/logout'
+      : 'http://localhost:3001/auth/logout';
 };
 
 export const setTrackingContexts = async (user: ?GetUserType) => {

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,10 @@ import queryString from 'query-string';
 import Loadable from 'react-loadable';
 import * as OfflinePluginRuntime from 'offline-plugin/runtime';
 import { HelmetProvider } from 'react-helmet-async';
+import { showLoading, hideLoading } from 'react-redux-loading-bar';
 import webPushManager from 'src/helpers/web-push-manager';
 import { history } from 'src/helpers/history';
-import { client } from 'shared/graphql';
+import { createClient } from 'shared/graphql';
 import { initStore } from 'src/store';
 import { track, events } from 'src/helpers/analytics';
 import { wsLink } from 'shared/graphql';
@@ -39,6 +40,11 @@ const store = initStore(
     },
   }
 );
+
+const client = createClient({
+  onRefetching: () => store.dispatch(showLoading()),
+  onRefetchFinished: () => store.dispatch(hideLoading()),
+});
 
 const App = () => {
   return (
@@ -108,6 +114,6 @@ window.addEventListener('beforeinstallprompt', e => {
   });
 });
 
-subscribeToDesktopPush(data => {
+subscribeToDesktopPush(client, data => {
   if (data && data.href) history.push(data.href);
 });

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,6 @@
 // @flow
 import { combineReducers } from 'redux';
+import { loadingBarReducer } from 'react-redux-loading-bar';
 import composer from './composer';
 import modals from './modals';
 import toasts from './toasts';
@@ -27,6 +28,7 @@ const getReducers = () => {
     notifications,
     connectionStatus,
     message,
+    loadingBar: loadingBarReducer,
   });
 };
 

--- a/src/subscribe-to-desktop-push.js
+++ b/src/subscribe-to-desktop-push.js
@@ -1,7 +1,6 @@
 // @flow
 import { isDesktopApp } from './helpers/desktop-app-utils';
 import { getItemFromStorage } from './helpers/localStorage';
-import { client } from 'shared/graphql';
 import {
   subscribeToNewNotifications,
   subscribeToDirectMessageNotifications,
@@ -11,6 +10,7 @@ import formatNotification from 'shared/notification-to-text';
 // On Electron listen to new notifications outside the component tree
 // and show desktop push notifications
 export const subscribeToDesktopPush = (
+  client: any,
   onClick: ({ href?: string }) => void
 ) => {
   if (isDesktopApp()) {

--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import queryString from 'query-string';
+import LoadingBar from 'react-redux-loading-bar';
 import Icon from 'src/components/icons';
 import ProfileDropdown from './components/profileDropdown';
 import MessagesTab from './components/messagesTab';
@@ -50,6 +51,7 @@ type Props = {
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
   pageVisibility: PageVisibilityType,
+  loadingBar: Object,
 };
 
 type State = {
@@ -68,6 +70,7 @@ class Navbar extends React.Component<Props, State> {
     if (curr.networkOnline !== nextProps.networkOnline) return true;
     if (curr.websocketConnection !== nextProps.websocketConnection) return true;
     if (curr.pageVisibility !== nextProps.pageVisibility) return true;
+    if (curr.loadingBar.default !== nextProps.loadingBar.default) return true;
 
     // If the update was caused by the focus on the skip link
     if (nextState.isSkipLinkFocused !== this.state.isSkipLinkFocused)
@@ -165,120 +168,126 @@ class Navbar extends React.Component<Props, State> {
 
     if (currentUser) {
       return (
-        <Nav hideOnMobile={hideNavOnMobile} data-cy="navbar">
-          <Head>
-            {notificationCounts.directMessageNotifications > 0 ||
-            notificationCounts.notifications > 0 ? (
-              <link
-                rel="shortcut icon"
-                id="dynamic-favicon"
-                // $FlowIssue
-                href={`${process.env.PUBLIC_URL}/img/favicon_unread.ico`}
-              />
-            ) : (
-              <link
-                rel="shortcut icon"
-                id="dynamic-favicon"
-                // $FlowIssue
-                href={`${process.env.PUBLIC_URL}/img/favicon.ico`}
-              />
-            )}
-          </Head>
-
-          <Logo
-            to="/"
-            aria-hidden
-            tabIndex="-1"
-            ishidden={this.state.isSkipLinkFocused || undefined}
-            onClick={() => this.trackNavigationClick('logo')}
-            data-cy="navbar-logo"
-          >
-            <Icon glyph="logo" size={28} />
-          </Logo>
-
-          <SkipLink
-            href="#main"
-            onFocus={this.handleSkipLinkFocus}
-            onBlur={this.handleSkipLinkBlur}
-          >
-            Skip to content
-          </SkipLink>
-
-          <HomeTab
-            {...this.getTabProps(match.url === '/' && match.isExact)}
-            to="/"
-            onClick={() => this.trackNavigationClick('home')}
-            data-cy="navbar-home"
-          >
-            <Icon glyph="home" size={isDesktopApp() ? 28 : 32} />
-            <Label>Home</Label>
-          </HomeTab>
-
-          <MessagesTab
-            active={history.location.pathname.includes('/messages')}
+        <React.Fragment>
+          <LoadingBar
+            showFastActions
+            style={{ backgroundColor: 'white', zIndex: 5000 }}
           />
+          <Nav hideOnMobile={hideNavOnMobile} data-cy="navbar">
+            <Head>
+              {notificationCounts.directMessageNotifications > 0 ||
+              notificationCounts.notifications > 0 ? (
+                <link
+                  rel="shortcut icon"
+                  id="dynamic-favicon"
+                  // $FlowIssue
+                  href={`${process.env.PUBLIC_URL}/img/favicon_unread.ico`}
+                />
+              ) : (
+                <link
+                  rel="shortcut icon"
+                  id="dynamic-favicon"
+                  // $FlowIssue
+                  href={`${process.env.PUBLIC_URL}/img/favicon.ico`}
+                />
+              )}
+            </Head>
 
-          <ExploreTab
-            {...this.getTabProps(history.location.pathname === '/explore')}
-            to="/explore"
-            onClick={() => this.trackNavigationClick('explore')}
-            data-cy="navbar-explore"
-          >
-            <Icon glyph="explore" size={isDesktopApp() ? 28 : 32} />
-            <Label>Explore</Label>
-          </ExploreTab>
+            <Logo
+              to="/"
+              aria-hidden
+              tabIndex="-1"
+              ishidden={this.state.isSkipLinkFocused || undefined}
+              onClick={() => this.trackNavigationClick('logo')}
+              data-cy="navbar-logo"
+            >
+              <Icon glyph="logo" size={28} />
+            </Logo>
 
-          <NotificationsTab
-            onClick={() => this.trackNavigationClick('notifications')}
-            location={history.location}
-            currentUser={currentUser}
-            active={history.location.pathname.includes('/notifications')}
-          />
+            <SkipLink
+              href="#main"
+              onFocus={this.handleSkipLinkFocus}
+              onBlur={this.handleSkipLinkBlur}
+            >
+              Skip to content
+            </SkipLink>
 
-          <ProfileDrop>
-            <Tab
-              className={'hideOnMobile'}
+            <HomeTab
+              {...this.getTabProps(match.url === '/' && match.isExact)}
+              to="/"
+              onClick={() => this.trackNavigationClick('home')}
+              data-cy="navbar-home"
+            >
+              <Icon glyph="home" size={isDesktopApp() ? 28 : 32} />
+              <Label>Home</Label>
+            </HomeTab>
+
+            <MessagesTab
+              active={history.location.pathname.includes('/messages')}
+            />
+
+            <ExploreTab
+              {...this.getTabProps(history.location.pathname === '/explore')}
+              to="/explore"
+              onClick={() => this.trackNavigationClick('explore')}
+              data-cy="navbar-explore"
+            >
+              <Icon glyph="explore" size={isDesktopApp() ? 28 : 32} />
+              <Label>Explore</Label>
+            </ExploreTab>
+
+            <NotificationsTab
+              onClick={() => this.trackNavigationClick('notifications')}
+              location={history.location}
+              currentUser={currentUser}
+              active={history.location.pathname.includes('/notifications')}
+            />
+
+            <ProfileDrop>
+              <Tab
+                className={'hideOnMobile'}
+                {...this.getTabProps(
+                  history.location.pathname === `/users/${currentUser.username}`
+                )}
+                to={currentUser ? `/users/${currentUser.username}` : '/'}
+                onClick={() => this.trackNavigationClick('profile')}
+              >
+                {currentUser &&
+                  typeof currentUser.totalReputation === 'number' && (
+                    <Reputation>
+                      <Icon glyph="rep" />{' '}
+                      {truncateNumber(
+                        parseInt(currentUser.totalReputation, 10),
+                        1
+                      )}
+                    </Reputation>
+                  )}
+                <Navatar
+                  style={{ gridArea: 'label' }}
+                  user={currentUser}
+                  size={32}
+                  showHoverProfile={false}
+                  showOnlineStatus={false}
+                  isClickable={false}
+                  dataCy="navbar-profile"
+                />
+              </Tab>
+              <ProfileDropdown user={currentUser} />
+            </ProfileDrop>
+
+            <ProfileTab
+              className={'hideOnDesktop'}
               {...this.getTabProps(
                 history.location.pathname === `/users/${currentUser.username}`
               )}
               to={currentUser ? `/users/${currentUser.username}` : '/'}
               onClick={() => this.trackNavigationClick('profile')}
             >
-              {currentUser &&
-                typeof currentUser.totalReputation === 'number' && (
-                  <Reputation>
-                    <Icon glyph="rep" />{' '}
-                    {truncateNumber(
-                      parseInt(currentUser.totalReputation, 10),
-                      1
-                    )}
-                  </Reputation>
-                )}
-              <Navatar
-                style={{ gridArea: 'label' }}
-                user={currentUser}
-                size={32}
-                showHoverProfile={false}
-                showOnlineStatus={false}
-                isClickable={false}
-                dataCy="navbar-profile"
-              />
-            </Tab>
-            <ProfileDropdown user={currentUser} />
-          </ProfileDrop>
-
-          <ProfileTab
-            className={'hideOnDesktop'}
-            {...this.getTabProps(
-              history.location.pathname === `/users/${currentUser.username}`
-            )}
-            to={currentUser ? `/users/${currentUser.username}` : '/'}
-            onClick={() => this.trackNavigationClick('profile')}
-          >
-            <Icon glyph="profile" />
-            <Label>Profile</Label>
-          </ProfileTab>
-        </Nav>
+              <Icon glyph="profile" />
+              <Label>Profile</Label>
+            </ProfileTab>
+          </Nav>
+        </React.Fragment>
       );
     }
     if (!currentUser && !isLoadingCurrentUser) {
@@ -345,6 +354,7 @@ const map = state => ({
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
   pageVisibility: state.connectionStatus.pageVisibility,
+  loadingBar: state.loadingBar,
 });
 export default compose(
   // $FlowIssue

--- a/yarn.lock
+++ b/yarn.lock
@@ -10212,6 +10212,14 @@ react-portal@^3.1.0:
   dependencies:
     prop-types "^15.5.8"
 
+react-redux-loading-bar@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/react-redux-loading-bar/-/react-redux-loading-bar-4.1.0.tgz#3ca460569d979450d9d1dc992328efa449c10a7a"
+  integrity sha512-9L51ZvPqnlPs97j44FZLio6maQ/2BMP8xXFPArDWxByyLyGYs2fXpSZw+Lby9qr8Px3SsH9dylfC8HfQrmc/Mw==
+  dependencies:
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.2"
+
 react-redux@^5.0.2:
   version "5.0.7"
   resolved "http://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz#0dc1076d9afb4670f993ffaef44b8f8c1155a4c8"


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [x] WIP
- [ ] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

First commit adds an Apollo Link that keeps track of how many queries are being refetched at any given point.

@brianlovin my idea would be to hook this into the Redux state and showing a global loading indicator whenever a query refetches in the background. Potential ideas would be a small spinner in the navbar or a GitHub-style top looping progress bar.

WDYT, could that work? It would only fire when re-fetching, i.e. only when users navigate back to the tab in their browser or back to a page they've been on before that shows cached content. Having a refetch loading indicator should give them the safety that they're always looking at fresh data!