### PR TITLE
Move loaders creation outside of each req

### DIFF
--- a/api/apollo-server.js
+++ b/api/apollo-server.js
@@ -40,6 +40,7 @@ class ProtectedApolloServer extends ApolloServer {
   }
 }
 
+const loaders = createLoaders();
 const server = new ProtectedApolloServer({
   schema,
   formatError: createErrorFormatter(),
@@ -51,7 +52,6 @@ const server = new ProtectedApolloServer({
       };
     }
 
-    const loaders = createLoaders();
     let currentUser = req.user && !req.user.bannedAt ? req.user : null;
 
     return {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

@mxstbr this one change improves memory usage on the API node server by ~25%. Was there a specific reason we created loaders on every request instead of once for the entire app process?