### PR TITLE
Remove use of Google+ APIs

### DIFF
--- a/api/routes/auth/google.js
+++ b/api/routes/auth/google.js
@@ -4,10 +4,7 @@ import { createSigninRoutes } from './create-signin-routes';
 
 const googleAuthRouter = Router();
 const { main, callbacks } = createSigninRoutes('google', {
-  scope: [
-    'https://www.googleapis.com/auth/plus.login',
-    'https://www.googleapis.com/auth/plus.profile.emails.read',
-  ],
+  scope: 'profile email',
 });
 
 googleAuthRouter.get('/', main);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

Google is deprecating the Google+ APIs in March, but said that we should expect degradations in service starting in January. I was worried this would be a more involved migration process from Google+ auth to the generic "Google Sign-in" product - turns out, it just requires a change in scopes! Tested locally for creating a new user with Google signin and authenticating with an existing user via Google.