### PR TITLE
Safer signed out chat input

### DIFF
--- a/cypress/integration/thread/chat_input_spec.js
+++ b/cypress/integration/thread/chat_input_spec.js
@@ -31,17 +31,14 @@ describe('chat input', () => {
 
     it('should render', () => {
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[data-cy="chat-input-send-button"]').should('be.visible');
+      cy.get('[data-cy="chat-input-send-button"]').should('not.be.visible');
       cy.get('[data-cy="chat-input-media-uploader"]').should('not.be.visible');
-      cy.get('[data-cy="markdownHint"]').should('have.css', 'opacity', '0');
-
-      const newMessage = 'A new message!';
-      cy.get('[contenteditable="true"]').type(newMessage);
-      cy.get('[data-cy="markdownHint"]').should('have.css', 'opacity', '1');
-      // Wait for the messages to be loaded before sending new message
-      cy.get('[data-cy="message-group"]').should('be.visible');
-      cy.get('[data-cy="chat-input-send-button"]').click();
-      cy.contains('Sign in');
+      cy.get('[data-cy="join-channel-login-upsell"]').should('be.visible');
+      cy.get('[data-cy="thread-join-channel-upsell-button"]').should(
+        'be.visible'
+      );
+      cy.get('[data-cy="thread-join-channel-upsell-button"]').click();
+      cy.get('[data-cy="login-modal"]').should('be.visible');
     });
   });
 

--- a/cypress/integration/thread_spec.js
+++ b/cypress/integration/thread_spec.js
@@ -52,11 +52,12 @@ describe('Thread View', () => {
     it('should prompt logged-out users to log in', () => {
       const newMessage = 'A new message!';
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[contenteditable="true"]').type(newMessage);
-      // Wait for the messages to be loaded before sending new message
-      cy.get('[data-cy="message-group"]').should('be.visible');
-      cy.get('[data-cy="chat-input-send-button"]').click();
-      cy.contains('Sign in');
+      cy.get('[data-cy="join-channel-login-upsell"]').should('be.visible');
+      cy.get('[data-cy="thread-join-channel-upsell-button"]').should(
+        'be.visible'
+      );
+      cy.get('[data-cy="thread-join-channel-upsell-button"]').click();
+      cy.get('[data-cy="login-modal"]').should('be.visible');
     });
   });
 
@@ -442,7 +443,7 @@ describe('edit message signed in', () => {
   });
 });
 
-describe('/new/thread', () => {
+describe.only('/new/thread', () => {
   beforeEach(() => {
     cy.auth(author.id).then(() => cy.visit('/new/thread'));
   });

--- a/src/components/upsell/joinChannel.js
+++ b/src/components/upsell/joinChannel.js
@@ -98,7 +98,7 @@ class JoinChannel extends React.Component<Props, State> {
 
     if (!currentUser) {
       return (
-        <JoinChannelContainer>
+        <JoinChannelContainer data-cy="join-channel-login-upsell">
           <JoinChannelContent>
             <JoinChannelTitle>Log in or sign up to chat</JoinChannelTitle>
           </JoinChannelContent>

--- a/src/components/upsell/joinChannel.js
+++ b/src/components/upsell/joinChannel.js
@@ -4,21 +4,24 @@ import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import toggleChannelSubscriptionMutation from 'shared/graphql/mutations/channel/toggleChannelSubscription';
 import type { ToggleChannelSubscriptionType } from 'shared/graphql/mutations/channel/toggleChannelSubscription';
-import { addToastWithTimeout } from '../../actions/toasts';
+import { addToastWithTimeout } from 'src/actions/toasts';
+import { openModal } from 'src/actions/modals';
 import type { Dispatch } from 'redux';
+import { withCurrentUser } from 'src/components/withCurrentUser';
 import {
   JoinChannelContainer,
   JoinChannelContent,
   JoinChannelTitle,
   JoinChannelSubtitle,
 } from './style';
-import { Button } from '../buttons';
+import { Button } from 'src/components/buttons';
 
 type Props = {
   channel: Object,
   community: Object,
   toggleChannelSubscription: Function,
   dispatch: Dispatch<Object>,
+  currentUser: ?Object,
 };
 
 type State = {
@@ -33,6 +36,8 @@ class JoinChannel extends React.Component<Props, State> {
       isLoading: false,
     };
   }
+
+  login = () => this.props.dispatch(openModal('CHAT_INPUT_LOGIN_MODAL'));
 
   toggleSubscription = () => {
     const { channel, dispatch } = this.props;
@@ -89,7 +94,26 @@ class JoinChannel extends React.Component<Props, State> {
 
   render() {
     const { isLoading } = this.state;
-    const { channel, community } = this.props;
+    const { channel, community, currentUser } = this.props;
+
+    if (!currentUser) {
+      return (
+        <JoinChannelContainer>
+          <JoinChannelContent>
+            <JoinChannelTitle>Log in or sign up to chat</JoinChannelTitle>
+          </JoinChannelContent>
+
+          <Button
+            loading={isLoading}
+            onClick={this.login}
+            dataCy="thread-join-channel-upsell-button"
+          >
+            Log in or sign up
+          </Button>
+        </JoinChannelContainer>
+      );
+    }
+
     return (
       <JoinChannelContainer>
         <JoinChannelContent>
@@ -116,5 +140,6 @@ class JoinChannel extends React.Component<Props, State> {
 
 export default compose(
   connect(),
+  withCurrentUser,
   toggleChannelSubscriptionMutation
 )(JoinChannel);

--- a/src/helpers/localStorage.js
+++ b/src/helpers/localStorage.js
@@ -1,13 +1,3 @@
-export const localStorageAllowed = () => {
-  try {
-    localStorage.setItem('test', 'test');
-    localStorage.removeItem('test');
-    return true;
-  } catch (e) {
-    return false;
-  }
-};
-
 export const clearStorage = () => localStorage.clear();
 
 export const getItemFromStorage = (key: string) => {

--- a/src/helpers/localStorage.js
+++ b/src/helpers/localStorage.js
@@ -1,3 +1,13 @@
+export const localStorageAllowed = () => {
+  try {
+    localStorage.setItem('test', 'test');
+    localStorage.removeItem('test');
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
 export const clearStorage = () => localStorage.clear();
 
 export const getItemFromStorage = (key: string) => {

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -327,21 +327,19 @@ class ThreadContainer extends React.Component<Props, State> {
       </Input>
     );
 
-    if (!currentUser) {
-      return chatInputComponent;
-    }
+    const joinLoginUpsell = (
+      <JoinChannel channel={thread.channel} community={thread.community} />
+    );
 
-    if (currentUser && !currentUser.id) {
-      return chatInputComponent;
+    if (!currentUser || !currentUser.id) {
+      return joinLoginUpsell;
     }
 
     if (channelPermissions.isMember) {
       return chatInputComponent;
     }
 
-    return (
-      <JoinChannel channel={thread.channel} community={thread.community} />
-    );
+    return joinLoginUpsell;
   };
 
   renderPost = () => {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

We've had a couple reports of people being signed out, composing a message in the chat input, being prompted to login, and post-auth, losing the message that had been typed. This is likely a problem with localStorage persistence, but since it's very tricky to make this bulletproof across mobile, desktop, browsers, and operating systems, we should just ensure that users are signed in before they can type into the chat input.