### PR TITLE
Do not call `markSingleNotificationSeen` for all client-side notifications

### DIFF
--- a/src/views/navbar/components/notificationsTab.js
+++ b/src/views/navbar/components/notificationsTab.js
@@ -236,16 +236,16 @@ class NotificationsTab extends React.Component<Props, State> {
     const newNotifications =
       notifications &&
       notifications.map(n => Object.assign({}, n, { isSeen: true }));
-    this.processAndMarkSeenNotifications(newNotifications);
+    this.processAndMarkSeenNotifications(newNotifications, false);
     // otherwise
     return markAllNotificationsSeen().catch(err => {
       console.error(err);
       // Undo the optimistic update from above
-      this.processAndMarkSeenNotifications(oldNotifications);
+      this.processAndMarkSeenNotifications(oldNotifications, false);
     });
   };
 
-  processAndMarkSeenNotifications = stateNotifications => {
+  processAndMarkSeenNotifications = (stateNotifications, sync = true) => {
     const {
       data: { notifications },
       location,
@@ -321,12 +321,15 @@ class NotificationsTab extends React.Component<Props, State> {
         });
 
         // and then mark it as seen on the server
-        client.mutate({
-          mutation: markSingleNotificationSeenMutation,
-          variables: {
-            id: n.id,
-          },
-        });
+        console.log('SYNC!');
+        if (sync) {
+          client.mutate({
+            mutation: markSingleNotificationSeenMutation,
+            variables: {
+              id: n.id,
+            },
+          });
+        }
 
         return newNotification;
       } else {

--- a/src/views/navbar/components/notificationsTab.js
+++ b/src/views/navbar/components/notificationsTab.js
@@ -321,7 +321,6 @@ class NotificationsTab extends React.Component<Props, State> {
         });
 
         // and then mark it as seen on the server
-        console.log('SYNC!');
         if (sync) {
           client.mutate({
             mutation: markSingleNotificationSeenMutation,


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

As you can see in the diff, we were calling the `markSingleNotificationSeen` mutation from the client for all notifications when clicking "Mark all as seen", even though we also call the `markAllAsSeen` mutation.

This results in a lot of unnecessary work and huge spikes in response times.

This fixes it by not unnecessarily calling `markSingleNotificationSeen`.



<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->