### PR TITLE
Fix unreliable DM thread subscriptions

### DIFF
--- a/api/models/directMessageThread.js
+++ b/api/models/directMessageThread.js
@@ -4,6 +4,7 @@ import { NEW_DOCUMENTS } from './utils';
 import { createChangefeed } from 'shared/changefeed-utils';
 import { trackQueue } from 'shared/bull/queues';
 import { events } from 'shared/analytics';
+import { getDirectMessageThreadRecords } from './usersDirectMessageThreads';
 
 export type DBDirectMessageThread = {
   createdAt: Date,
@@ -100,19 +101,32 @@ const getUpdatedDirectMessageThreadChangefeed = () =>
       includeInitial: false,
     })
     .filter(NEW_DOCUMENTS.or(THREAD_LAST_ACTIVE_CHANGED))('new_val')
-    .eqJoin('id', db.table('usersDirectMessageThreads'), { index: 'threadId' })
-    .without({
-      right: ['id', 'createdAt', 'threadId', 'lastActive', 'lastSeen'],
-    })
-    .zip()
     .run();
 
-const listenToUpdatedDirectMessageThreads = (cb: Function): Function => {
+const listenToUpdatedDirectMessageThreadRecords = (cb: Function) => {
   return createChangefeed(
     getUpdatedDirectMessageThreadChangefeed,
     cb,
     'listenToUpdatedDirectMessageThreads'
   );
+};
+
+const listenToUpdatedDirectMessageThreads = (cb: Function): Function => {
+  // NOTE(@mxstbr): Running changefeeds on eqJoin's does not work well, so we
+  // hack around that by listening to record changes and then "faking" an eqJoin
+  // by doing another db query!
+  return listenToUpdatedDirectMessageThreadRecords(directMessageThread => {
+    getDirectMessageThreadRecords(directMessageThread.id).then(
+      usersDirectMessageThread => {
+        usersDirectMessageThread.forEach(userDirectMessageThread => {
+          cb({
+            ...userDirectMessageThread,
+            ...directMessageThread,
+          });
+        });
+      }
+    );
+  });
 };
 
 // prettier-ignore

--- a/api/models/usersDirectMessageThreads.js
+++ b/api/models/usersDirectMessageThreads.js
@@ -124,6 +124,13 @@ const isMemberOfDirectMessageThread = (threadId: string, userId: string) => {
     .run();
 };
 
+const getDirectMessageThreadRecords = (threadId: string) => {
+  return db
+    .table('usersDirectMessageThreads')
+    .getAll(threadId, { index: 'threadId' })
+    .run();
+};
+
 module.exports = {
   createMemberInDirectMessageThread,
   removeMemberInDirectMessageThread,
@@ -134,4 +141,5 @@ module.exports = {
   getMembersInDirectMessageThread,
   getMembersInDirectMessageThreads,
   isMemberOfDirectMessageThread,
+  getDirectMessageThreadRecords,
 };


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

for some reason, changefeeds with `.eqJoin`s afterwards do not always return all the data. (see #4764)

This works around that issue by doing a fake join on the API server instead: it fetches the records with another db query and then calls the listener with all those records.

As far as I can tell locally, this fixes #4764!

We should probably look at all our other changefeeds to make sure we are not doing joins anywhere else.