### PR TITLE
Upgrade to apollo-server-express@2.4.0-alpha.0

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "algoliasearch": "^3.32.0",
     "apollo-local-query": "^0.3.1",
-    "apollo-server-express": "^2.3.1",
+    "apollo-server-express": "2.4.0-alpha.0",
     "apollo-upload-client": "^9.1.0",
     "aws-sdk": "2.200.0",
     "axios": "^0.16.2",

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1077,20 +1077,20 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apollo-cache-control@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.4.0.tgz#fec343e6ec95aa4f1b88e07e62f067bee0c48397"
-  integrity sha512-WuriaNQIugTE8gYwfBWWCbbQTSKul/cV4JMi5UgqNIUvjHvnKZQLKbt5uYWow6QQNMkLT9hey8QPYkWpogkeSA==
+apollo-cache-control@0.5.0-alpha.0:
+  version "0.5.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.5.0-alpha.0.tgz#aed22e09121b90f6f5ab24a38429c2551d1d870d"
+  integrity sha512-vb1tU8+oE6WAPvUwz18SBvxKUfG6OMJlaIiBLFQ+1bFkqZneTil7A3L4QgRSTPZKus7ckCZ9WR7DNx/zj7hn8A==
   dependencies:
     apollo-server-env "2.2.0"
-    graphql-extensions "0.4.0"
+    graphql-extensions "0.5.0-alpha.0"
 
-apollo-datasource@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.2.1.tgz#3ecef4efe64f7a04a43862f32027d38ac09e142c"
-  integrity sha512-r185+JTa5KuF1INeTAk7AEP76zwMN6c8Ph1lmpzJMNwBUEzTGnLClrccCskCBx4SxfnkdKbuQdwn9JwCJUWrdg==
+apollo-datasource@0.3.0-alpha.0:
+  version "0.3.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-0.3.0-alpha.0.tgz#beeaab9b7d5cb370b92c7bff17d3ad0d1cd56e4a"
+  integrity sha512-xY3H4/lbwOdh4t2vGLkSAN/FG1OOvmUgRp6vzOW12yzLK9+Hn6j6k0X29WkJFpjLf9JlWqWHEHumi2hqKJtOEg==
   dependencies:
-    apollo-server-caching "0.2.1"
+    apollo-server-caching "0.3.0-alpha.0"
     apollo-server-env "2.2.0"
 
 apollo-engine-reporting-protobuf@0.2.0:
@@ -1100,15 +1100,15 @@ apollo-engine-reporting-protobuf@0.2.0:
   dependencies:
     protobufjs "^6.8.6"
 
-apollo-engine-reporting@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/apollo-engine-reporting/-/apollo-engine-reporting-0.2.0.tgz#e71816b1f46e782f8538c5a118148d4c0e628e25"
-  integrity sha512-Q6FfVb10v/nrv8FaFsPjIYlWh62jaYav3LuMgM9PsHWGK/zRQFXOEwLxcY2UCvG7O1moxF3XGmfBhMgo54py+Q==
+apollo-engine-reporting@0.3.0-alpha.0:
+  version "0.3.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/apollo-engine-reporting/-/apollo-engine-reporting-0.3.0-alpha.0.tgz#3a55da736404bded6d7ab560f0544e0cf109ad35"
+  integrity sha512-0hRFvT8Gc/VATKVa+qtehaQYTgi+2sOOpHJ7TA8gzkVXmSXiIy6tbJZBnLbh9D1xKfOoF3qtspJrcxBI5A8Ceg==
   dependencies:
     apollo-engine-reporting-protobuf "0.2.0"
     apollo-server-env "2.2.0"
     async-retry "^1.2.1"
-    graphql-extensions "0.4.0"
+    graphql-extensions "0.5.0-alpha.0"
     lodash "^4.17.10"
 
 apollo-env@0.2.5:
@@ -1141,30 +1141,30 @@ apollo-local-query@^0.3.1:
   dependencies:
     debug "^2.6.9"
 
-apollo-server-caching@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.2.1.tgz#7e67f8c8cac829e622b394f0fb82579cabbeadfd"
-  integrity sha512-+U9F3X297LL8Gqy6ypfDNEv/DfV/tDht9Dr2z3AMaEkNW1bwO6rmdDL01zYxDuVDVq6Z3qSiNCSO2pXE2F0zmA==
+apollo-server-caching@0.3.0-alpha.0:
+  version "0.3.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.3.0-alpha.0.tgz#1a4e3762da926018be975d3dfd17da4d60e66923"
+  integrity sha512-GY2OKVnVGvClY9sXQLnuCuMn9foE4dTExA9UHNf5stZqx3E/t/r9pLnu7w1wC1B8ppV9iW7oh83/MLKgJ/dnsQ==
   dependencies:
     lru-cache "^5.0.0"
 
-apollo-server-core@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.3.1.tgz#cbdc0020a0dfecf2220cf5062dbb304fdf56edf2"
-  integrity sha512-8jMWYOQIZi9mDJlHe2rXg8Cp4xKYogeRu23jkcNy+k5UjZL+eO+kHXbNFiTaP4HLYYEpe2XE3asxp6q5YUEQeQ==
+apollo-server-core@2.4.0-alpha.0:
+  version "2.4.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.4.0-alpha.0.tgz#420193c2aa0f05dac92feaa64f50e7c9a700f1cb"
+  integrity sha512-/n0y1zCtCpmEmn45eT7jorFqVTMR5JoP67yjSTup+FfEOSjskAeP3uuuCHLx3qhdoDgXTtzdeDmWFXyYS/1nVA==
   dependencies:
     "@apollographql/apollo-tools" "^0.2.6"
     "@apollographql/graphql-playground-html" "^1.6.6"
     "@types/ws" "^6.0.0"
-    apollo-cache-control "0.4.0"
-    apollo-datasource "0.2.1"
-    apollo-engine-reporting "0.2.0"
-    apollo-server-caching "0.2.1"
+    apollo-cache-control "0.5.0-alpha.0"
+    apollo-datasource "0.3.0-alpha.0"
+    apollo-engine-reporting "0.3.0-alpha.0"
+    apollo-server-caching "0.3.0-alpha.0"
     apollo-server-env "2.2.0"
     apollo-server-errors "2.2.0"
-    apollo-server-plugin-base "0.2.1"
-    apollo-tracing "0.4.0"
-    graphql-extensions "0.4.1"
+    apollo-server-plugin-base "0.3.0-alpha.0"
+    apollo-tracing "0.5.0-alpha.0"
+    graphql-extensions "0.5.0-alpha.0"
     graphql-subscriptions "^1.0.0"
     graphql-tag "^2.9.2"
     graphql-tools "^4.0.0"
@@ -1187,10 +1187,10 @@ apollo-server-errors@2.2.0:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.2.0.tgz#5b452a1d6ff76440eb0f127511dc58031a8f3cb5"
   integrity sha512-gV9EZG2tovFtT1cLuCTavnJu2DaKxnXPRNGSTo+SDI6IAk6cdzyW0Gje5N2+3LybI0Wq5KAbW6VLei31S4MWmg==
 
-apollo-server-express@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.3.1.tgz#0598e2fa0a0d9e6eb570c0bb6ce65c31810a9c09"
-  integrity sha512-J+rObr4GdT/5j6qTByUJoSvZSjTAX/7VqIkr2t+GxwcVUFGet2MdOHuV6rtWKc8CRgvVKfKN6iBrb2EOFcp2LQ==
+apollo-server-express@2.4.0-alpha.0:
+  version "2.4.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.4.0-alpha.0.tgz#a919f6e75f7181e73185b50e387fa7e159153277"
+  integrity sha512-ODrCMxxpgSYZ8tV45l2UuCKuQ7D4h88C+IfBXAU5ItGrfny0tkJCSuRnOmyY8o/MOF8aenqB7m0IWdf8dRxG/Q==
   dependencies:
     "@apollographql/graphql-playground-html" "^1.6.6"
     "@types/accepts" "^1.3.5"
@@ -1198,25 +1198,25 @@ apollo-server-express@^2.3.1:
     "@types/cors" "^2.8.4"
     "@types/express" "4.16.0"
     accepts "^1.3.5"
-    apollo-server-core "2.3.1"
+    apollo-server-core "2.4.0-alpha.0"
     body-parser "^1.18.3"
     cors "^2.8.4"
     graphql-subscriptions "^1.0.0"
     graphql-tools "^4.0.0"
     type-is "^1.6.16"
 
-apollo-server-plugin-base@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.2.1.tgz#d08c9576f7f11ab6e212f352d482faaa4059a31e"
-  integrity sha512-497NIY9VWRYCrMSkgR11IrIUO4Fsy6aGgnpOJoTdLQAnkDD9SJDSRzwKj4gypUoTT2unfKDng4eMxXVZlHvjOw==
+apollo-server-plugin-base@0.3.0-alpha.0:
+  version "0.3.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.3.0-alpha.0.tgz#e5b0f860a530a9b7dca01a39f493051562fda32f"
+  integrity sha512-ygDc6CGgyEU2PaVPR7xOM1ZzMnR/evGRMHAane1VhMgc8m60jaoDRprM+7B7MJ9NJw4slA08Gr6Hq65kezAMRA==
 
-apollo-tracing@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.4.0.tgz#4b939063f4292422ac5a3564b76d1d88dec0a916"
-  integrity sha512-BlM8iQUQva4fm0xD/pLwkcz0degfB9a/aAn4k4cK36eLVD8XUkl7ptEB0c+cwcj7tOYpV1r5QX1XwdayBzlHSg==
+apollo-tracing@0.5.0-alpha.0:
+  version "0.5.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.5.0-alpha.0.tgz#2d4aa71b76bbaf7ec3e25053c25320606549366e"
+  integrity sha512-uYetlXSKHv29jNKoDqC0n7AgoWrQ/s9OmSJAuAHLE9Q0+9PvMrbMXtoL7WH4vcy1ObYMwaL+Zh727191VzrSVw==
   dependencies:
     apollo-server-env "2.2.0"
-    graphql-extensions "0.4.0"
+    graphql-extensions "0.5.0-alpha.0"
 
 apollo-upload-client@^9.1.0:
   version "9.1.0"
@@ -4539,17 +4539,10 @@ graphql-depth-limit@^1.1.0:
   dependencies:
     arrify "^1.0.1"
 
-graphql-extensions@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.4.0.tgz#5857c7b7b9f20dbccbfd88730fffa5963b3c61ee"
-  integrity sha512-8TUgIIUVpXWOcqq9RdmTSHUrhc3a/s+saKv9cCl8TYWHK9vyJIdea7ZaSKHGDthZNcsN+C3LulZYRL3Ah8ukoA==
-  dependencies:
-    "@apollographql/apollo-tools" "^0.2.6"
-
-graphql-extensions@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.4.1.tgz#92c49a8409ffbfb24559d7661ab60cc90d6086e4"
-  integrity sha512-Xei4rBxbsTHU6dYiq9y1xxbpRMU3+Os7yD3vXV5W4HbTaxRMizDmu6LAvV4oBEi0ttwICHARQjYTjDTDhHnxrQ==
+graphql-extensions@0.5.0-alpha.0:
+  version "0.5.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.5.0-alpha.0.tgz#978cb03f6af4637e355f1bf9cf8dfd11b9c25218"
+  integrity sha512-+U2qE7w8/VMinCZrg+wVQ78UAwnEXQtU2RlcxMW+MBg007YDLl3cu2IyLqMNP8/ADBZ5w84RqBrYT02/r2IfxA==
   dependencies:
     "@apollographql/apollo-tools" "^0.2.6"
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

This implements query parsing and validation caching, reference https://github.com/apollographql/apollo-server/pull/2111, and should thusly provide a nice speedup for our frontend's queries!

Since it's an alpha version, we should ship it to alpha.spectrum first, make sure nothing breaks and only then release to production and keep a close eye on the metrics too.