### PR TITLE
Hotfix Android thread creation

### DIFF
--- a/api/mutations/thread/publishThread.js
+++ b/api/mutations/thread/publishThread.js
@@ -1,6 +1,7 @@
 // @flow
 const debug = require('debug')('api:mutations:thread:publish-thread');
 import stringSimilarity from 'string-similarity';
+import { convertToRaw } from 'draft-js';
 import { stateFromMarkdown } from 'draft-js-import-markdown';
 import type { GraphQLContext } from '../../';
 import UserError from '../../utils/UserError';
@@ -71,11 +72,13 @@ export default requireAuth(
       type = 'DRAFTJS';
       if (thread.content.body) {
         thread.content.body = JSON.stringify(
-          stateFromMarkdown(thread.content.body, {
-            parserOptions: {
-              breaks: true,
-            },
-          })
+          convertToRaw(
+            stateFromMarkdown(thread.content.body, {
+              parserOptions: {
+                breaks: true,
+              },
+            })
+          )
         );
       }
     }


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

I messed this up when I switched to the new markdown => DraftJS conversion library, I forgot to update this usage properly. That means any threads submitted from Android since we deployed the plaintext chat input are broken and crash the client.

Hotfix deploying this to prod, then I will dive into figuring out what to do about the broken threads in the db.

Closes #4570