### PR TITLE
Track database connection count and queue size in DataDog

### DIFF
--- a/shared/middlewares/statsd.js
+++ b/shared/middlewares/statsd.js
@@ -1,27 +1,10 @@
 // @flow
-const debug = require('debug')('shared:middlewares:statsd');
 import statsdMiddleware from 'express-statsd';
-import StatsD from 'hot-shots';
-
-export const client = new StatsD({
-  mock: process.env.NODE_ENV !== 'production',
-  prefix: `${process.env.SENTRY_NAME || 'server'}.`,
-});
-
-client.socket.on('error', function(error) {
-  console.error('Error in socket: ', error);
-});
+import { statsd } from '../statsd';
 
 const middleware = statsdMiddleware({
-  client,
+  client: statsd,
 });
-
-const log = () => {
-  client.mockBuffer.forEach(item => {
-    debug(item);
-  });
-  client.mockBuffer = [];
-};
 
 export default (
   req: express$Request,
@@ -35,7 +18,5 @@ export default (
   req.statsdKey = `http.${req.method.toLowerCase()}${pathname
     .toLowerCase()
     .replace('/', '.')}`;
-  // Log the StatsD metrics in development
-  if (debug.enabled) res.once('finish', log);
   return middleware(req, res, next);
 };

--- a/shared/statsd.js
+++ b/shared/statsd.js
@@ -1,0 +1,25 @@
+// @flow
+const debug = require('debug')('shared:middlewares:statsd');
+import StatsD from 'hot-shots';
+
+export const statsd = new StatsD({
+  mock: process.env.NODE_ENV !== 'production',
+  prefix: `${process.env.SENTRY_NAME || 'server'}.`,
+});
+
+statsd.socket.on('error', function(error) {
+  console.error('Error in socket: ', error);
+});
+
+// Log StatsD events in development by monkey-patching the internal _send method
+// because hot-shots does not expose a way to listen to events as they happen
+if (debug.enabled) {
+  const originalSend = statsd._send;
+  statsd._send = (...args) => {
+    statsd.mockBuffer.forEach(item => {
+      debug(item);
+    });
+    statsd.mockBuffer = [];
+    return originalSend.call(statsd, ...args);
+  };
+}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)
- athena
- vulcan
- mercury
- hermes
- chronos
- analytics

This is based on #4444 and adds tracking of the database connection count and query queue size over time in DataDog.

I'm not sure we should ship this as it changes _very_ often, many times per sec, which is why I've submitted it as a separate PR. Trying to get input from the observability team on this.