### PR TITLE
Console an error in case a user queries threads from a deleted community or channel

### DIFF
--- a/api/queries/thread/channel.js
+++ b/api/queries/thread/channel.js
@@ -3,7 +3,7 @@ import type { GraphQLContext } from '../../';
 import type { DBThread } from 'shared/types';
 
 export default async (root: DBThread, _: any, ctx: GraphQLContext) => {
-  const { channelId } = root;
+  const { channelId, id } = root;
   const { loaders } = ctx;
   const channel = await loaders.channel.load(channelId);
   if (!channel) {
@@ -11,6 +11,7 @@ export default async (root: DBThread, _: any, ctx: GraphQLContext) => {
       'User queried thread of non-existent/deleted channel: ',
       channelId
     );
+    console.error('Thread queried: ', id);
   }
   return channel;
 };

--- a/api/queries/thread/channel.js
+++ b/api/queries/thread/channel.js
@@ -2,5 +2,15 @@
 import type { GraphQLContext } from '../../';
 import type { DBThread } from 'shared/types';
 
-export default ({ channelId }: DBThread, _: any, { loaders }: GraphQLContext) =>
-  loaders.channel.load(channelId);
+export default async (root: DBThread, _: any, ctx: GraphQLContext) => {
+  const { channelId } = root;
+  const { loaders } = ctx;
+  const channel = await loaders.channel.load(channelId);
+  if (!channel) {
+    console.error(
+      'User queried thread of non-existent/deleted channel: ',
+      channelId
+    );
+  }
+  return channel;
+};

--- a/api/queries/thread/community.js
+++ b/api/queries/thread/community.js
@@ -3,7 +3,7 @@ import type { GraphQLContext } from '../../';
 import type { DBThread } from 'shared/types';
 
 export default async (root: DBThread, _: any, ctx: GraphQLContext) => {
-  const { communityId } = root;
+  const { communityId, id } = root;
   const { loaders } = ctx;
   const community = await loaders.community.load(communityId);
   if (!community) {
@@ -11,6 +11,7 @@ export default async (root: DBThread, _: any, ctx: GraphQLContext) => {
       'User queried thread of non-existent/deleted community: ',
       communityId
     );
+    console.error('Thread queried: ', id);
   }
   return community;
 };

--- a/api/queries/thread/community.js
+++ b/api/queries/thread/community.js
@@ -2,8 +2,15 @@
 import type { GraphQLContext } from '../../';
 import type { DBThread } from 'shared/types';
 
-export default (
-  { communityId }: DBThread,
-  _: any,
-  { loaders }: GraphQLContext
-) => loaders.community.load(communityId);
+export default async (root: DBThread, _: any, ctx: GraphQLContext) => {
+  const { communityId } = root;
+  const { loaders } = ctx;
+  const community = await loaders.community.load(communityId);
+  if (!community) {
+    console.error(
+      'User queried thread of non-existent/deleted community: ',
+      communityId
+    );
+  }
+  return community;
+};


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

@mxstbr I suppose this is enough to help us quickly track down problems as they arise. An alternative option here is to kick off a worker job to do its own investigation and attempt to proactively clean up bad data. Would you rather that happen here?