### PR TITLE
Fix missing close method in community create upsell

### DIFF
--- a/src/components/upsell/index.js
+++ b/src/components/upsell/index.js
@@ -102,7 +102,7 @@ export const UpsellCreateCommunity = () => {
       <Subtitle>{subtitle}</Subtitle>
       <Actions>
         <Link to="/new/community">
-          <Button onClick={close}>Get Started</Button>
+          <Button>Get Started</Button>
         </Link>
       </Actions>
     </NullCard>


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

I missed this in #4681 and noticed errors in hyperion.