### PR TITLE
Add shift key listener when deleting messages

### DIFF
--- a/src/components/message/index.js
+++ b/src/components/message/index.js
@@ -44,6 +44,8 @@ import {
 } from './style';
 import getThreadLink from 'src/helpers/get-thread-link';
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
+import deleteMessage from 'shared/graphql/mutations/message/deleteMessage';
+import { deleteMessageWithToast } from 'src/components/modals/DeleteDoubleCheckModal';
 
 type Props = {|
   me: boolean,
@@ -103,6 +105,15 @@ class Message extends React.Component<Props, State> {
 
   deleteMessage = (e: any) => {
     e.stopPropagation();
+
+    if (e.shiftKey) {
+      // If Shift key is pressed, we assume confirmation
+      return deleteMessageWithToast(
+        this.props.dispatch,
+        this.props.deleteMessage,
+        this.props.message.id
+      );
+    }
 
     const message = 'Are you sure you want to delete this message?';
 
@@ -168,8 +179,8 @@ class Message extends React.Component<Props, State> {
       threadType === 'story' && thread
         ? `/${getThreadLink(thread)}?m=${selectedMessageId}`
         : threadType === 'directMessageThread'
-          ? `/messages/${threadId}?m=${selectedMessageId}`
-          : `/thread/${threadId}?m=${selectedMessageId}`;
+        ? `/messages/${threadId}?m=${selectedMessageId}`
+        : `/thread/${threadId}?m=${selectedMessageId}`;
 
     return (
       <MessagesContext.Consumer>
@@ -237,18 +248,17 @@ class Message extends React.Component<Props, State> {
                     />
                   )}
 
-                  {message.modifiedAt &&
-                    !isEditing && (
-                      <EditedIndicator
-                        data-cy="edited-message-indicator"
-                        tipLocation={'top-right'}
-                        tipText={`Edited ${convertTimestampToDate(
-                          new Date(message.modifiedAt)
-                        )}`}
-                      >
-                        Edited
-                      </EditedIndicator>
-                    )}
+                  {message.modifiedAt && !isEditing && (
+                    <EditedIndicator
+                      data-cy="edited-message-indicator"
+                      tipLocation={'top-right'}
+                      tipText={`Edited ${convertTimestampToDate(
+                        new Date(message.modifiedAt)
+                      )}`}
+                    >
+                      Edited
+                    </EditedIndicator>
+                  )}
 
                   {message.reactions.count > 0 && (
                     <Reaction
@@ -415,6 +425,7 @@ class Message extends React.Component<Props, State> {
 }
 
 export default compose(
+  deleteMessage,
   withCurrentUser,
   withRouter,
   toggleReactionMutation,

--- a/src/components/message/index.js
+++ b/src/components/message/index.js
@@ -60,6 +60,7 @@ type Props = {|
   history: History,
   dispatch: Dispatch<Object>,
   currentUser: UserInfoType,
+  deleteMessage: Function,
 |};
 
 type State = {

--- a/src/components/modals/DeleteDoubleCheckModal/index.js
+++ b/src/components/modals/DeleteDoubleCheckModal/index.js
@@ -64,7 +64,7 @@ type Props = {
 export const deleteMessageWithToast = (
   dispatch: Function,
   deleteMessage: Function,
-  id
+  id: string
 ) => {
   return deleteMessage(id)
     .then(({ data }: DeleteMessageType) => {

--- a/src/components/modals/DeleteDoubleCheckModal/index.js
+++ b/src/components/modals/DeleteDoubleCheckModal/index.js
@@ -61,6 +61,28 @@ type Props = {
   isOpen: boolean,
 };
 
+export const deleteMessageWithToast = (
+  dispatch: Function,
+  deleteMessage: Function,
+  id
+) => {
+  return deleteMessage(id)
+    .then(({ data }: DeleteMessageType) => {
+      const { deleteMessage } = data;
+      if (deleteMessage) {
+        dispatch(addToastWithTimeout('neutral', 'Message deleted.'));
+      }
+    })
+    .catch(err => {
+      dispatch(
+        addToastWithTimeout(
+          'error',
+          `Sorry, we weren't able to delete this message. ${err.message}`
+        )
+      );
+    });
+};
+
 class DeleteDoubleCheckModal extends React.Component<Props, State> {
   state = {
     isLoading: false,
@@ -82,27 +104,16 @@ class DeleteDoubleCheckModal extends React.Component<Props, State> {
 
     switch (entity) {
       case 'message':
-        return this.props
-          .deleteMessage(id)
-          .then(({ data }: DeleteMessageType) => {
-            const { deleteMessage } = data;
-            if (deleteMessage) {
-              dispatch(addToastWithTimeout('neutral', 'Message deleted.'));
-              this.setState({
-                isLoading: false,
-              });
-              this.close();
-            }
-            return;
-          })
-          .catch(err => {
-            dispatch(
-              addToastWithTimeout(
-                'error',
-                `Sorry, we weren't able to delete this message. ${err.message}`
-              )
-            );
+        return deleteMessageWithToast(
+          this.props.dispatch,
+          this.props.deleteMessage,
+          id
+        ).then(() => {
+          this.setState({
+            isLoading: false,
           });
+          this.close();
+        });
       case 'thread': {
         return this.props
           .deleteThread(id)


### PR DESCRIPTION
This allows skipping of the confirmation modal when pressing shift while clicking the message delete button. This allows faster moderation. I got this idea from Discord (they're doing that too).

Thought it would be a nice little feature. If not wanted, just reject it.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- The delete message button can now be clicked while pressing the Shift key to skip confirmation

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->



