### PR TITLE
fix: popper menu can't be hide on iOS safari & remove gray backgroud when click

### DIFF
--- a/src/components/outsideClickHandler/index.js
+++ b/src/components/outsideClickHandler/index.js
@@ -10,14 +10,19 @@ type Props = {
 class OutsideAlerter extends React.Component<Props> {
   wrapperRef: React.Node;
 
+  // iOS bug, see: https://stackoverflow.com/questions/10165141/jquery-on-and-delegate-doesnt-work-on-ipad
   componentDidMount() {
     // $FlowFixMe
-    document.addEventListener('mousedown', this.handleClickOutside);
+    document
+      .getElementById('root')
+      .addEventListener('mousedown', this.handleClickOutside);
   }
 
   componentWillUnmount() {
     // $FlowFixMe
-    document.removeEventListener('mousedown', this.handleClickOutside);
+    document
+      .getElementById('root')
+      .removeEventListener('mousedown', this.handleClickOutside);
   }
 
   setWrapperRef = (node: React.Node) => {

--- a/src/reset.css.js
+++ b/src/reset.css.js
@@ -30,6 +30,7 @@ injectGlobal`
     padding: 0;
     margin: 0;
     -webkit-font-smoothing: antialiased;
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
       sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
   }


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->

before: https://static.ucloud.cn/0a8e31accf6e44f3ab4c9c266b195619.mp4

after: https://static.ucloud.cn/64357148c6a942ee833453e3039be005.mp4