### PR TITLE
Dont log server memory to datadog in dev mode

### DIFF
--- a/shared/statsd.js
+++ b/shared/statsd.js
@@ -107,4 +107,6 @@ function collectMemoryStats() {
 }
 
 // Report memory usage every second
-setInterval(collectMemoryStats, 1000);
+if (process.env.NODE_ENV === 'production') {
+  setInterval(collectMemoryStats, 1000);
+}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

Without this we log memory usage of locally running worker servers.