### PR TITLE
Add communities "memberCount" index, rewrite chronos queries

### DIFF
--- a/api/migrations/20181127090014-communities-member-count-index.js
+++ b/api/migrations/20181127090014-communities-member-count-index.js
@@ -1,0 +1,13 @@
+exports.up = function(r, conn) {
+  return r
+    .table('communities')
+    .indexCreate('memberCount')
+    .run(conn);
+};
+
+exports.down = function(r, conn) {
+  return r
+    .table('communities')
+    .indexDrop('memberCount')
+    .run(conn);
+};

--- a/chronos/models/community.js
+++ b/chronos/models/community.js
@@ -21,7 +21,7 @@ export const getCommunities = (
 export const getTopCommunities = (amount: number): Array<Object> => {
   return db
     .table('communities')
-    .orderBy('memberCount')
+    .orderBy({ index: db.desc('memberCount') })
     .filter(community => community.hasFields('deletedAt').not())
     .limit(amount)
     .run();
@@ -33,7 +33,7 @@ export const getCommunitiesWithMinimumMembers = (
 ) => {
   return db
     .table('communities')
-    .filter(row => row('memberCount').ge(min))
+    .between(min, db.maxval, { index: 'memberCount' })
     .filter(community => community.hasFields('deletedAt').not())
     .map(row => row('id'))
     .run();


### PR DESCRIPTION
Should alleviate some load on the communities table, rather than having to go through all of them this is now mostly instantaneous!

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- chronos

**Run database migrations (delete if no migration was added)**
YES