### PR TITLE
Edit latest message when pressing arrow up

### DIFF
--- a/src/actions/message.js
+++ b/src/actions/message.js
@@ -13,4 +13,17 @@ export const replyToMessage = (input: ReplyInput) => {
   };
 };
 
+export const editMessage = (id: string) => {
+  return {
+    type: 'EDIT_MESSAGE',
+    messageId: id,
+  };
+};
+
+export const cancelMessageEdit = (id: string) => {
+  return {
+    type: 'EDIT_MESSAGE_CANCEL',
+  };
+};
+
 export type ReplyToMessageActionType = $Call<typeof replyToMessage, ReplyInput>;

--- a/src/components/chatInput/index.js
+++ b/src/components/chatInput/index.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import Icon from 'src/components/icons';
 import { addToastWithTimeout } from 'src/actions/toasts';
 import { openModal } from 'src/actions/modals';
-import { replyToMessage } from 'src/actions/message';
+import { replyToMessage, editMessage } from 'src/actions/message';
 import { withCurrentUser } from 'src/components/withCurrentUser';
 import {
   Form,
@@ -142,6 +142,12 @@ const ChatInput = (props: Props) => {
       // If backspace is pressed on the empty
       case 'Backspace': {
         if (text.length === 0) removeAttachments();
+        return;
+      }
+      case 'ArrowUp': {
+        if (text.length === 0) {
+          props.dispatch(editMessage('latest'));
+        }
         return;
       }
     }

--- a/src/components/message/editingBody.js
+++ b/src/components/message/editingBody.js
@@ -11,6 +11,7 @@ import { addToastWithTimeout } from 'src/actions/toasts';
 import compose from 'recompose/compose';
 import { connect } from 'react-redux';
 import editMessageMutation from 'shared/graphql/mutations/message/editMessage';
+import { cancelMessageEdit } from '../../actions/message';
 
 type Props = {
   message: MessageInfoType,

--- a/src/components/message/index.js
+++ b/src/components/message/index.js
@@ -165,7 +165,6 @@ class Message extends React.Component<Props> {
       thread,
     } = this.props;
     const isEditing = this.props.editingMessage === this.props.message.id;
-    console.log(this.props.editingMessage);
 
     const canEditMessage = me && message.messageType !== 'media';
     const selectedMessageId = btoa(new Date(message.timestamp).getTime() - 1);

--- a/src/reducers/message.js
+++ b/src/reducers/message.js
@@ -3,6 +3,7 @@ import type { ReplyToMessageActionType } from '../actions/message';
 
 const initialState = {
   quotedMessage: {},
+  editingMessage: null,
 };
 
 type Actions = ReplyToMessageActionType;
@@ -19,6 +20,18 @@ export default function message(
           [action.threadId]: action.messageId,
         },
       };
+    case 'EDIT_MESSAGE': {
+      return {
+        ...state,
+        editingMessage: action.messageId,
+      };
+    }
+    case 'EDIT_MESSAGE_CANCEL': {
+      return {
+        ...state,
+        editingMessage: null,
+      };
+    }
     default:
       return state;
   }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -18,6 +18,7 @@ export const initStore = (initialState?: Object) => {
   let store = createStore(
     getReducers(),
     initialState || {},
+    // $FlowIssue
     composeEnhancers(applyMiddleware(thunkMiddleware, crashReporter))
   );
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Closes #3512

- **Step 1: I moved the state of the currently being edited message ID to Redux.** This allows us to trigger a message edit from anywhere in the app, which we need to do in the chat input when the user presses "Arrow Up".
- **Step 2: We select the latest message when pressing Arrow Up in the chat input.** Unfortunately, in the chat input we do not know anything about messages, so we cannot select the latest one. To work around that I added a special key, `"latest"`, that the `messageGroup` component knows about. If `editMessage('latest')` is called, the messageGroup gets the latest message sent by the current user and calls `editMessage` again with the ID of the last message, thereby selecting it and starting the editing process.

Admittedly, this is a bit hacky and convoluted. It works fine, but I wish there was a better way to do this. Maybe we should pass down the latest message ID to the chat input from the thread components instead? 