### PR TITLE
Properly handle missing thread data while getting thread link

### DIFF
--- a/src/helpers/get-thread-link.js
+++ b/src/helpers/get-thread-link.js
@@ -3,6 +3,7 @@ import slugg from 'slugg';
 import type { ThreadInfoType } from 'shared/graphql/fragments/thread/threadInfo';
 
 const getThreadLink = (thread: ThreadInfoType) => {
+  if (!thread.community || !thread.channel) return `/thread/${thread.id}`;
   return `${thread.community.slug}/${thread.channel.slug}/${slugg(
     thread.content.title
   )}~${thread.id}`;

--- a/src/routes.js
+++ b/src/routes.js
@@ -375,6 +375,13 @@ class Routes extends React.Component<Props> {
 
               {isModal && (
                 <Route
+                  path="/thread/:threadId"
+                  component={RedirectOldThreadRoute}
+                />
+              )}
+
+              {isModal && (
+                <Route
                   path="/new/thread"
                   render={props => <ComposerFallback {...props} slider />}
                 />


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Hotfixing - /notifications is crashing right now because certain notifications don't have the proper community/channel data. This provides a fallback globally so that a route like `/thread/:id` with a `{ modal: true }` state will redirect properly.