### PR TITLE
Do not sign already signed images

### DIFF
--- a/shared/imgix/sign.js
+++ b/shared/imgix/sign.js
@@ -1,8 +1,8 @@
 // @flow
 require('now-env');
 import ImgixClient from 'imgix-core-js';
-import decodeUriComponent from 'decode-uri-component';
 import { getDefaultExpires } from './getDefaultExpires';
+import parse from 'url';
 
 const IS_PROD = process.env.NODE_ENV === 'production';
 export const LEGACY_PREFIX = 'https://spectrum.imgix.net/';
@@ -13,6 +13,7 @@ const isLocalUpload = (url: string): boolean => url.startsWith('/uploads/', 0) &
 export const hasLegacyPrefix = (url: string): boolean => url.startsWith(LEGACY_PREFIX, 0)
 // prettier-ignore
 const useProxy = (url: string): boolean => url.indexOf('spectrum.imgix.net') < 0 && url.startsWith('http', 0)
+const isSigned = (url: string) => parse(url).hostname === 'spectrum.imgix.net';
 
 /*
   When an image is uploaded to s3, we generate a url to be stored in our db
@@ -52,6 +53,7 @@ const signProxy = (url: string, opts?: Opts = defaultOpts): string => {
 
 export const signImageUrl = (url: string, opts: Opts = defaultOpts): string => {
   if (!url) return '';
+  if (isSigned(url)) return url;
   if (!opts.expires) {
     opts['expires'] = defaultOpts.expires;
   }


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- athena
- vulcan
- mercury
- hermes
- chronos
- analytics

**Related issues (delete if you don't know of any)**
Potentially closes #4667

@brianlovin you are more aware of the imgix stuff, could this solution break somehow? If so, the only other idea I have is to not sign images in `uploadImage`, would that work?

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->