### PR TITLE
Better spam protection on thread publish

### DIFF
--- a/api/mutations/thread/publishThread.js
+++ b/api/mutations/thread/publishThread.js
@@ -199,6 +199,7 @@ export default requireAuth(
         if (!t) return false;
         if (
           usersPreviousPublishedThreads.length === 1 &&
+          usersPreviousPublishedThreads[0] &&
           usersPreviousPublishedThreads[0].deletedAt
         )
           return false;

--- a/api/mutations/thread/publishThread.js
+++ b/api/mutations/thread/publishThread.js
@@ -197,6 +197,11 @@ export default requireAuth(
 
       const checkForSpam = usersPreviousPublishedThreads.map(t => {
         if (!t) return false;
+        if (
+          usersPreviousPublishedThreads.length === 1 &&
+          usersPreviousPublishedThreads[0].deletedAt
+        )
+          return false;
 
         const incomingTitle = thread.content.title;
         const thisTitle = t.content.title;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

I would guess that 99% of our system-generate spam reports are false positives. It seems like the most common reason people get blocked for spam is that they post once, realize they posted in the wrong channel, delete their post, and then re-publish in the correct channel. 

This PR accounts for this one specific flow and won't block people if they only published one previous post with the same title + body and that previous post was deleted.

Closes #4151