### PR TITLE
Add extra checks at send time for valid user recipient

### DIFF
--- a/hermes/send-email.js
+++ b/hermes/send-email.js
@@ -72,7 +72,7 @@ const sendEmail = async (options: Options): Promise<void> => {
     });
   }
 
-  if (!userCanReceiveEmail({ to, userId })) return Promise.resolve();
+  if (await !userCanReceiveEmail({ to, userId })) return Promise.resolve();
 
   return sg.send({
     ...defaultOptions,

--- a/hermes/send-email.js
+++ b/hermes/send-email.js
@@ -6,6 +6,7 @@ const debug = require('debug')('hermes:send-email');
 const stringify = require('json-stringify-pretty-compact');
 import { events } from 'shared/analytics';
 import { trackQueue } from 'shared/bull/queues';
+import { userCanReceiveEmail } from './user-can-receive-email';
 const { SENDGRID_API_KEY } = process.env;
 
 type ToType = {
@@ -32,7 +33,7 @@ const defaultOptions = {
   },
 };
 
-const sendEmail = (options: Options): Promise<void> => {
+const sendEmail = async (options: Options): Promise<void> => {
   let { templateId, to, dynamic_template_data, userId } = options;
 
   if (SENDGRID_API_KEY !== 'undefined') {
@@ -71,25 +72,7 @@ const sendEmail = (options: Options): Promise<void> => {
     });
   }
 
-  if (!to) {
-    if (userId) {
-      trackQueue.add({
-        userId: userId,
-        event: events.EMAIL_BOUNCED,
-        properties: { error: 'To field was not provided' },
-      });
-    }
-
-    return Promise.resolve();
-  }
-
-  // qq.com email addresses are isp blocked, which raises our error rate
-  // on sendgrid. prevent sending these emails at all
-  to = to.filter(toType => {
-    return toType.email.substr(to.length - 7) !== '@qq.com';
-  });
-
-  if (!to || to.length === 0) return Promise.resolve();
+  if (!userCanReceiveEmail({ to, userId })) return Promise.resolve();
 
   return sg.send({
     ...defaultOptions,

--- a/hermes/send-email.js
+++ b/hermes/send-email.js
@@ -9,7 +9,7 @@ import { trackQueue } from 'shared/bull/queues';
 import { userCanReceiveEmail } from './user-can-receive-email';
 const { SENDGRID_API_KEY } = process.env;
 
-type ToType = {
+export type ToType = {
   email: string,
   name?: string,
 };

--- a/hermes/user-can-receive-email.js
+++ b/hermes/user-can-receive-email.js
@@ -2,10 +2,11 @@
 import { getUserById } from 'shared/db/queries/user';
 import { events } from 'shared/analytics';
 import { trackQueue } from 'shared/bull/queues';
+import type { ToType } from './send-email';
 
 type Props = {
-  to: string,
-  userId: string,
+  to: Array<ToType>,
+  userId?: string,
 };
 
 export const userCanReceiveEmail = async ({ to, userId }: Props) => {
@@ -27,6 +28,7 @@ export const userCanReceiveEmail = async ({ to, userId }: Props) => {
     return toType.email.substr(to.length - 7) !== '@qq.com';
   });
 
+  if (!userId) return false;
   if (!to || to.length === 0) return false;
 
   const user = await getUserById(userId);

--- a/hermes/user-can-receive-email.js
+++ b/hermes/user-can-receive-email.js
@@ -1,0 +1,36 @@
+// @flow
+import { getUserById } from 'shared/db/queries/user';
+import { events } from 'shared/analytics';
+import { trackQueue } from 'shared/bull/queues';
+
+type Props = {
+  to: string,
+  userId: string,
+};
+
+export const userCanReceiveEmail = async ({ to, userId }: Props) => {
+  if (!to) {
+    if (userId) {
+      trackQueue.add({
+        userId: userId,
+        event: events.EMAIL_BOUNCED,
+        properties: { error: 'To field was not provided' },
+      });
+    }
+
+    return false;
+  }
+
+  // qq.com email addresses are isp blocked, which raises our error rate
+  // on sendgrid. prevent sending these emails at all
+  to = to.filter(toType => {
+    return toType.email.substr(to.length - 7) !== '@qq.com';
+  });
+
+  if (!to || to.length === 0) return false;
+
+  const user = await getUserById(userId);
+  if (!user || user.bannedAt || user.deletedAt || !user.email) return false;
+
+  return true;
+};


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hermes

Because emails are sent asynchronously via Hermes, it's possible for a user's record to get out of date between an email being triggered and the email being sent. This change ensures that at send-time the user is still existent, isn't banned, and has an email on file.