### PR TITLE
Fix presigned images in thread body

### DIFF
--- a/shared/imgix/signThread.js
+++ b/shared/imgix/signThread.js
@@ -39,7 +39,9 @@ const signBody = (body?: string, expires?: number): string => {
     // we need to remove all query params from the src, then re-sign in order to avoid duplicate signatures
     // or sending down a url with an expired signature
     if (imageUrlStoredAsSigned) {
-      const sanitized = decodeURIComponent(url.parse(src).pathname);
+      const pathname = url.parse(src).pathname;
+      // always attempt to use the parsed pathname, but fall back to the original src
+      const sanitized = decodeURIComponent(pathname || src);
       returnBody.entityMap[key].data.src = signImageUrl(sanitized, { expires });
     } else {
       returnBody.entityMap[key].data.src = signImageUrl(src, { expires });


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

@mxstbr this is a stopgap fix for #4667 - we should ship this anyways. It follows your advice of just handling the fix at the query layer. We detect if we stored an imgix url in the thread body, strip the query params, and re-sign it. I confirmed that this works locally.

A followup PR I can work on tomorrow if you approve this is to implement the rest of the steps in #4667 to make sure we don't store signed images in the db during publish or edit.