### PR TITLE
Fix /thread/:id modal routes

### DIFF
--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -218,7 +218,7 @@ class ThreadContainer extends React.Component<Props, State> {
         thread.channel.slug
       }/${slugg(thread.content.title)}~${thread.id}`;
       // $FlowFixMe
-      if (this.props.location.pathname !== properUrl)
+      if (this.props.history.location.pathname !== properUrl)
         // $FlowFixMe
         return this.props.history.replace(properUrl);
     }

--- a/src/views/thread/container.js
+++ b/src/views/thread/container.js
@@ -218,7 +218,7 @@ class ThreadContainer extends React.Component<Props, State> {
         thread.channel.slug
       }/${slugg(thread.content.title)}~${thread.id}`;
       // $FlowFixMe
-      if (this.props.history.location.pathname !== properUrl)
+      if (this.props.location.pathname !== properUrl)
         // $FlowFixMe
         return this.props.history.replace(properUrl);
     }

--- a/src/views/thread/redirect-old-route.js
+++ b/src/views/thread/redirect-old-route.js
@@ -16,10 +16,7 @@ export default getThreadByMatch(props => {
       <Redirect
         to={{
           ...props.location,
-          pathname: `${getThreadLink(thread)}${idx(
-            props,
-            _ => _.location.search
-          ) || ''}`,
+          pathname: `${getThreadLink(thread)}`,
         }}
       />
     );

--- a/src/views/thread/redirect-old-route.js
+++ b/src/views/thread/redirect-old-route.js
@@ -7,15 +7,20 @@ import idx from 'idx';
 import { getThreadByMatch } from 'shared/graphql/queries/thread/getThread';
 import { FullscreenThreadView } from 'src/views/thread';
 import LoadingThread from 'src/views/thread/components/loading';
+import getThreadLink from 'src/helpers/get-thread-link';
 
 export default getThreadByMatch(props => {
   if (props.data && props.data.thread && props.data.thread.id) {
     const { thread } = props.data;
     return (
       <Redirect
-        to={`/${thread.community.slug}/${thread.channel.slug}/${slugg(
-          thread.content.title
-        )}~${thread.id}${idx(props, _ => _.location.search) || ''}`}
+        to={{
+          pathname: `${getThreadLink(thread)}${idx(
+            props,
+            _ => _.location.search
+          ) || ''}`,
+          state: props.location.state,
+        }}
       />
     );
   }

--- a/src/views/thread/redirect-old-route.js
+++ b/src/views/thread/redirect-old-route.js
@@ -15,11 +15,11 @@ export default getThreadByMatch(props => {
     return (
       <Redirect
         to={{
+          ...props.location,
           pathname: `${getThreadLink(thread)}${idx(
             props,
             _ => _.location.search
           ) || ''}`,
-          state: props.location.state,
         }}
       />
     );


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Closes #4824

By passing the location state through `/thread/:id` as a modal works perfectly! :100: