### PR TITLE
Dont use page visibility to determine a refetch

### DIFF
--- a/src/components/threadFeed/index.js
+++ b/src/components/threadFeed/index.js
@@ -20,10 +20,7 @@ import type { Dispatch } from 'redux';
 import { ErrorBoundary } from 'src/components/error';
 import { withCurrentUser } from 'src/components/withCurrentUser';
 import { useConnectionRestored } from 'src/hooks/useConnectionRestored';
-import type {
-  WebsocketConnectionType,
-  PageVisibilityType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 
 const NullState = ({ viewContext, search }) => {
   let hd;
@@ -163,7 +160,6 @@ type Props = {
   search?: boolean,
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 type State = {
@@ -197,7 +193,6 @@ class ThreadFeedPure extends React.Component<Props, State> {
     const curr = this.props;
     if (curr.networkOnline !== nextProps.networkOnline) return true;
     if (curr.websocketConnection !== nextProps.websocketConnection) return true;
-    if (curr.pageVisibility !== nextProps.pageVisibility) return true;
     // fetching more
     if (curr.data.networkStatus === 7 && nextProps.data.networkStatus === 3)
       return false;
@@ -389,7 +384,6 @@ const map = state => ({
   newActivityIndicator: state.newActivityIndicator.hasNew,
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
-  pageVisibility: state.connectionStatus.pageVisibility,
 });
 const ThreadFeed = compose(
   // $FlowIssue

--- a/src/hooks/useConnectionRestored.js
+++ b/src/hooks/useConnectionRestored.js
@@ -1,13 +1,9 @@
 // @flow
-import type {
-  PageVisibilityType,
-  WebsocketConnectionType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 
 type ConnectionProps = {
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 type Props = {
@@ -31,13 +27,6 @@ const validateProps = (props: Props) => {
     return false;
   }
 
-  if (
-    !props.prev.hasOwnProperty('pageVisibility') ||
-    !props.curr.hasOwnProperty('pageVisibility')
-  ) {
-    return false;
-  }
-
   return true;
 };
 
@@ -57,17 +46,9 @@ const networkOnlineDidReconnect = (props: Props) => {
   return false;
 };
 
-const pageBecameVisible = (props: Props) => {
-  const { curr, prev } = props;
-  if (prev.pageVisibility === 'hidden' && curr.pageVisibility === 'visible')
-    return true;
-  return false;
-};
-
 export const useConnectionRestored = (props: Props) => {
   if (!validateProps(props)) return false;
   if (websocketDidReconnect(props)) return true;
   if (networkOnlineDidReconnect(props)) return true;
-  if (pageBecameVisible(props)) return true;
   return false;
 };

--- a/src/reducers/connectionStatus.js
+++ b/src/reducers/connectionStatus.js
@@ -5,12 +5,9 @@ export type WebsocketConnectionType =
   | 'reconnected'
   | 'reconnecting';
 
-export type PageVisibilityType = 'visible' | 'hidden';
-
 type InitialState = {
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 type ActionType = {
@@ -21,7 +18,6 @@ type ActionType = {
 const initialState: InitialState = {
   networkOnline: true,
   websocketConnection: 'connected',
-  pageVisibility: 'visible',
 };
 
 export default function status(
@@ -36,10 +32,6 @@ export default function status(
     case 'WEBSOCKET_CONNECTION':
       return Object.assign({}, state, {
         websocketConnection: action.value,
-      });
-    case 'PAGE_VISIBILITY':
-      return Object.assign({}, state, {
-        pageVisibility: action.value,
       });
     default:
       return state;

--- a/src/views/dashboard/components/threadFeed.js
+++ b/src/views/dashboard/components/threadFeed.js
@@ -24,10 +24,7 @@ import type { GetCommunityThreadConnectionType } from 'shared/graphql/queries/co
 import type { Dispatch } from 'redux';
 import { ErrorBoundary } from 'src/components/error';
 import { useConnectionRestored } from 'src/hooks/useConnectionRestored';
-import type {
-  WebsocketConnectionType,
-  PageVisibilityType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 
 type Node = {
   node: {
@@ -58,7 +55,6 @@ type Props = {
   hasActiveCommunity: boolean,
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 type State = {
@@ -92,7 +88,6 @@ class ThreadFeed extends React.Component<Props, State> {
     const curr = this.props;
     if (curr.networkOnline !== nextProps.networkOnline) return true;
     if (curr.websocketConnection !== nextProps.websocketConnection) return true;
-    if (curr.pageVisibility !== nextProps.pageVisibility) return true;
     // fetching more
     if (curr.data.networkStatus === 7 && nextProps.isFetchingMore) return false;
     return true;
@@ -352,7 +347,6 @@ const map = state => ({
   activeChannel: state.dashboardFeed.activeChannel,
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
-  pageVisibility: state.connectionStatus.pageVisibility,
 });
 export default compose(
   withRouter,

--- a/src/views/directMessages/containers/existingThread.js
+++ b/src/views/directMessages/containers/existingThread.js
@@ -15,10 +15,7 @@ import { MessagesContainer, ViewContent } from '../style';
 import { Loading } from 'src/components/loading';
 import ViewError from 'src/components/viewError';
 import { ErrorBoundary } from 'src/components/error';
-import type {
-  WebsocketConnectionType,
-  PageVisibilityType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 import { useConnectionRestored } from 'src/hooks/useConnectionRestored';
 
 type Props = {
@@ -35,7 +32,6 @@ type Props = {
   threadSliderIsOpen: boolean,
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 class ExistingThread extends React.Component<Props> {
@@ -160,7 +156,6 @@ class ExistingThread extends React.Component<Props> {
 const map = state => ({
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
-  pageVisibility: state.connectionStatus.pageVisibility,
   threadSliderIsOpen: state.threadSlider.isOpen,
 });
 export default compose(

--- a/src/views/directMessages/containers/index.js
+++ b/src/views/directMessages/containers/index.js
@@ -18,10 +18,7 @@ import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
 import { withCurrentUser } from 'src/components/withCurrentUser';
 import { useConnectionRestored } from 'src/hooks/useConnectionRestored';
-import type {
-  WebsocketConnectionType,
-  PageVisibilityType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 
 type Props = {
   subscribeToUpdatedDirectMessageThreads: Function,
@@ -39,7 +36,6 @@ type Props = {
   },
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 type State = {
@@ -204,7 +200,6 @@ class DirectMessages extends React.Component<Props, State> {
 const map = state => ({
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
-  pageVisibility: state.connectionStatus.pageVisibility,
 });
 
 export default compose(

--- a/src/views/navbar/components/messagesTab.js
+++ b/src/views/navbar/components/messagesTab.js
@@ -12,10 +12,7 @@ import markDirectMessageNotificationsSeenMutation from 'shared/graphql/mutations
 import { MessageTab, Label } from '../style';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
-import type {
-  WebsocketConnectionType,
-  PageVisibilityType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 import { useConnectionRestored } from 'src/hooks/useConnectionRestored';
 
 type Props = {
@@ -34,7 +31,6 @@ type Props = {
   dispatch: Dispatch<Object>,
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 type State = {
@@ -56,7 +52,6 @@ class MessagesTab extends React.Component<Props, State> {
 
     if (curr.networkOnline !== nextProps.networkOnline) return true;
     if (curr.websocketConnection !== nextProps.websocketConnection) return true;
-    if (curr.pageVisibility !== nextProps.pageVisibility) return true;
 
     // if a refetch completes
     if (curr.isRefetching !== nextProps.isRefetching) return true;
@@ -261,7 +256,6 @@ const map = state => ({
   count: state.notifications.directMessageNotifications,
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
-  pageVisibility: state.connectionStatus.pageVisibility,
 });
 export default compose(
   // $FlowIssue

--- a/src/views/navbar/components/notificationsTab.js
+++ b/src/views/navbar/components/notificationsTab.js
@@ -17,10 +17,7 @@ import { Tab, NotificationTab, Label } from '../style';
 import { deduplicateChildren } from 'src/components/infiniteScroll/deduplicateChildren';
 import { track, events } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
-import type {
-  WebsocketConnectionType,
-  PageVisibilityType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 import { useConnectionRestored } from 'src/hooks/useConnectionRestored';
 
 type Props = {
@@ -43,7 +40,6 @@ type Props = {
   count: number,
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 type State = {
@@ -65,7 +61,6 @@ class NotificationsTab extends React.Component<Props, State> {
 
     if (curr.networkOnline !== nextProps.networkOnline) return true;
     if (curr.websocketConnection !== nextProps.websocketConnection) return true;
-    if (curr.pageVisibility !== nextProps.pageVisibility) return true;
 
     const prevLocation = curr.location;
     const nextLocation = nextProps.location;
@@ -452,8 +447,8 @@ const map = state => ({
   count: state.notifications.notifications,
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
-  pageVisibility: state.connectionStatus.pageVisibility,
 });
+
 export default compose(
   // $FlowIssue
   connect(map),

--- a/src/views/navbar/index.js
+++ b/src/views/navbar/index.js
@@ -29,10 +29,7 @@ import {
 import { track, events } from 'src/helpers/analytics';
 import { isViewingMarketingPage } from 'src/helpers/is-viewing-marketing-page';
 import { isDesktopApp } from 'src/helpers/desktop-app-utils';
-import type {
-  WebsocketConnectionType,
-  PageVisibilityType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 
 type Props = {
   isLoading: boolean,
@@ -49,7 +46,6 @@ type Props = {
   activeInboxThread: ?string,
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 type State = {
@@ -67,7 +63,6 @@ class Navbar extends React.Component<Props, State> {
 
     if (curr.networkOnline !== nextProps.networkOnline) return true;
     if (curr.websocketConnection !== nextProps.websocketConnection) return true;
-    if (curr.pageVisibility !== nextProps.pageVisibility) return true;
 
     // If the update was caused by the focus on the skip link
     if (nextState.isSkipLinkFocused !== this.state.isSkipLinkFocused)
@@ -344,7 +339,6 @@ const map = state => ({
   notificationCounts: state.notifications,
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
-  pageVisibility: state.connectionStatus.pageVisibility,
 });
 export default compose(
   // $FlowIssue

--- a/src/views/notifications/index.js
+++ b/src/views/notifications/index.js
@@ -48,10 +48,7 @@ import type { Dispatch } from 'redux';
 import { ErrorBoundary } from 'src/components/error';
 import { isDesktopApp } from 'src/helpers/desktop-app-utils';
 import { useConnectionRestored } from 'src/hooks/useConnectionRestored';
-import type {
-  WebsocketConnectionType,
-  PageVisibilityType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 
 type Props = {
   markAllNotificationsSeen?: Function,
@@ -71,7 +68,6 @@ type Props = {
   },
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 type State = {
@@ -143,7 +139,6 @@ class NotificationsPure extends React.Component<Props, State> {
     const curr = this.props;
     if (curr.networkOnline !== nextProps.networkOnline) return true;
     if (curr.websocketConnection !== nextProps.websocketConnection) return true;
-    if (curr.pageVisibility !== nextProps.pageVisibility) return true;
     // fetching more
     if (curr.data.networkStatus === 7 && nextProps.data.networkStatus === 3)
       return false;
@@ -436,7 +431,6 @@ class NotificationsPure extends React.Component<Props, State> {
 const map = state => ({
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
-  pageVisibility: state.connectionStatus.pageVisibility,
 });
 
 export default compose(

--- a/src/views/thread/components/messages.js
+++ b/src/views/thread/components/messages.js
@@ -30,10 +30,7 @@ import getThreadLink from 'src/helpers/get-thread-link';
 import type { GetThreadMessageConnectionType } from 'shared/graphql/queries/thread/getThreadMessageConnection';
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
 import { useConnectionRestored } from 'src/hooks/useConnectionRestored';
-import type {
-  WebsocketConnectionType,
-  PageVisibilityType,
-} from 'src/reducers/connectionStatus';
+import type { WebsocketConnectionType } from 'src/reducers/connectionStatus';
 
 type State = {
   subscription: ?Function,
@@ -61,7 +58,6 @@ type Props = {
   hasError: boolean,
   networkOnline: boolean,
   websocketConnection: WebsocketConnectionType,
-  pageVisibility: PageVisibilityType,
 };
 
 class MessagesWithData extends React.Component<Props, State> {
@@ -374,7 +370,6 @@ class MessagesWithData extends React.Component<Props, State> {
 const map = state => ({
   networkOnline: state.connectionStatus.networkOnline,
   websocketConnection: state.connectionStatus.websocketConnection,
-  pageVisibility: state.connectionStatus.pageVisibility,
 });
 
 export default compose(


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Closes #4367 - I'd like to add this back in in the future, and just add some kind of time that checks for an idle duration in order to determine whether a refetch makes sense. Although a pre-requisite of this will be fix:
- inbox should not go through thread selection logic after a refetch
- thread view should not go through messages refetch logic after a refetch (breaks pagination arguments)