### PR TITLE
Properly transform author username suggestion

### DIFF
--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -309,9 +309,19 @@ const ChatInput = (props: Props) => {
     return aNameIndex - bNameIndex || aUsernameIndex - bUsernameIndex;
   };
 
+  const cleanSuggestionUserObject = user => {
+    return {
+      ...user,
+      id: user.username,
+      display: user.username,
+      filterName: user.name.toLowerCase(),
+    };
+  };
+
   const searchUsers = async (queryString, callback) => {
     const filteredParticipants = props.participants
       ? props.participants
+          .map(cleanSuggestionUserObject)
           .filter(Boolean)
           .filter(participant => {
             return (
@@ -352,13 +362,7 @@ const ChatInput = (props: Props) => {
       .filter(edge => edge.node.username)
       .map(edge => {
         const user = edge.node;
-        return {
-          ...user,
-          id: user.username,
-          display: user.username,
-          username: user.username,
-          filterName: user.name.toLowerCase(),
-        };
+        return cleanSuggestionUserObject(user);
       });
 
     // Prepend the filtered participants in case a user is tabbing down right now

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -93,7 +93,8 @@ type Props = {
   onBlur: ?Function,
 };
 
-export const cleanSuggestionUserObject = user => {
+export const cleanSuggestionUserObject = (user: ?Object) => {
+  if (!user) return null;
   return {
     ...user,
     id: user.username,

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -93,6 +93,15 @@ type Props = {
   onBlur: ?Function,
 };
 
+export const cleanSuggestionUserObject = user => {
+  return {
+    ...user,
+    id: user.username,
+    display: user.username,
+    filterName: user.name.toLowerCase(),
+  };
+};
+
 // $FlowFixMe
 const ChatInput = (props: Props) => {
   const cacheKey = `last-content-${props.thread}`;
@@ -307,15 +316,6 @@ const ChatInput = (props: Props) => {
     if (aNameIndex === 0) return -1;
     if (aUsernameIndex === 0) return -1;
     return aNameIndex - bNameIndex || aUsernameIndex - bUsernameIndex;
-  };
-
-  const cleanSuggestionUserObject = user => {
-    return {
-      ...user,
-      id: user.username,
-      display: user.username,
-      filterName: user.name.toLowerCase(),
-    };
   };
 
   const searchUsers = async (queryString, callback) => {

--- a/src/views/directMessages/containers/existingThread.js
+++ b/src/views/directMessages/containers/existingThread.js
@@ -112,7 +112,7 @@ class ExistingThread extends React.Component<Props> {
         const thread = data.directMessageThread;
         const mentionSuggestions = thread.participants
           .map(cleanSuggestionUserObject)
-          .filter(user => user.username !== currentUser.username);
+          .filter(user => user && user.username !== currentUser.username);
         return (
           <MessagesContainer>
             <ViewContent

--- a/src/views/directMessages/containers/existingThread.js
+++ b/src/views/directMessages/containers/existingThread.js
@@ -6,7 +6,7 @@ import { withApollo } from 'react-apollo';
 import setLastSeenMutation from 'shared/graphql/mutations/directMessageThread/setDMThreadLastSeen';
 import Messages from '../components/messages';
 import Header from '../components/header';
-import ChatInput from 'src/components/chatInput';
+import ChatInput, { cleanSuggestionUserObject } from 'src/components/chatInput';
 import viewNetworkHandler from 'src/components/viewNetworkHandler';
 import getDirectMessageThread, {
   type GetDirectMessageThreadType,
@@ -111,11 +111,7 @@ class ExistingThread extends React.Component<Props> {
       if (data.directMessageThread) {
         const thread = data.directMessageThread;
         const mentionSuggestions = thread.participants
-          .map(user => ({
-            ...user,
-            id: user.username,
-            display: user.username,
-          }))
+          .map(cleanSuggestionUserObject)
           .filter(user => user.username !== currentUser.username);
         return (
           <MessagesContainer>

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -405,7 +405,12 @@ class ThreadContainer extends React.Component<Props, State> {
     if (!messageConnection || messageConnection.edges.length === 0)
       return this.setState({
         participants: [
-          { ...author.user, filterName: author.user.name.toLowerCase() },
+          {
+            ...author.user,
+            id: author.user.username,
+            display: author.user.username,
+            filterName: author.user.name.toLowerCase(),
+          },
         ],
       });
 

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -404,28 +404,16 @@ class ThreadContainer extends React.Component<Props, State> {
 
     if (!messageConnection || messageConnection.edges.length === 0)
       return this.setState({
-        participants: [
-          {
-            ...author.user,
-            id: author.user.username,
-            display: author.user.username,
-            filterName: author.user.name.toLowerCase(),
-          },
-        ],
+        participants: [author.user],
       });
 
     const participants = messageConnection.edges
       .map(edge => edge.node)
       .map(node => node.author.user);
 
-    const participantsWithAuthor = [...participants, author.user]
-      .filter((user, index, array) => array.indexOf(user) === index)
-      .map(user => ({
-        ...user,
-        id: user.username,
-        display: user.username,
-        filterName: user.name.toLowerCase(),
-      }));
+    const participantsWithAuthor = [...participants, author.user].filter(
+      (user, index, array) => array.indexOf(user) === index
+    );
 
     return this.setState({ participants: participantsWithAuthor });
   };


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Last small bug with @ mention suggestions that I found:
- if you were trying to @ mention the author of a post when no messages existed in the thread, we weren't properly transforming the author's user object so it would insert the person's `id` instead of `username` into the chat input. This PR fixes that bug and also refactors the suggestion transformation to single function, rather than having transformations happen across multiple files.