### PR TITLE
Fix join link redirectpath default state

### DIFF
--- a/src/views/communityLogin/index.js
+++ b/src/views/communityLogin/index.js
@@ -40,7 +40,7 @@ type State = {
 };
 
 export class Login extends React.Component<Props, State> {
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
 
     this.state = {

--- a/src/views/communityLogin/index.js
+++ b/src/views/communityLogin/index.js
@@ -40,7 +40,13 @@ type State = {
 };
 
 export class Login extends React.Component<Props, State> {
-  state = { redirectPath: null };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      redirectPath: props.redirectPath,
+    };
+  }
 
   escape = () => {
     this.props.history.push(`/${this.props.match.params.communitySlug}`);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Was unnecessarily setting the state to `null` even if the prop existed to have a sensible default at construction. So now I do that.