### PR TITLE
feat: Add button to hide thread upsell

### DIFF
--- a/cypress/integration/thread/chat_input_spec.js
+++ b/cypress/integration/thread/chat_input_spec.js
@@ -34,10 +34,7 @@ describe('chat input', () => {
       cy.get('[data-cy="chat-input-send-button"]').should('not.be.visible');
       cy.get('[data-cy="chat-input-media-uploader"]').should('not.be.visible');
       cy.get('[data-cy="join-channel-login-upsell"]').should('be.visible');
-      cy.get('[data-cy="thread-join-channel-upsell-button"]').should(
-        'be.visible'
-      );
-      cy.get('[data-cy="thread-join-channel-upsell-button"]').click();
+      cy.get('[data-cy="join-channel-login-upsell"]').click();
       cy.get('[data-cy="login-modal"]').should('be.visible');
     });
   });

--- a/cypress/integration/thread_spec.js
+++ b/cypress/integration/thread_spec.js
@@ -53,10 +53,7 @@ describe('Thread View', () => {
       const newMessage = 'A new message!';
       cy.get('[data-cy="thread-view"]').should('be.visible');
       cy.get('[data-cy="join-channel-login-upsell"]').should('be.visible');
-      cy.get('[data-cy="thread-join-channel-upsell-button"]').should(
-        'be.visible'
-      );
-      cy.get('[data-cy="thread-join-channel-upsell-button"]').click();
+      cy.get('[data-cy="join-channel-login-upsell"]').click();
       cy.get('[data-cy="login-modal"]').should('be.visible');
     });
   });

--- a/src/components/buttons/index.js
+++ b/src/components/buttons/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Label,
+  StyledFloatingButton,
   StyledSolidButton,
   StyledTextButton,
   StyledIconButton,
@@ -53,14 +54,36 @@ export const Button = (props: ButtonProps) => (
     ) : (
       ''
     )}
-    {props.loading &&
-      !props.icon && (
-        <Spinner color="text.reverse" size={props.large ? '18' : '14'} />
-      )}
+    {props.loading && !props.icon && (
+      <Spinner color="text.reverse" size={props.large ? '18' : '14'} />
+    )}
     <Label loading={props.loading} hasIcon={props.icon}>
       {props.children}
     </Label>
   </StyledSolidButton>
+);
+
+export const FloatingButton = (props: ButtonProps) => (
+  <StyledFloatingButton
+    disabled={props.loading}
+    data-cy={props.dataCy}
+    {...props}
+  >
+    {props.icon ? (
+      props.loading ? (
+        <SpinnerContainer>
+          <Spinner color="text.reverse" size={props.large ? '18' : '14'} />
+        </SpinnerContainer>
+      ) : (
+        <Icon glyph={props.icon} />
+      )
+    ) : (
+      ''
+    )}
+    {props.loading && !props.icon && (
+      <Spinner color="text.reverse" size={props.large ? '18' : '14'} />
+    )}
+  </StyledFloatingButton>
 );
 
 export const OutlineButton = (props: ButtonProps) => (
@@ -80,10 +103,9 @@ export const OutlineButton = (props: ButtonProps) => (
     ) : (
       ''
     )}
-    {props.loading &&
-      !props.icon && (
-        <Spinner color="brand.alt" size={props.large ? '18' : '14'} />
-      )}
+    {props.loading && !props.icon && (
+      <Spinner color="brand.alt" size={props.large ? '18' : '14'} />
+    )}
     <Label loading={props.loading} hasIcon={props.icon}>
       {props.children}
     </Label>
@@ -108,10 +130,9 @@ export const FauxOutlineButton = (props: ButtonProps) => (
     ) : (
       ''
     )}
-    {props.loading &&
-      !props.icon && (
-        <Spinner color="brand.alt" size={props.large ? '18' : '14'} />
-      )}
+    {props.loading && !props.icon && (
+      <Spinner color="brand.alt" size={props.large ? '18' : '14'} />
+    )}
     <Label loading={props.loading} hasIcon={props.icon}>
       {props.children}
     </Label>
@@ -131,10 +152,9 @@ export const TextButton = (props: ButtonProps) => (
     ) : (
       ''
     )}
-    {props.loading &&
-      !props.icon && (
-        <Spinner color="text.alt" size={props.large ? '18' : '14'} />
-      )}
+    {props.loading && !props.icon && (
+      <Spinner color="text.alt" size={props.large ? '18' : '14'} />
+    )}
     <Label loading={props.loading} hasIcon={props.icon}>
       {props.children}
     </Label>

--- a/src/components/buttons/index.js
+++ b/src/components/buttons/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Label,
-  StyledFloatingButton,
   StyledSolidButton,
   StyledTextButton,
   StyledIconButton,
@@ -61,29 +60,6 @@ export const Button = (props: ButtonProps) => (
       {props.children}
     </Label>
   </StyledSolidButton>
-);
-
-export const FloatingButton = (props: ButtonProps) => (
-  <StyledFloatingButton
-    disabled={props.loading}
-    data-cy={props.dataCy}
-    {...props}
-  >
-    {props.icon ? (
-      props.loading ? (
-        <SpinnerContainer>
-          <Spinner color="text.reverse" size={props.large ? '18' : '14'} />
-        </SpinnerContainer>
-      ) : (
-        <Icon glyph={props.icon} />
-      )
-    ) : (
-      ''
-    )}
-    {props.loading && !props.icon && (
-      <Spinner color="text.reverse" size={props.large ? '18' : '14'} />
-    )}
-  </StyledFloatingButton>
 );
 
 export const OutlineButton = (props: ButtonProps) => (

--- a/src/components/buttons/style.js
+++ b/src/components/buttons/style.js
@@ -89,13 +89,6 @@ export const StyledSolidButton = styled.button`
   }
 `;
 
-export const StyledFloatingButton = styled(StyledSolidButton)`
-  position: absolute;
-  bottom: 16px;
-  right: 16px;
-  width: auto !important;
-`;
-
 export const StyledTextButton = styled(StyledSolidButton)`
   background: transparent;
   background-image: none;

--- a/src/components/buttons/style.js
+++ b/src/components/buttons/style.js
@@ -27,8 +27,8 @@ const baseButton = css`
         ? '8px 12px'
         : '4px 8px'
       : props.large
-        ? '16px 32px'
-        : '12px 16px'};
+      ? '16px 32px'
+      : '12px 16px'};
 
   &:hover {
     transition: ${Transition.hover.on};
@@ -65,11 +65,11 @@ export const StyledSolidButton = styled.button`
     props.disabled || props.gradientTheme === 'none'
       ? 'none'
       : props.gradientTheme
-        ? Gradient(
-            eval(`props.theme.${props.gradientTheme}.alt`),
-            eval(`props.theme.${props.gradientTheme}.default`)
-          )
-        : Gradient(props.theme.brand.alt, props.theme.brand.default)};
+      ? Gradient(
+          eval(`props.theme.${props.gradientTheme}.alt`),
+          eval(`props.theme.${props.gradientTheme}.default`)
+        )
+      : Gradient(props.theme.brand.alt, props.theme.brand.default)};
   color: ${theme.text.reverse};
 
   &:hover {
@@ -87,6 +87,13 @@ export const StyledSolidButton = styled.button`
         ? 'none'
         : `${Shadow.low} ${hexa(props.theme.bg.reverse, 0.15)}`};
   }
+`;
+
+export const StyledFloatingButton = styled(StyledSolidButton)`
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  width: auto !important;
 `;
 
 export const StyledTextButton = styled(StyledSolidButton)`
@@ -190,8 +197,8 @@ export const StyledIconButton = styled.button`
     props.disabled
       ? props.theme.bg.inactive
       : props.color
-        ? eval(`props.theme.${props.color}`)
-        : props.theme.text.alt};
+      ? eval(`props.theme.${props.color}`)
+      : props.theme.text.alt};
   opacity: ${props => (props.opacity ? props.opacity : 1)};
 
   &:hover {
@@ -199,10 +206,10 @@ export const StyledIconButton = styled.button`
       props.disabled
         ? props.theme.bg.inactive
         : props.hoverColor
-          ? eval(`props.theme.${props.hoverColor}`)
-          : props.color
-            ? eval(`props.theme.${props.color}`)
-            : props.theme.brand.alt};
+        ? eval(`props.theme.${props.hoverColor}`)
+        : props.color
+        ? eval(`props.theme.${props.color}`)
+        : props.theme.brand.alt};
     transform: ${props => (props.disabled ? 'none' : 'scale(1.05)')};
     box-shadow: none;
     opacity: 1;

--- a/src/components/upsell/joinChannel.js
+++ b/src/components/upsell/joinChannel.js
@@ -9,12 +9,13 @@ import { openModal } from 'src/actions/modals';
 import type { Dispatch } from 'redux';
 import { withCurrentUser } from 'src/components/withCurrentUser';
 import {
+  JoinChannelClose,
   JoinChannelContainer,
   JoinChannelContent,
   JoinChannelTitle,
   JoinChannelSubtitle,
 } from './style';
-import { Button } from 'src/components/buttons';
+import { Button, FloatingButton } from 'src/components/buttons';
 
 type Props = {
   channel: Object,
@@ -26,6 +27,7 @@ type Props = {
 
 type State = {
   isLoading: boolean,
+  isOpen: boolean,
 };
 
 class JoinChannel extends React.Component<Props, State> {
@@ -34,6 +36,7 @@ class JoinChannel extends React.Component<Props, State> {
 
     this.state = {
       isLoading: false,
+      isOpen: true,
     };
   }
 
@@ -92,13 +95,31 @@ class JoinChannel extends React.Component<Props, State> {
       });
   };
 
+  hideUpsell = () => {
+    this.setState({
+      isOpen: false,
+    });
+  };
+
   render() {
-    const { isLoading } = this.state;
+    const { isLoading, isOpen } = this.state;
     const { channel, community, currentUser } = this.props;
+
+    if (!isOpen) {
+      return (
+        <FloatingButton
+          loading={isLoading}
+          onClick={!currentUser ? this.login : this.toggleSubscription}
+          icon={!currentUser ? 'door-enter' : 'plus'}
+          dataCy="thread-join-channel-upsell-button"
+        />
+      );
+    }
 
     if (!currentUser) {
       return (
         <JoinChannelContainer data-cy="join-channel-login-upsell">
+          <JoinChannelClose onClick={this.hideUpsell}>x</JoinChannelClose>
           <JoinChannelContent>
             <JoinChannelTitle>Log in or sign up to chat</JoinChannelTitle>
           </JoinChannelContent>
@@ -116,6 +137,7 @@ class JoinChannel extends React.Component<Props, State> {
 
     return (
       <JoinChannelContainer>
+        <JoinChannelClose onClick={this.hideUpsell}>x</JoinChannelClose>
         <JoinChannelContent>
           <JoinChannelTitle>
             Join the {channel.name} channel in the {community.name} community

--- a/src/components/upsell/joinChannel.js
+++ b/src/components/upsell/joinChannel.js
@@ -9,7 +9,6 @@ import { openModal } from 'src/actions/modals';
 import type { Dispatch } from 'redux';
 import { withCurrentUser } from 'src/components/withCurrentUser';
 import {
-  JoinChannelClose,
   JoinChannelContainer,
   JoinChannelContent,
   JoinChannelTitle,

--- a/src/components/upsell/joinChannel.js
+++ b/src/components/upsell/joinChannel.js
@@ -104,7 +104,11 @@ class JoinChannel extends React.Component<Props, State> {
             hoverColor={'success.default'}
             gradientTheme={'success'}
             onClick={currentUser ? this.toggleSubscription : this.login}
-            dataCy="thread-join-channel-upsell-button"
+            dataCy={
+              currentUser
+                ? 'thread-join-channel-upsell-button'
+                : 'join-channel-login-upsell'
+            }
           >
             {label}
           </Button>

--- a/src/components/upsell/joinChannel.js
+++ b/src/components/upsell/joinChannel.js
@@ -15,7 +15,7 @@ import {
   JoinChannelTitle,
   JoinChannelSubtitle,
 } from './style';
-import { Button, FloatingButton } from 'src/components/buttons';
+import { Button } from 'src/components/buttons';
 
 type Props = {
   channel: Object,
@@ -27,18 +27,10 @@ type Props = {
 
 type State = {
   isLoading: boolean,
-  isOpen: boolean,
 };
 
 class JoinChannel extends React.Component<Props, State> {
-  constructor() {
-    super();
-
-    this.state = {
-      isLoading: false,
-      isOpen: true,
-    };
-  }
+  state = { isLoading: false };
 
   login = () => this.props.dispatch(openModal('CHAT_INPUT_LOGIN_MODAL'));
 
@@ -95,66 +87,29 @@ class JoinChannel extends React.Component<Props, State> {
       });
   };
 
-  hideUpsell = () => {
-    this.setState({
-      isOpen: false,
-    });
-  };
-
   render() {
-    const { isLoading, isOpen } = this.state;
+    const { isLoading } = this.state;
     const { channel, community, currentUser } = this.props;
-
-    if (!isOpen) {
-      return (
-        <FloatingButton
-          loading={isLoading}
-          onClick={!currentUser ? this.login : this.toggleSubscription}
-          icon={!currentUser ? 'door-enter' : 'plus'}
-          dataCy="thread-join-channel-upsell-button"
-        />
-      );
-    }
-
-    if (!currentUser) {
-      return (
-        <JoinChannelContainer data-cy="join-channel-login-upsell">
-          <JoinChannelClose onClick={this.hideUpsell}>x</JoinChannelClose>
-          <JoinChannelContent>
-            <JoinChannelTitle>Log in or sign up to chat</JoinChannelTitle>
-          </JoinChannelContent>
-
-          <Button
-            loading={isLoading}
-            onClick={this.login}
-            dataCy="thread-join-channel-upsell-button"
-          >
-            Log in or sign up
-          </Button>
-        </JoinChannelContainer>
-      );
-    }
+    const label = !currentUser
+      ? `Join ${community.name} community`
+      : community.communityPermissions.isMember
+      ? `Join ${channel.name} channel`
+      : `Join ${community.name} community`;
 
     return (
       <JoinChannelContainer>
-        <JoinChannelClose onClick={this.hideUpsell}>x</JoinChannelClose>
         <JoinChannelContent>
-          <JoinChannelTitle>
-            Join the {channel.name} channel in the {community.name} community
-          </JoinChannelTitle>
-          <JoinChannelSubtitle>
-            Once you join this channel you’ll be able to post your replies here!
-          </JoinChannelSubtitle>
+          <Button
+            loading={isLoading}
+            color={'success.default'}
+            hoverColor={'success.default'}
+            gradientTheme={'success'}
+            onClick={currentUser ? this.toggleSubscription : this.login}
+            dataCy="thread-join-channel-upsell-button"
+          >
+            {label}
+          </Button>
         </JoinChannelContent>
-
-        <Button
-          loading={isLoading}
-          onClick={this.toggleSubscription}
-          icon="plus"
-          dataCy="thread-join-channel-upsell-button"
-        >
-          Join
-        </Button>
       </JoinChannelContainer>
     );
   }

--- a/src/components/upsell/style.js
+++ b/src/components/upsell/style.js
@@ -429,15 +429,3 @@ export const JoinChannelSubtitle = styled.h4`
   font-weight: 400;
   color: ${theme.text.secondary};
 `;
-
-export const JoinChannelClose = styled.span`
-  cursor: pointer;
-  font-size: 15px;
-  position: absolute;
-  right: 0px;
-  top: -4px;
-  padding: 8px;
-  align-items: center;
-  display: flex;
-  color: ${theme.text.alt};
-`;

--- a/src/components/upsell/style.js
+++ b/src/components/upsell/style.js
@@ -401,9 +401,6 @@ export const JoinChannelContainer = styled.div`
   position: relative;
 
   @media (max-width: 768px) {
-    flex-direction: column;
-    padding: 16px;
-
     button {
       width: 100%;
     }

--- a/src/components/upsell/style.js
+++ b/src/components/upsell/style.js
@@ -329,8 +329,8 @@ export const ButtonTwitter = styled(SigninButton)`
     props.whitebg
       ? props.theme.social.twitter.default
       : props.preferred
-        ? '#fff'
-        : 'rgba(255,255,255,0.8)'};
+      ? '#fff'
+      : 'rgba(255,255,255,0.8)'};
 
   &:after {
     color: ${theme.social.twitter.default};
@@ -349,8 +349,8 @@ export const ButtonFacebook = styled(SigninButton)`
     props.whitebg
       ? props.theme.social.facebook.default
       : props.preferred
-        ? '#fff'
-        : 'rgba(255,255,255,0.8)'};
+      ? '#fff'
+      : 'rgba(255,255,255,0.8)'};
 
   &:after {
     color: ${theme.social.facebook.default};
@@ -369,8 +369,8 @@ export const ButtonGoogle = styled(SigninButton)`
     props.whitebg
       ? props.theme.social.google.default
       : props.preferred
-        ? '#fff'
-        : 'rgba(255,255,255,0.8)'};
+      ? '#fff'
+      : 'rgba(255,255,255,0.8)'};
 
   &:after {
     color: ${theme.social.google.default};
@@ -399,12 +399,17 @@ export const JoinChannelContainer = styled.div`
   margin-bottom: 12px;
   background: ${theme.bg.wash};
 
+  & button {
+    margin-right: 16px;
+  }
+
   @media (max-width: 768px) {
     flex-direction: column;
     padding: 16px;
 
     button {
       width: 100%;
+      margin-right: 0;
       margin-top: 16px;
     }
   }
@@ -428,4 +433,15 @@ export const JoinChannelSubtitle = styled.h4`
   font-size: 16px;
   font-weight: 400;
   color: ${theme.text.secondary};
+`;
+
+export const JoinChannelClose = styled.span`
+  cursor: pointer;
+  font-size: 15px;
+  position: absolute;
+  right: 25px;
+  padding: 0 8px;
+  height: 27px;
+  align-items: center;
+  display: flex;
 `;

--- a/src/components/upsell/style.js
+++ b/src/components/upsell/style.js
@@ -392,16 +392,13 @@ export const JoinChannelContainer = styled.div`
   display: flex;
   border: 1px solid ${theme.bg.border};
   border-radius: 4px;
-  padding: 16px 24px;
+  padding: 8px;
   align-items: center;
-  flex: 1 0 auto;
-  width: calc(100% - 24px);
+  flex: 0 0 auto;
+  width: calc(100% - 16px);
   margin-bottom: 12px;
   background: ${theme.bg.wash};
-
-  & button {
-    margin-right: 16px;
-  }
+  position: relative;
 
   @media (max-width: 768px) {
     flex-direction: column;
@@ -409,8 +406,6 @@ export const JoinChannelContainer = styled.div`
 
     button {
       width: 100%;
-      margin-right: 0;
-      margin-top: 16px;
     }
   }
 `;
@@ -419,8 +414,8 @@ export const JoinChannelContent = styled.div`
   display: flex;
   flex-direction: column;
   flex: auto;
-  justify-content: center;
-  padding-right: 32px;
+  align-self: flex-start;
+  width: 100%;
 `;
 
 export const JoinChannelTitle = styled.h3`
@@ -439,9 +434,10 @@ export const JoinChannelClose = styled.span`
   cursor: pointer;
   font-size: 15px;
   position: absolute;
-  right: 25px;
-  padding: 0 8px;
-  height: 27px;
+  right: 0px;
+  top: -4px;
+  padding: 8px;
   align-items: center;
   display: flex;
+  color: ${theme.text.alt};
 `;

--- a/src/views/thread/components/threadCommunityBanner.js
+++ b/src/views/thread/components/threadCommunityBanner.js
@@ -155,11 +155,16 @@ class ThreadCommunityBanner extends React.Component<Props, State> {
               onClick={this.joinChannel}
               loading={isLoading}
             >
-              Join channel
+              Join{' '}
+              {community.communityPermissions.isMember
+                ? 'channel'
+                : 'community'}
             </Button>
           ) : (
             <Link to={loginUrl}>
-              <Button gradientTheme={'success'}>Join Community</Button>
+              <Button color={'success'} gradientTheme={'success'}>
+                Join community
+              </Button>
             </Link>
           )}
         </CommunityHeader>


### PR DESCRIPTION
When the upsell is closed, the action related to it becomes available through a floating button.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Closes #4531.
<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->

