### PR TITLE
Fix login redirects

### DIFF
--- a/api/utils/is-spectrum-url.js
+++ b/api/utils/is-spectrum-url.js
@@ -16,7 +16,8 @@ export default (url: string): boolean => {
     const { hostname, protocol } = new URL(url);
     // hostname might be spectrum.chat or subdomain.spectrum.chat, so we use .endsWith
     // We don't just check .contains because otherwise folks could make spectrum.chat.mydomain.com
-    const IS_SPECTRUM_URL = hostname.endsWith('.spectrum.chat');
+    const IS_SPECTRUM_URL =
+      hostname === 'spectrum.chat' || hostname === 'alpha.spectrum.chat';
     const IS_LOCALHOST = hostname === 'localhost';
     const IS_HTTP = protocol === 'https:' || protocol === 'http:';
     // Make sure the passed redirect URL is a spectrum.chat one or (in development) localhost


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

@mxstbr this closes #4571 

The reason we initially did `.endsWith('spectrum.chat')` was to ensure logins came from our app. Before joining GitHub we changed this to `.endsWith('.spectrum.chat')` to prevent any malicious auth requests from from something like `hackerdomainspectrum.chat`

Unfortunately this broke redirects from community views. The problem is that we switched to getting the `hostname` from `new URL(url)` which will only ever return a hostname like `spectrum.chat` or `alpha.spectrum.chat`, therefore the `endsWith` was always missing the first period, and `isSpectrumUrl` returned false every time.

The fix here is to just not use `endsWith` at all - it's unnecessary since `new URL` will return the correct hostname from any given url. So we can just match that to prod or alpha and return true.

Can you give this a second eye and make sure there's no security implications here? I've deployed this to alpha and confirmed that it fixes login redirects.