### PR TITLE
Use message threadIdAndTimestamp index for getNewMessageCount query

### DIFF
--- a/chronos/models/message.js
+++ b/chronos/models/message.js
@@ -31,15 +31,10 @@ export const getNewMessageCount = (
 
   return db
     .table('messages')
-    .getAll(threadId, { index: 'threadId' })
+    .between([threadId, db.now().sub(range)], [threadId, db.now()], {
+      index: 'threadIdAndTimestamp',
+    })
     .filter(db.row.hasFields('deletedAt').not())
-    .filter(
-      db.row('timestamp').during(
-        // only count messages sent in the past week
-        db.now().sub(range),
-        db.now()
-      )
-    )
     .count()
     .run();
 };


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- chronos

This should reduce load when computing really long threads (> 500 msgs).