### PR TITLE
Update draft-js-export-markdown to fix escaped code chars

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "draft-js-code-editor-plugin": "0.2.1",
     "draft-js-drag-n-drop-plugin": "^2.0.3",
     "draft-js-embed-plugin": "^1.2.0",
-    "draft-js-export-markdown": "^1.2.2",
+    "draft-js-export-markdown": "^1.3.0",
     "draft-js-focus-plugin": "^2.2.0",
     "draft-js-image-plugin": "^2.0.6",
     "draft-js-import-markdown": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5395,10 +5395,10 @@ draft-js-embed-plugin@^1.2.0:
   dependencies:
     decorate-component-with-props "^1.0.2"
 
-draft-js-export-markdown@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/draft-js-export-markdown/-/draft-js-export-markdown-1.2.2.tgz#1fc65f0b786f2e3107db44be300beb97fab9e231"
-  integrity sha512-lQ74NRWHy+oeG4eEjQBHlKrJtYtlLYCfFdCQDbDX80YvhuRtUwiWey6LMDN/uDc4FttCYM//fVS3c8oTMmn+6g==
+draft-js-export-markdown@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/draft-js-export-markdown/-/draft-js-export-markdown-1.3.0.tgz#e7f0d7aabc1f787c24e1c6dc524b681463aae8c8"
+  integrity sha512-kOiDGQ9KehcbYYcwzlkR+Gja6svEwIgId1gz3EtEVsZ09cxZaV13Qlkydm0J5wPy5Omthvdpj0Iw1B2E4BZRZQ==
   dependencies:
     draft-js-utils "^1.2.0"
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

Fixes bug where characters like underscores would be escaped and insert backslashes into messages when edited.