### PR TITLE
Upgrade apollo-cache-inmemory

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "algoliasearch": "^3.30.0",
     "amplitude": "^3.5.0",
     "amplitude-js": "^4.4.0",
-    "apollo-cache-inmemory": "^1.3.11",
+    "apollo-cache-inmemory": "1.3.12-beta.0",
     "apollo-client": "^2.4.7",
     "apollo-link": "^1.2.4",
     "apollo-link-http": "^1.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,14 +1434,14 @@ apollo-cache-control@0.4.0:
     apollo-server-env "2.2.0"
     graphql-extensions "0.4.0"
 
-apollo-cache-inmemory@^1.3.11:
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.11.tgz#6cb8f24ec812715169f9acbb0b67833f9a19ec90"
-  integrity sha512-fSoyjBV5RV57J3i/VHDDB74ZgXc0PFiogheNFHEhC0mL6rg5e/DjTx0Vg+csIBk23gvlzTvV+eypx7Q2NJ+dYg==
+apollo-cache-inmemory@1.3.12-beta.0:
+  version "1.3.12-beta.0"
+  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.3.12-beta.0.tgz#7c7e659fd0ad41f744ea977f24b471ff5a1ffc8b"
+  integrity sha512-bTQONAbg4KXPw64aj8xeifB4W50Hy2qsRqgsXfSbVDSg/799lFTuz9V3GWVi1PqUFyC7B3rzyEopGCVrRA1GUA==
   dependencies:
     apollo-cache "^1.1.21"
     apollo-utilities "^1.0.26"
-    optimism "^0.6.6"
+    optimism "^0.6.8"
 
 apollo-cache@1.1.21, apollo-cache@^1.1.21:
   version "1.1.21"
@@ -10536,7 +10536,7 @@ opn@^5.1.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optimism@^0.6.6:
+optimism@^0.6.8:
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.6.8.tgz#0780b546da8cd0a72e5207e0c3706c990c8673a6"
   integrity sha512-bN5n1KCxSqwBDnmgDnzMtQTHdL+uea2HYFx1smvtE+w2AMl0Uy31g0aXnP/Nt85OINnMJPRpJyfRQLTCqn5Weg==


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Ref https://github.com/apollographql/apollo-client/issues/4210

Before this change, a memory leak problem in `apollo-cache-inmemory` would cause heap usage to rise continuously as optimistic updates were performed (e.g. anytime someone sent a message). Sending 20 messages quickly could cause the heap to go from 60mb memory usage to >1gb, and in many cases crash the browser. After updating to this alpha version of the package, I can see very clear garbage collection cycles with heap memory peaking at ~300mb. 

Note: @mxstbr we still have some perf issues for people sending messages *very* quickly, but this is likely our application code and a result of many async events happening in our chat input. I hope #4472 will help with this :)