### PR TITLE
Dont generate data in deleted communities

### DIFF
--- a/api/migrations/seed/index.js
+++ b/api/migrations/seed/index.js
@@ -61,6 +61,7 @@ users.forEach(user => {
 debug('Generating channels...');
 let channels = defaultChannels;
 communities.forEach(community => {
+  if (community.deletedAt) return;
   randomAmount({ max: 10 }, () => {
     channels.push(generateChannel(community.id));
   });
@@ -78,6 +79,11 @@ generatedUsersChannels.map(elem => {
 debug('Generating threads...');
 let threads = defaultThreads;
 channels.forEach(channel => {
+  const community = communities.find(
+    community => community.id === channel.communityId
+  );
+  if (community.deletedAt) return;
+
   randomAmount({ max: 10 }, () => {
     const creator = faker.random.arrayElement(users);
     const thread = generateThread(channel.communityId, channel.id, creator.id);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

Did a clean site rebuild on a new laptop today and ran into issues immediately when opening the client. I realized that our db seed content generator was creating threads in deleted communities, so when you loaded your everything feed it would get a valid thread with an invalid community. 

This PR fixes it so that we don't generate channels and threads in a community marked as deleted.