### PR TITLE
More aggressively reconnect changefeeds

### DIFF
--- a/shared/changefeed-utils/index.js
+++ b/shared/changefeed-utils/index.js
@@ -63,7 +63,7 @@ export const createChangefeed = (
     },
     {
       changefeedName: name,
-      attemptDelay: 60000,
+      attemptDelay: 10000,
       maxAttempts: Infinity,
       logger: {
         // Ignore log and info logs in production


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

The `rethinkdb-changefeed-reconnect` library implements a linear back-off strategy, that means the delay between connection attempts is set to `attemptDelay * numAttempts`. (see https://github.com/LearnersGuild/rethinkdb-changefeed-reconnect/blob/a0228387c3b3e3cb6face53b7bc1c8b631449675/src/index.js#L22-L24)

Our default value of 60s for the attemptDelay is thusly very slow, the first attempt will be made after 60s, second 120s after that, third 180s after that, etc. etc. etc.

This switches it to be a bit more aggressive and try reconnecting after 10s, then 20s after that, then 30s after that, then 40s after that, etc.