### PR TITLE
Fix editing communities

### DIFF
--- a/api/models/community.js
+++ b/api/models/community.js
@@ -412,7 +412,7 @@ export const createCommunity = ({ input }: CreateCommunityInput, user: DBUser): 
 export const editCommunity = async ({ input }: EditCommunityInput, userId: string): Promise<DBCommunity> => {
   const { name, slug, description, website, file, coverPhoto, coverFile, communityId } = input
 
-  const community = await db.table('communities').get(communityId).run()
+  let community = await db.table('communities').get(communityId).run()
 
   // if the input comes in with a coverPhoto of length 0 (empty string), it means
   // the user was trying to delete or reset their cover photo from the front end.
@@ -442,7 +442,6 @@ export const editCommunity = async ({ input }: EditCommunityInput, userId: strin
     }, { returnChanges: 'always' })
     .run()
     .then(result => {
-      let community
       if (result.replaced === 1) {
         community = result.changes[0].new_val;
         trackQueue.add({
@@ -466,7 +465,7 @@ export const editCommunity = async ({ input }: EditCommunityInput, userId: strin
       }
 
       searchQueue.add({
-        id: community.id,
+        id: communityId,
         type: 'community',
         event: 'edited'
       })

--- a/src/views/communitySettings/components/editForm.js
+++ b/src/views/communitySettings/components/editForm.js
@@ -6,10 +6,10 @@ import { withRouter } from 'react-router';
 import editCommunityMutation from 'shared/graphql/mutations/community/editCommunity';
 import type { EditCommunityType } from 'shared/graphql/mutations/community/editCommunity';
 import type { GetCommunityType } from 'shared/graphql/queries/community/getCommunity';
-import { openModal } from '../../../actions/modals';
-import { addToastWithTimeout } from '../../../actions/toasts';
-import { Button, IconButton } from '../../../components/buttons';
-import { Notice } from '../../../components/listItems/style';
+import { openModal } from 'src/actions/modals';
+import { addToastWithTimeout } from 'src/actions/toasts';
+import { Button, IconButton } from 'src/components/buttons';
+import { Notice } from 'src/components/listItems/style';
 import Icon from 'src/components/icons';
 import {
   Input,
@@ -18,7 +18,7 @@ import {
   PhotoInput,
   Error,
   CoverInput,
-} from '../../../components/formElements';
+} from 'src/components/formElements';
 import {
   Form,
   FormTitle,
@@ -28,11 +28,8 @@ import {
   ImageInputWrapper,
   DeleteCoverWrapper,
   DeleteCoverButton,
-} from '../../../components/editForm/style';
-import {
-  SectionCard,
-  SectionTitle,
-} from '../../../components/settingsViews/style';
+} from 'src/components/editForm/style';
+import { SectionCard, SectionTitle } from 'src/components/settingsViews/style';
 import { track, events, transformations } from 'src/helpers/analytics';
 import type { Dispatch } from 'redux';
 
@@ -191,6 +188,7 @@ class EditForm extends React.Component<Props, State> {
       website,
       file,
       coverFile,
+      coverPhoto,
       communityId,
       photoSizeError,
     } = this.state;
@@ -200,6 +198,7 @@ class EditForm extends React.Component<Props, State> {
       website,
       file,
       coverFile,
+      coverPhoto,
       communityId,
     };
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

We broke editing communities a while back with https://github.com/withspectrum/spectrum/pull/4664 - what we forgot is that if there was no `input.coverPhoto` we assumed the user was trying to reset their cover photo. By no longer including `coverPhoto` in the input from that PR, the API assumed that *every* edit was resetting the cover photo! So even if you changed the description if your community, poof: the cover photo disappears.

Additionally, that `editCommunity` mutation is some of earliest javascript I've ever written and was an absolute nightmare to reason about. I've refactored it to hopefully make *much* more sense. 