### PR TITLE
Limit digests to just 20 threads

### DIFF
--- a/chronos/queues/digests/processIndividualDigest.js
+++ b/chronos/queues/digests/processIndividualDigest.js
@@ -54,7 +54,8 @@ const processJob = async (job: Job<ProcessIndividualDigestJobData>) => {
   const threads = await attachMetadataToThreads(threadsInTimeframe, timeframe)
     .then(threads => attachMessageCountStringToThreads(threads))
     .then(threads => attachScoreToThreads(threads))
-    .then(threads => cleanThreadData(threads));
+    .then(threads => cleanThreadData(threads))
+    .then(threads => threads.slice(0, 20));
 
   const user = await getUserById(userId);
 

--- a/chronos/queues/digests/processIndividualDigest.js
+++ b/chronos/queues/digests/processIndividualDigest.js
@@ -51,11 +51,15 @@ const processJob = async (job: Job<ProcessIndividualDigestJobData>) => {
 
   debug('Got threads in timeframe');
 
+  let hasOverflowThreads = false;
   const threads = await attachMetadataToThreads(threadsInTimeframe, timeframe)
     .then(threads => attachMessageCountStringToThreads(threads))
     .then(threads => attachScoreToThreads(threads))
     .then(threads => cleanThreadData(threads))
-    .then(threads => threads.slice(0, 20));
+    .then(threads => {
+      hasOverflowThreads = true;
+      return threads.slice(0, 20);
+    });
 
   const user = await getUserById(userId);
 
@@ -71,6 +75,7 @@ const processJob = async (job: Job<ProcessIndividualDigestJobData>) => {
     reputationString,
     timeframe,
     threads,
+    hasOverflowThreads,
   });
 };
 

--- a/email-templates/weeklyDigest.html
+++ b/email-templates/weeklyDigest.html
@@ -441,6 +441,21 @@
                 </tr>
                 {{/each}}
 
+                {{#data.hasOverflowThreads}}
+                <tr>
+                  <td>
+                    <p>&nbsp;</p>
+                    <p class="reputation-string">Today’s digest highlights the top 20 conversations in your
+                      communities - but there are more active conversations waiting for you!</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a class="button" href="https://spectrum.chat">See more conversations</a>
+                  </td>
+                </tr>
+                {{/data.hasOverflowThreads}}
+
                 {{#data.communities}}
                 <tr>
                   <td>

--- a/hermes/queues/send-digest-email.js
+++ b/hermes/queues/send-digest-email.js
@@ -17,6 +17,7 @@ export default async (job: Job<SendDigestEmailJobData>) => {
     reputationString,
     communities,
     timeframe,
+    hasOverflowThreads,
   } = job.data;
 
   if (!email || !userId || !username) {
@@ -68,6 +69,7 @@ export default async (job: Job<SendDigestEmailJobData>) => {
         preheader,
         unsubscribeToken,
         data: {
+          hasOverflowThreads,
           username,
           threads,
           communities,

--- a/shared/bull/types.js
+++ b/shared/bull/types.js
@@ -424,6 +424,7 @@ export type SendDigestEmailJobData = {
   reputationString: string,
   communities: ?Array<DBCommunity>,
   timeframe: Timeframe,
+  hasOverflowThreads: boolean,
 };
 
 export type Queues = {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- chronos

I took this out a while ago, but digests are getting pretty crazy for people in many communities. Let's cap digests at 20 threads per email.