### PR TITLE
Fix repeating heading in digest emails

### DIFF
--- a/built-email-templates/weeklyDigest.html
+++ b/built-email-templates/weeklyDigest.html
@@ -1,4 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
 <!-- 
   START_CONFIG
   { 
@@ -13,7 +14,6 @@
   }
   END_CONFIG
 -->
-<html xmlns="http://www.w3.org/1999/xhtml">
 
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -121,7 +121,7 @@
                 </tr>
                 {{/data.hasOverflowThreads}}
 
-                {{#data.communities}}
+                {{#if data.communities}}
                 <tr>
                   <td style="word-break:break-word">
                     <div class="section-divider" style="border-bottom:1px solid #DAE4F2; display:block; height:1px; margin:32px 0" height="1"></div>
@@ -133,7 +133,7 @@
                     <h2 class="discover-divider" style="color:#16171A; font-size:20px; font-weight:bold; margin-top:0; text-align:left; margin-bottom:0" align="left">Discover more communities:</h2>
                   </td>
                 </tr>
-                {{/data.communities}}
+                {{/if}}
 
                 {{#each data.communities}}
                 <tr>

--- a/email-template-scripts/sendgrid-sync.js
+++ b/email-template-scripts/sendgrid-sync.js
@@ -86,7 +86,14 @@ const processPath = path => {
         .slice(configStart, configEnd)
         .replace('START_CONFIG', '')
         .replace(/(\r\n\t|\n|\r\t)/gm, '');
-      const config = JSON.parse(configString);
+
+      let config;
+      try {
+        config = JSON.parse(configString);
+      } catch (err) {
+        console.error({ err, configString, file, configStart, configEnd });
+        return;
+      }
 
       if (!UPDATE_PROD_TEMPLATES && !config.test) {
         console.error('🔅 No test config for this template, skipping');

--- a/email-templates/weeklyDigest.html
+++ b/email-templates/weeklyDigest.html
@@ -1,4 +1,7 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html
+  PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
 
 <!-- 
   START_CONFIG
@@ -14,8 +17,6 @@
   }
   END_CONFIG
 -->
-
-<html xmlns="http://www.w3.org/1999/xhtml">
 
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -440,7 +441,8 @@
 
                         <td valign="middle">
                           <p>
-                            Posted in <a href="https://spectrum.chat/{{community.slug}}">{{community.name}}</a>&nbsp;·&nbsp;<a
+                            Posted in <a
+                              href="https://spectrum.chat/{{community.slug}}">{{community.name}}</a>&nbsp;·&nbsp;<a
                               href="https://spectrum.chat/{{community.slug}}/{{channel.slug}}">{{channel.name}}</a>
                           </p>
                           <p>
@@ -470,7 +472,7 @@
                 </tr>
                 {{/data.hasOverflowThreads}}
 
-                {{#data.communities}}
+                {{#if data.communities}}
                 <tr>
                   <td>
                     <div class="section-divider"></div>
@@ -482,12 +484,13 @@
                     <h2 class="discover-divider">Discover more communities:</h2>
                   </td>
                 </tr>
-                {{/data.communities}}
+                {{/if}}
 
                 {{#each data.communities}}
                 <tr>
                   <td>
-                    <table width="100%" cellpadding="0" cellspacing="0" class="thread-community-header suggested-community">
+                    <table width="100%" cellpadding="0" cellspacing="0"
+                      class="thread-community-header suggested-community">
                       <tr width="100%" cellpadding="0" cellspacing="0">
                         <td valign="middle" width="32">
                           <a href="https://spectrum.chat/{{slug}}" class="block">
@@ -556,7 +559,8 @@
                 </li>
 
                 <li>
-                  <a href="https://spectrum.chat/spectrum/hugs-n-bugs">Report bugs</a> · <a href="https://spectrum.chat/spectrum/feature-requests">Request
+                  <a href="https://spectrum.chat/spectrum/hugs-n-bugs">Report bugs</a> · <a
+                    href="https://spectrum.chat/spectrum/feature-requests">Request
                     a feature</a>
                 </li>
               </ul>


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

Closes #4736 - for some reason our email scripts now handle the build pipeline differently, stripping out the `<doctype>` - this has forced me to move the template comments inside the `<html>` tag. I tested everything locally and this works, it was just a weird change.