### PR TITLE
Nicer reputation string in digest emails

### DIFF
--- a/chronos/queues/digests/getReputationString.js
+++ b/chronos/queues/digests/getReputationString.js
@@ -19,9 +19,7 @@ export const getReputationString = ({
   const during = timeframe === 'weekly' ? 'last week' : 'yesterday';
 
   let reputationString;
-  if (!hasGainedReputation) {
-    reputationString = `You were a little quiet ${during} and haven't gained any reputation – join some of the conversations below, your communities would love to hear from you.`;
-  } else {
+  if (hasGainedReputation) {
     reputationString = `You gained ${reputationGained} reputation ${during}.`;
   }
 

--- a/chronos/queues/digests/getReputationString.js
+++ b/chronos/queues/digests/getReputationString.js
@@ -21,6 +21,8 @@ export const getReputationString = ({
   let reputationString;
   if (hasGainedReputation) {
     reputationString = `You gained ${reputationGained} reputation ${during}.`;
+  } else {
+    reputationString = `You didn’t gain any reputation ${during}.`;
   }
 
   if (isFirstReputation) {

--- a/chronos/queues/digests/test/__snapshots__/reputation-string.test.js.snap
+++ b/chronos/queues/digests/test/__snapshots__/reputation-string.test.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`existing users should handle no reputation gain 1`] = `"You were a little quiet last week and haven't gained any reputation – join some of the conversations below, your communities would love to hear from you. You have a total of 10 reputation across all of your communities."`;
+exports[`existing users should handle no reputation gain 1`] = `"You didn’t gain any reputation last week. You have a total of 10 reputation across all of your communities."`;
 
 exports[`existing users should handle reputation gain 1`] = `"You gained 10 reputation last week. You have a total of 20 reputation across all of your communities - well done!"`;
 
-exports[`first-time users should be told when they haven't gained any reputation 1`] = `"You were a little quiet last week and haven't gained any reputation – join some of the conversations below, your communities would love to hear from you. Reputation is an indicator of how active and constructive you are across all your communities. The more great conversations you start or join, the more reputation you will have."`;
+exports[`first-time users should be told when they haven't gained any reputation 1`] = `"You didn’t gain any reputation last week. Reputation is an indicator of how active and constructive you are across all your communities. The more great conversations you start or join, the more reputation you will have."`;
 
 exports[`first-time users should get an explanation what reputation is 1`] = `"You gained 10 reputation last week. Reputation is an indicator of how active and constructive you are across all your communities. The more great conversations you start or join, the more reputation you will have."`;
 
 exports[`should handle a daily timeframe 1`] = `"You gained 10 reputation yesterday. You have a total of 20 reputation across all of your communities - well done!"`;
 
-exports[`should handle a daily timeframe 2`] = `"You were a little quiet yesterday and haven't gained any reputation – join some of the conversations below, your communities would love to hear from you. Reputation is an indicator of how active and constructive you are across all your communities. The more great conversations you start or join, the more reputation you will have."`;
+exports[`should handle a daily timeframe 2`] = `"You didn’t gain any reputation yesterday. Reputation is an indicator of how active and constructive you are across all your communities. The more great conversations you start or join, the more reputation you will have."`;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- chronos

Slightly less snarky rep string if the user didn't write anything in the previous digest period.