### PR TITLE
Accessible login

### DIFF
--- a/src/components/fullscreenView/index.js
+++ b/src/components/fullscreenView/index.js
@@ -1,3 +1,4 @@
+// @flow
 import React, { Component } from 'react';
 import {
   ClusterOne,
@@ -6,9 +7,15 @@ import {
   ClusterFour,
 } from '../../components/illustrations';
 import Icon from '../../components/icons';
-import { FullscreenViewContainer, Illustrations, Close } from './style';
+import { FullscreenViewContainer, Illustrations, CloseLink } from './style';
 import { ESC } from 'src/helpers/keycodes';
-class FullscreenView extends Component {
+
+type Props = {
+  closePath: string,
+  children: any,
+};
+
+class FullscreenView extends Component<Props> {
   componentDidMount() {
     document.addEventListener('keydown', this.handleKeyPress, false);
   }
@@ -17,44 +24,29 @@ class FullscreenView extends Component {
     document.removeEventListener('keydown', this.handleKeyPress, false);
   }
 
-  handleKeyPress = e => {
-    const { close, noCloseButton } = this.props;
-
-    // if we don't want the user to close the onboarding flow - when they
-    // are setting a username - ignore esc key presses
-    if (noCloseButton) return;
-
+  handleKeyPress = (e: any) => {
+    const { closePath } = this.props;
     // if person taps esc, close the dialog
-    if (e.keyCode === ESC) {
-      return close();
+    if (closePath && e.keyCode === ESC) {
+      return (window.location = closePath);
     }
   };
 
   render() {
-    const {
-      close,
-      hasBackground,
-      children,
-      noCloseButton,
-      showBackgroundOnMobile = true,
-    } = this.props;
+    const { closePath, children } = this.props;
 
     return (
       <FullscreenViewContainer>
-        {!noCloseButton && (
-          <Close onClick={close}>
-            <Icon glyph={'view-close'} size={32} />
-          </Close>
-        )}
+        <CloseLink href={closePath}>
+          <Icon glyph={'view-close'} size={32} />
+        </CloseLink>
 
-        {hasBackground && (
-          <Illustrations showBackgroundOnMobile={showBackgroundOnMobile}>
-            <ClusterOne src="/img/cluster-2.svg" role="presentation" />
-            <ClusterTwo src="/img/cluster-1.svg" role="presentation" />
-            <ClusterThree src="/img/cluster-5.svg" role="presentation" />
-            <ClusterFour src="/img/cluster-4.svg" role="presentation" />
-          </Illustrations>
-        )}
+        <Illustrations>
+          <ClusterOne src="/img/cluster-2.svg" role="presentation" />
+          <ClusterTwo src="/img/cluster-1.svg" role="presentation" />
+          <ClusterThree src="/img/cluster-5.svg" role="presentation" />
+          <ClusterFour src="/img/cluster-4.svg" role="presentation" />
+        </Illustrations>
 
         {children}
       </FullscreenViewContainer>

--- a/src/components/fullscreenView/style.js
+++ b/src/components/fullscreenView/style.js
@@ -24,16 +24,12 @@ export const FullscreenViewContainer = styled.div`
 export const Illustrations = styled.span`
   z-index: ${zIndex.background};
 
-  ${p =>
-    !p.showBackgroundOnMobile &&
-    css`
-      @media screen and (max-width: 768px) {
-        display: none;
-      }
-    `};
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
 `;
 
-export const Close = styled.div`
+export const CloseLink = styled.a`
   color: ${theme.text.default};
   position: absolute;
   top: 8px;

--- a/src/components/upsell/index.js
+++ b/src/components/upsell/index.js
@@ -92,7 +92,7 @@ export const UpsellMiniCreateCommunity = () => {
 // to create a community rather than joining communities - if they choose
 // to go down the path of creating a community, clicking on the 'get started'
 // button will close the new user onboarding
-export const UpsellCreateCommunity = ({ close }: { close: Function }) => {
+export const UpsellCreateCommunity = () => {
   const title = 'Create a community';
   const subtitle = 'Building communities on Spectrum is easy and free forever';
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -32,6 +32,7 @@ import { withCurrentUser } from 'src/components/withCurrentUser';
 import Maintenance from 'src/components/maintenance';
 import type { GetUserType } from 'shared/graphql/queries/user/getUser';
 import RedirectOldThreadRoute from './views/thread/redirect-old-route';
+import NewUserOnboarding from './views/newUserOnboarding';
 
 /* prettier-ignore */
 const Explore = Loadable({
@@ -267,6 +268,8 @@ class Routes extends React.Component<Props> {
                       <Redirect
                         to={`/users/${currentUser.username}/settings`}
                       />
+                    ) : currentUser && !currentUser.username ? (
+                      <NewUserOnboarding />
                     ) : isLoadingCurrentUser ? null : (
                       <Login redirectPath={`${CLIENT_URL}/me/settings`} />
                     )

--- a/src/views/communityLogin/index.js
+++ b/src/views/communityLogin/index.js
@@ -68,7 +68,7 @@ export class Login extends React.Component<Props> {
       const { brandedLogin } = community;
 
       return (
-        <FullscreenView hasBackground noCloseButton={true} close={null}>
+        <FullscreenView closePath={`${CLIENT_URL}`}>
           <FullscreenContent
             data-cy="community-login-page"
             style={{ justifyContent: 'center' }}
@@ -117,14 +117,14 @@ export class Login extends React.Component<Props> {
 
     if (isLoading) {
       return (
-        <FullscreenView>
+        <FullscreenView closePath={CLIENT_URL}>
           <Loading />
         </FullscreenView>
       );
     }
 
     return (
-      <FullscreenView close={this.escape}>
+      <FullscreenView closePath={CLIENT_URL}>
         <ViewError
           refresh
           heading={'We had trouble finding this community'}

--- a/src/views/dashboard/index.js
+++ b/src/views/dashboard/index.js
@@ -112,13 +112,7 @@ class Dashboard extends React.Component<Props, State> {
     if (user) {
       // if the user hasn't joined any communities yet, we have nothing to show them on the dashboard. So instead just render the onboarding step to upsell popular communities to join
       if (user.communityConnection.edges.length === 0) {
-        return (
-          <NewUserOnboarding
-            noCloseButton
-            close={() => {}}
-            currentUser={user}
-          />
-        );
+        return <NewUserOnboarding currentUser={user} />;
       }
 
       // at this point we have succesfully validated a user, and the user has both a username and joined communities - we can show their thread feed!

--- a/src/views/login/index.js
+++ b/src/views/login/index.js
@@ -15,6 +15,7 @@ import {
 } from './style';
 import queryString from 'query-string';
 import { track, events } from 'src/helpers/analytics';
+import { CLIENT_URL } from 'src/api/constants';
 
 type Props = {
   redirectPath: ?string,
@@ -46,12 +47,7 @@ export class Login extends React.Component<Props> {
         : 'Spectrum is a place where communities can share, discuss, and grow together. Sign in below to get in on the conversation.';
 
     return (
-      <FullscreenView
-        hasBackground
-        // $FlowFixMe
-        noCloseButton={!this.props.close}
-        close={this.props.close && this.props.close}
-      >
+      <FullscreenView closePath={CLIENT_URL}>
         <FullscreenContent
           data-cy="login-page"
           style={{ justifyContent: 'center' }}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This PR reduces a lot of confusing props and logic in fullscreen views. Basically a fullscreen override requires a `closePath` prop now, which will be triggered on-click or if the user presses escape. For all the user onboarding steps, the `closePath` is the logout path. This will prevent people getting stuck on the "create username" step of the flow with no way to get out or sign in with a different account. For all other views, the `closePath` is just the `CLIENT_URL`, aka take me home.

Closes #4676 