### PR TITLE
Fix loading state on DMs

### DIFF
--- a/src/views/directMessages/components/threadsList.js
+++ b/src/views/directMessages/components/threadsList.js
@@ -106,7 +106,7 @@ class ThreadsList extends React.Component<Props, State> {
     const { currentUser, dmData, activeThreadId } = this.props;
     const { scrollElement } = this.state;
 
-    if (!dmData || !dmData.user) return null;
+    if (!dmData) return null;
 
     const dmDataExists =
       currentUser && dmData.user && dmData.user.directMessageThreadsConnection;
@@ -138,7 +138,7 @@ class ThreadsList extends React.Component<Props, State> {
 
     const uniqueThreads = deduplicateChildren(threads, 'id');
 
-    if (!dmDataExists && dmData.isLoading) {
+    if (!dmDataExists && dmData.loading) {
       return (
         <div>
           <LoadingDM />


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

If you client-side navigate to /messages from any other page, the threads list will appear blank at first because of this small bug. Now we will show the proper loading threads.