### PR TITLE
Dont use firstnamelastname on empty user profile thread feed

### DIFF
--- a/src/views/user/index.js
+++ b/src/views/user/index.js
@@ -147,9 +147,7 @@ class UserView extends React.Component<Props, State> {
         },
       });
 
-      const nullHeading = `${
-        user.firstName ? user.firstName : user.name
-      } hasn’t ${
+      const nullHeading = `${user.name} hasn’t ${
         selectedView === 'creator' ? 'created' : 'joined'
       } any conversations yet.`;
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Ref https://spectrum.chat/?t=331e064e-72c2-4143-adc3-bfa64bc5dce8
We shouldn't really ever use `firstName` or `lastName` anywhere in the frontend since people can't actually change it right now - it's just imported from an auth flow. I did a cursory check across all our servers for uses of these fields that could break, but I think this is the main one (the only other case being in the user onboarding where we use the fields to try and guess at a username suggestion)