### PR TITLE
Fix edit action bar to bottom of text area

### DIFF
--- a/src/views/thread/components/actionBar.js
+++ b/src/views/thread/components/actionBar.js
@@ -23,6 +23,7 @@ import {
   ShareButtons,
   ShareButton,
   ActionBarContainer,
+  FixedBottomActionBarContainer,
   FlyoutRow,
   DropWrap,
   EditDone,
@@ -252,7 +253,7 @@ class ActionBar extends React.Component<Props, State> {
 
     if (isEditing) {
       return (
-        <ActionBarContainer>
+        <FixedBottomActionBarContainer>
           <div style={{ display: 'flex' }} />
           <div style={{ display: 'flex' }}>
             <EditDone data-cy="cancel-thread-edit-button">
@@ -269,7 +270,7 @@ class ActionBar extends React.Component<Props, State> {
               </Button>
             </EditDone>
           </div>
-        </ActionBarContainer>
+        </FixedBottomActionBarContainer>
       );
     } else {
       return (

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -432,8 +432,8 @@ export const ShareButton = styled.span`
       props.facebook
         ? props.theme.social.facebook.default
         : props.twitter
-          ? props.theme.social.twitter.default
-          : props.theme.text.default};
+        ? props.theme.social.twitter.default
+        : props.theme.text.default};
   }
 
   ${Tooltip};
@@ -607,6 +607,13 @@ export const ActionBarContainer = styled.div`
 
 export const WatercoolerActionBarContainer = styled(ActionBarContainer)`
   margin-bottom: 16px;
+`;
+
+export const FixedBottomActionBarContainer = styled(ActionBarContainer)`
+  z-index: 1;
+  bottom: 0;
+  position: sticky;
+  width: 100%;
 `;
 
 export const FollowButton = styled(Button)`


### PR DESCRIPTION
Before this change the 'Save' and 'Cancel' buttons would move on/off the
screen as you scrolled which meant you had to scroll all the way to the
bottom of a post to select either of the options.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)
- desktop

**Release notes for users (delete if codebase-only change)**
- Fix 'Save' and 'Cancel' buttons to bottom of window when editing a post for easier access.

**Related issues (delete if you don't know of any)**
Closes #4395 

<!-- If there are UI changes please share mobile and desktop screenshots or recordings. -->

![screenshot 2018-12-08 at 02 17 04](https://user-images.githubusercontent.com/8593744/49680693-64033800-fa8f-11e8-913c-e39598b501af.png)

As you can see from the scrollbar in the above screenshot we aren't at the bottom of the post but you can still access the action bar buttons.