### PR TITLE
Break words while editing messages on mobile

### DIFF
--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -432,6 +432,8 @@ export const EditorInput = styled(EditorWrapper)`
   transition: border 0.3s ease-out;
   color: ${props => props.theme.text.secondary};
   background: ${props => props.theme.bg.default};
+  max-width: 100%;
+  word-break: break-all;
 
   @media (max-width: 768px) {
     font-size: 16px;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Closes #4620 - we have to break words if people type in a long string like a url