### PR TITLE
Fix email updating flow

### DIFF
--- a/api/mutations/user/editUser.js
+++ b/api/mutations/user/editUser.js
@@ -55,7 +55,7 @@ export default requireAuth(
       const pendingEmail = input.email;
 
       // if user is changing their email, make sure it's not taken by someone else
-      if (pendingEmail !== currentUser.email) {
+      if (pendingEmail !== currentUser.email || !currentUser.email) {
         if (!isEmail(input.email)) {
           return new UserError('Please enter a valid email address.');
         }

--- a/api/queries/user/email.js
+++ b/api/queries/user/email.js
@@ -3,8 +3,9 @@ import type { GraphQLContext } from '../../';
 import type { DBUser } from 'shared/types';
 import { isAdmin } from '../../utils/permissions';
 
-export default ({ id, email }: DBUser, _: any, { user }: GraphQLContext) => {
+export default ({ id }: DBUser, _: any, { user, loaders }: GraphQLContext) => {
   // Only admins and the user themselves can view the email
   if (!user || (id !== user.id && !isAdmin(user.id))) return null;
+  const { email } = loaders.user.load(id);
   return email;
 };

--- a/api/queries/user/email.js
+++ b/api/queries/user/email.js
@@ -3,9 +3,13 @@ import type { GraphQLContext } from '../../';
 import type { DBUser } from 'shared/types';
 import { isAdmin } from '../../utils/permissions';
 
-export default ({ id }: DBUser, _: any, { user, loaders }: GraphQLContext) => {
+export default async (
+  { id }: DBUser,
+  _: any,
+  { user, loaders }: GraphQLContext
+) => {
   // Only admins and the user themselves can view the email
   if (!user || (id !== user.id && !isAdmin(user.id))) return null;
-  const { email } = loaders.user.load(id);
+  const { email } = await loaders.user.load(id);
   return email;
 };

--- a/src/views/userSettings/components/editForm.js
+++ b/src/views/userSettings/components/editForm.js
@@ -10,7 +10,6 @@ import Icon from 'src/components/icons';
 import { SERVER_URL, CLIENT_URL } from 'src/api/constants';
 import GithubProfile from 'src/components/githubProfile';
 import { GithubSigninButton } from 'src/components/loginButtonSet/github';
-import { withCurrentUser } from 'src/components/withCurrentUser';
 import {
   Input,
   TextArea,
@@ -62,7 +61,6 @@ type State = {
 };
 
 type Props = {
-  currentUser: Object,
   dispatch: Dispatch<Object>,
   client: Object,
   editUser: Function,
@@ -293,9 +291,9 @@ class UserWithData extends React.Component<Props, State> {
   };
 
   handleUsernameValidation = ({ error, username }) => {
-    const { currentUser } = this.props;
+    const { user } = this.props;
     // we want to reset error if was typed same username which was set before
-    const usernameError = currentUser.username === username ? '' : error;
+    const usernameError = user.username === username ? '' : error;
     this.setState({
       usernameError,
       username,
@@ -307,7 +305,7 @@ class UserWithData extends React.Component<Props, State> {
   };
 
   render() {
-    const { currentUser } = this.props;
+    const { user } = this.props;
     const {
       name,
       username,
@@ -416,7 +414,7 @@ class UserWithData extends React.Component<Props, State> {
           {emailError && <Error>{emailError}</Error>}
 
           <GithubProfile
-            id={currentUser.id}
+            id={user.id}
             render={profile => {
               if (!profile) {
                 return (
@@ -475,7 +473,6 @@ const UserSettings = compose(
   editUserMutation,
   withRouter,
   withApollo,
-  withCurrentUser,
   connect()
 )(UserWithData);
 export default UserSettings;

--- a/src/views/userSettings/index.js
+++ b/src/views/userSettings/index.js
@@ -77,29 +77,6 @@ class UserSettings extends React.Component<Props> {
       );
     }
 
-    // if the user isn't logged in, or for some reason the user settings that were returned don't match the user id in the store, we show a warning error state
-    if (!currentUser || (user && user.id !== currentUser.id)) {
-      return (
-        <React.Fragment>
-          >
-          <Titlebar
-            title={'No User Found'}
-            provideBack={true}
-            backRoute={'/'}
-            noComposer
-          />
-          <AppViewWrapper>
-            <ViewError
-              heading={'These aren’t the settings you’re looking for.'}
-              subheading={
-                'You can only view your own user settings. Head on back.'
-              }
-            />
-          </AppViewWrapper>
-        </React.Fragment>
-      );
-    }
-
     // user is viewing their own settings, validated on the server
     if (user && user.id && currentUser.id === user.id) {
       const subnavItems = [


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

This fixes small bugs in the user settings view where the editform might possibly receive stale data. I've fixed this and made it so that the `email` field resolver *always* reads from the db, rather than from the cookie.