### PR TITLE
Rework automatic embeds to operate on raw content state

### DIFF
--- a/shared/draft-utils/add-embeds-to-draft-js.js
+++ b/shared/draft-utils/add-embeds-to-draft-js.js
@@ -1,12 +1,6 @@
 // @flow
-import {
-  EditorState,
-  Entity,
-  AtomicBlockUtils,
-  ContentState,
-  convertToRaw,
-  SelectionState,
-} from 'draft-js';
+import genKey from 'draft-js/lib/generateRandomKey';
+import type { RawDraftContentState } from 'draft-js/lib/RawDraftContentState.js';
 
 const FIGMA_URLS = /\b((?:https?\/\/)?(?:www\.)?figma.com\/(file|proto)\/([0-9a-zA-Z]{22,128})(?:\/.*)?)/gi;
 const YOUTUBE_URLS = /\b(?:\/\/)?(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)([\w\-\_]*)(&(amp;)?[\w\?=]*)?/gi;
@@ -24,68 +18,71 @@ type AddEmbedAttrs = {
 };
 
 export const addEmbedsToEditorState = (
-  editorState: typeof EditorState
-): typeof EditorState => {
-  const raw = convertToRaw(editorState.getCurrentContent());
-  let newEditorState = editorState;
-  raw.blocks.forEach(block => {
+  input: RawDraftContentState
+): RawDraftContentState => {
+  let lastEntityKey = Math.min(...Object.keys(input.entityMap));
+  if (lastEntityKey === Infinity) lastEntityKey = -1;
+  let newEntityMap = input.entityMap || {};
+  let newBlocks = [];
+
+  // Detect the embeds and add an atomic block and an entity to the
+  // raw content state for each one
+  input.blocks.forEach((block, index) => {
+    newBlocks.push(block);
+
     if (block.type !== 'unstyled') return;
+
     const embeds = getEmbedsFromText(block.text);
-    if (embeds.length > 0) {
-      embeds.forEach(embed => {
-        const selection = SelectionState.createEmpty(block.key);
-        newEditorState = addEmbedToEditorState(newEditorState, embed);
+    if (!embeds.length === 0) return;
+
+    embeds.forEach(embed => {
+      lastEntityKey++;
+      const entityKey = lastEntityKey;
+      newBlocks.push({
+        type: 'atomic',
+        data: {},
+        text: ' ',
+        depth: 0,
+        // TODO
+        entityRanges: [
+          {
+            offset: 0,
+            length: 1,
+            key: entityKey,
+          },
+        ],
+        inlineStyleRanges: [],
+        key: genKey(),
+      });
+      newEntityMap[entityKey] = {
+        data: {
+          ...embed,
+          src: embed.url,
+        },
+        mutability: 'MUTABLE',
+        type: 'embed',
+      };
+    });
+    // If this is the last block we need to add an empty block below the atomic block,
+    // otherwise users cannot remove the embed during editing
+    if (index === input.blocks.length - 1) {
+      newBlocks.push({
+        type: 'unstyled',
+        data: {},
+        text: ' ',
+        depth: 0,
+        entityRanges: [],
+        inlineStyleRanges: [],
+        key: genKey(),
       });
     }
   });
-  return newEditorState;
-};
 
-// Taken from https://github.com/vacenz/last-draft-js-plugins/blob/master/draft-js-embed-plugin/src/modifiers/addEmbed.js
-// adapted to pass additional attrs onto the iframe
-export const addEmbedToEditorState = (
-  editorState: typeof EditorState,
-  attrs: AddEmbedAttrs
-) => {
-  const urlType = 'embed';
-  const entityKey = Entity.create(urlType, 'IMMUTABLE', {
-    src: (attrs && attrs.url) || null,
-    aspectRatio: attrs && attrs.aspectRatio,
-    width: attrs && attrs.width,
-    height: attrs && attrs.height,
-  });
-  const newEditorState = AtomicBlockUtils.insertAtomicBlock(
-    editorState,
-    entityKey,
-    ' '
-  );
-  // insertAtomicBlock inserts _before_ the current block, which is not what we want,
-  // so we have to manually move the new atomic block one further down
-  const content = newEditorState.getCurrentContent();
-  let newBlocks = [];
-  let moveNext;
-  content.getBlocksAsArray().forEach(block => {
-    if (!moveNext) {
-      newBlocks.push(block);
-    } else {
-      newBlocks = [
-        ...newBlocks.slice(0, newBlocks.length - 2),
-        block,
-        ...newBlocks.slice(newBlocks.length - 2),
-      ];
-    }
-    if (block.type === 'atomic' && block.getEntityAt(0) === entityKey) {
-      // move the automatically added empty block above the atomic block below the atomic block
-      newBlocks = [
-        ...newBlocks.slice(0, newBlocks.length - 2),
-        newBlocks[newBlocks.length - 1],
-        newBlocks[newBlocks.length - 2],
-      ];
-      moveNext = true;
-    }
-  });
-  const newContent = ContentState.createFromBlockArray(newBlocks);
-  return EditorState.push(newEditorState, newContent, 'insert-characters');
+  return {
+    ...input,
+    entityMap: newEntityMap,
+    blocks: newBlocks,
+  };
 };
 
 // Utility function to return the first capturing group of each unique match

--- a/shared/draft-utils/process-thread-content.js
+++ b/shared/draft-utils/process-thread-content.js
@@ -43,11 +43,7 @@ export default (type: 'TEXT' | 'DRAFTJS', body: string): string => {
 
   // Add automatic embeds to body
   try {
-    const editorState = EditorState.createWithContent(
-      convertFromRaw(JSON.parse(newBody))
-    );
-    const newEditorState = addEmbedsToEditorState(editorState);
-    return JSON.stringify(convertToRaw(newEditorState.getCurrentContent()));
+    return JSON.stringify(addEmbedsToEditorState(JSON.parse(newBody)));
     // Ignore errors during automatic embed detection
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
- Fixes #4630, automatic embeds are now correctly inserted right below the paragraph with the links!
- Related to #4629 as it removes another instance where we used DraftJS—now we only operate on the raw data structure!

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->