### PR TITLE
[HOTFIX] Remove draftjs block type validation in messages

### DIFF
--- a/api/mutations/message/addMessage.js
+++ b/api/mutations/message/addMessage.js
@@ -118,7 +118,20 @@ export default requireAuth(async (_: any, args: Input, ctx: GraphQLContext) => {
         'Please provide serialized raw DraftJS content state as content.body'
       );
     }
-    validateRawContentState(body);
+    if (!validateRawContentState(body)) {
+      trackQueue.add({
+        userId: user.id,
+        event: eventFailed,
+        properties: {
+          reason: 'invalid draftjs data',
+          message,
+        },
+      });
+
+      throw new UserError(
+        'Please provide serialized raw DraftJS content state as content.body'
+      );
+    }
   }
 
   if (message.parentId) {

--- a/api/mutations/message/editMessage.js
+++ b/api/mutations/message/editMessage.js
@@ -84,7 +84,20 @@ export default requireAuth(async (_: any, args: Args, ctx: GraphQLContext) => {
         'Please provide serialized raw DraftJS content state as content.body'
       );
     }
-    validateRawContentState(parsed);
+    if (!validateRawContentState(body)) {
+      trackQueue.add({
+        userId: user.id,
+        event: eventFailed,
+        properties: {
+          reason: 'invalid draftjs data',
+          message,
+        },
+      });
+
+      throw new UserError(
+        'Please provide serialized raw DraftJS content state as content.body'
+      );
+    }
   }
 
   if (body === message.content.body) {

--- a/api/utils/validate-draft-js-input.js
+++ b/api/utils/validate-draft-js-input.js
@@ -1,0 +1,18 @@
+export const validateRawContentState = (input: any) => {
+  if (!input.blocks || !Array.isArray(input.blocks) || !input.entityMap) {
+    trackQueue.add({
+      userId: user.id,
+      event: eventFailed,
+      properties: {
+        reason: 'invalid draftjs data',
+        message,
+      },
+    });
+
+    throw new UserError(
+      'Please provide serialized raw DraftJS content state as content.body'
+    );
+  }
+
+  return input;
+};

--- a/api/utils/validate-draft-js-input.js
+++ b/api/utils/validate-draft-js-input.js
@@ -1,19 +1,13 @@
 // @flow
 export const validateRawContentState = (input: any) => {
-  if (!input || !input.blocks || !Array.isArray(input.blocks) || !input.entityMap) {
-    trackQueue.add({
-      userId: user.id,
-      event: eventFailed,
-      properties: {
-        reason: 'invalid draftjs data',
-        message,
-      },
-    });
-
-    throw new UserError(
-      'Please provide serialized raw DraftJS content state as content.body'
-    );
+  if (
+    !input ||
+    !input.blocks ||
+    !Array.isArray(input.blocks) ||
+    !input.entityMap
+  ) {
+    return false;
   }
 
-  return input;
+  return true;
 };

--- a/api/utils/validate-draft-js-input.js
+++ b/api/utils/validate-draft-js-input.js
@@ -1,5 +1,6 @@
+// @flow
 export const validateRawContentState = (input: any) => {
-  if (!input.blocks || !Array.isArray(input.blocks) || !input.entityMap) {
+  if (!input || !input.blocks || !Array.isArray(input.blocks) || !input.entityMap) {
     trackQueue.add({
       userId: user.id,
       event: eventFailed,


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

This is confusing now that we have the plaintext input, and doesn't add anything as invalid blocks are treated as text blocks anyway on the frontend.

Going to hotfix ship this as it's breaking some users