### PR TITLE
Dont use createwritequery for setuseronline

### DIFF
--- a/shared/db/queries/user.js
+++ b/shared/db/queries/user.js
@@ -533,26 +533,23 @@ export const editUser = createWriteQuery(
   }
 );
 
-export const setUserOnline = createWriteQuery(
-  (id: string, isOnline: boolean) => ({
-    query: db
-      .table('users')
-      .get(id)
-      .update(
-        {
-          isOnline,
-          lastSeen: new Date(),
-        },
-        { returnChanges: 'always' }
-      )
-      .run()
-      .then(res => {
-        const user = res.changes[0].new_val || res.changes[0].old_val;
-        return user;
-      }),
-    invalidateTags: () => [id],
-  })
-);
+export const setUserOnline = async (id: string, isOnline: boolean) => {
+  return await db
+    .table('users')
+    .get(id)
+    .update(
+      {
+        isOnline,
+        lastSeen: new Date(),
+      },
+      { returnChanges: 'always' }
+    )
+    .run()
+    .then(res => {
+      const user = res.changes[0].new_val || res.changes[0].old_val;
+      return user;
+    });
+};
 
 export const setUserPendingEmail = createWriteQuery(
   (userId: string, pendingEmail: string) => ({


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

This query is throwing errors when running the api locally. @mxstbr I think to get around this before you had the `setUserOnline` function throw an error if no result was returned from the database. I suppose that's why, because if the query returns null to `createWriteQuery` it will try to run `result.run` - obviously you can't run `null.run` so it fails. Either way, this seems like a highly-trafficked path that might need optimization. Open to ideas.