### PR TITLE
fix composer z-index bug safari

### DIFF
--- a/src/components/composer/style.js
+++ b/src/components/composer/style.js
@@ -226,6 +226,7 @@ export const OptionalSelector = styled(Selector)`
 `;
 
 export const ThreadInputs = styled(FlexCol)`
+  position: relative;
   grid-area: body;
   overflow-y: scroll;
   padding: 32px;


### PR DESCRIPTION

**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Closes ##4636

the ThreadInputs component needs to be "positioned" for the z-index to work correctly in safari..

