### PR TITLE
Temporarily disable chronos usersNotifications cleanup

### DIFF
--- a/chronos/queues/remove-seen-usersNotifications.js
+++ b/chronos/queues/remove-seen-usersNotifications.js
@@ -60,11 +60,14 @@ const processJob = async () => {
 };
 
 export default async () => {
-  try {
-    await processJob();
-  } catch (err) {
-    debug('❌ Error in job:\n');
-    debug(err);
-    Raven.captureException(err);
-  }
+  // NOTE(@mxstbr): This would iterate over the entire usersNotifications table every minute (!),
+  // so I've disabled it for now. We should run this at most once a week.
+  return;
+  // try {
+  //   await processJob();
+  // } catch (err) {
+  //   debug('❌ Error in job:\n');
+  //   debug(err);
+  //   Raven.captureException(err);
+  // }
 };


### PR DESCRIPTION

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- chronos


We would run the cleanup once a minute (!) and it would iterate over the entire table, locking up the database.

This temporarily disables the usersNotifications cleanup until we figure out the right cron pattern as a hotfix. This is already live.
