### PR TITLE
fix(cypress): grab the found user's id

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -16,7 +16,7 @@ Cypress.Commands.add('auth', userId => {
 
   return cy.setCookie(
     'session',
-    encode(JSON.stringify({ passport: { user: userId } })),
+    encode(JSON.stringify({ passport: { user: user.id } })),
     {
       httpOnly: true,
       secure: false,


### PR DESCRIPTION
It didn't look like the `getUser` function was ever called and I thought it was odd that the user ID that's returned is the one provided as an argument to the function so I changed this command to grab the found user's ID.

(Unless there was a reason that you guys were doing this.)

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing
