### PR TITLE
[HOTFIX] Fix email jobs never completing

### DIFF
--- a/hermes/send-email.js
+++ b/hermes/send-email.js
@@ -27,7 +27,7 @@ const defaultOptions = {
   },
 };
 
-const sendEmail = (options: Options) => {
+const sendEmail = (options: Options): Promise<void> => {
   const { templateId, to, dynamic_template_data, userId } = options;
 
   if (SENDGRID_API_KEY !== 'undefined') {
@@ -50,7 +50,7 @@ const sendEmail = (options: Options) => {
       })
     );
 
-    return;
+    return Promise.resolve();
   }
 
   if (userId) {
@@ -69,23 +69,20 @@ const sendEmail = (options: Options) => {
       });
     }
 
-    return;
+    return Promise.resolve();
   }
 
   // qq.com email addresses are isp blocked, which raises our error rate
   // on sendgrid. prevent sending these emails at all
   if (to.substr(to.length - 7) === '@qq.com') {
-    return;
+    return Promise.resolve();
   }
 
-  // $FlowFixMe
-  return new Promise((res, rej) => {
-    return sg.send({
-      ...defaultOptions,
-      templateId,
-      to,
-      dynamic_template_data,
-    });
+  return sg.send({
+    ...defaultOptions,
+    templateId,
+    to,
+    dynamic_template_data,
   });
 };
 

--- a/hermes/send-email.js
+++ b/hermes/send-email.js
@@ -80,7 +80,7 @@ const sendEmail = (options: Options) => {
 
   // $FlowFixMe
   return new Promise((res, rej) => {
-    sg.send({
+    return sg.send({
       ...defaultOptions,
       templateId,
       to,


### PR DESCRIPTION
The job queue didn't know that the job had completed because the
returned promise from `sendEmail` never resolved.

Just need to return the Promise that is returned from `sg.send`, see
https://github.com/sendgrid/sendgrid-nodejs/blob/master/packages/mail/USE_CASES.md#handling-successfailureerrors


<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hermes

This is going live right now to fix our emails not sending.