### PR TITLE
Fix join token redirect issue for private communities

### DIFF
--- a/src/views/communityLogin/index.js
+++ b/src/views/communityLogin/index.js
@@ -35,8 +35,12 @@ type Props = {
   redirectPath: ?string,
 };
 
-export class Login extends React.Component<Props> {
-  redirectPath = null;
+type State = {
+  redirectPath: ?string,
+};
+
+export class Login extends React.Component<Props, State> {
+  state = { redirectPath: null };
 
   escape = () => {
     this.props.history.push(`/${this.props.match.params.communitySlug}`);
@@ -46,12 +50,12 @@ export class Login extends React.Component<Props> {
     const { location, redirectPath } = this.props;
 
     if (redirectPath) {
-      this.redirectPath = redirectPath;
+      this.setState({ redirectPath });
     }
 
     if (location && !redirectPath) {
       const searchObj = queryString.parse(this.props.location.search);
-      this.redirectPath = searchObj.r;
+      this.setState({ redirectPath: searchObj.r });
     }
 
     track(events.LOGIN_PAGE_VIEWED, { redirectPath: this.redirectPath });
@@ -63,6 +67,7 @@ export class Login extends React.Component<Props> {
       isLoading,
       match,
     } = this.props;
+    const { redirectPath } = this.state;
 
     if (community && community.id) {
       const { brandedLogin } = community;
@@ -89,8 +94,7 @@ export class Login extends React.Component<Props> {
 
             <LoginButtonSet
               redirectPath={
-                this.redirectPath ||
-                `${CLIENT_URL}/${match.params.communitySlug}`
+                redirectPath || `${CLIENT_URL}/${match.params.communitySlug}`
               }
               signinType={'signin'}
             />

--- a/src/views/communityLogin/index.js
+++ b/src/views/communityLogin/index.js
@@ -58,7 +58,7 @@ export class Login extends React.Component<Props, State> {
       this.setState({ redirectPath: searchObj.r });
     }
 
-    track(events.LOGIN_PAGE_VIEWED, { redirectPath: this.redirectPath });
+    track(events.LOGIN_PAGE_VIEWED, { redirectPath: this.state.redirectPath });
   }
 
   render() {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

I was dumbly storing the `redirectPath` value in a class variable, which of course doesn't trigger a re-render when it's changed in `componentDidMount`. Thus, this doesn't work when the page is loaded via SSR, because `cDM` loads after render and doesn't re-render when we update the `redirectPath` variable.

Anyways, this was confusing because locally everything worked fine (client-side rendering) but broke in prod. This now works (cc @mxstbr for SSR e2e tests :P)