### PR TITLE
Improve db connection count tracking

### DIFF
--- a/shared/db/db.js
+++ b/shared/db/db.js
@@ -59,9 +59,9 @@ poolMaster.on('queueing', size => {
   statsd.gauge('db.query_queue.size', size);
 });
 
-poolMaster.on('size', size => {
-  statsd.gauge('db.connections.count', size);
-});
+setInterval(() => {
+  statsd.gauge('db.connections.count', poolMaster.getLength());
+}, 5000);
 
 // Exit the process on unhealthy db in test env
 if (process.env.TEST_DB) {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)
- athena
- vulcan
- mercury
- hermes
- chronos
- analytics

The previous version with events literally only fired on startup of instances and then never again, making it not useful for showing neat graphs.

This fixes it by sending the current count every 5s, no matter if it changes or not, which is how DataDog expects it to be.