### PR TITLE
Add exception to signedOutFallback so signed in users can see the pages

### DIFF
--- a/src/helpers/signed-out-fallback.js
+++ b/src/helpers/signed-out-fallback.js
@@ -5,11 +5,27 @@ import { withCurrentUser } from 'src/components/withCurrentUser';
 import AuthViewHandler from 'src/views/authViewHandler';
 
 const Switch = props => {
-  const { Component, FallbackComponent, ...rest } = props;
+  const { Component, FallbackComponent, searchParamException, ...rest } = props;
+  let isException = false;
+
+  if (searchParamException) {
+    const searchParamsString = (props.location && props.location.search) || '';
+    const searchParams = new Map(
+      searchParamsString
+        .substring(1)
+        .split('&')
+        .map(kv => kv.split('='))
+    );
+
+    isException =
+      searchParams.has(searchParamException) &&
+      searchParams.get(searchParamException) !== 'false';
+  }
+
   return (
     <AuthViewHandler>
       {authed => {
-        if (!authed) {
+        if (!authed || isException) {
           return <FallbackComponent {...rest} />;
         } else {
           return <Component {...rest} />;
@@ -24,13 +40,15 @@ const ConnectedSwitch = compose(withCurrentUser)(Switch);
 
 const signedOutFallback = (
   Component: React$ComponentType<*>,
-  FallbackComponent: React$ComponentType<*>
+  FallbackComponent: React$ComponentType<*>,
+  searchParamException: string = null
 ) => {
   return (props: *) => (
     <ConnectedSwitch
       {...props}
       FallbackComponent={FallbackComponent}
       Component={Component}
+      searchParamException={searchParamException}
     />
   );
 };

--- a/src/helpers/signed-out-fallback.js
+++ b/src/helpers/signed-out-fallback.js
@@ -41,7 +41,7 @@ const ConnectedSwitch = compose(withCurrentUser)(Switch);
 const signedOutFallback = (
   Component: React$ComponentType<*>,
   FallbackComponent: React$ComponentType<*>,
-  searchParamException: string = null
+  searchParamException: ?string = null
 ) => {
   return (props: *) => (
     <ConnectedSwitch

--- a/src/helpers/signed-out-fallback.js
+++ b/src/helpers/signed-out-fallback.js
@@ -12,7 +12,9 @@ const Switch = props => {
   if (searchParamException) {
     const searchParamsString = (props.location && props.location.search) || '';
     const searchParams = queryString.parse(searchParamsString);
-    isException = !!searchParams[searchParamException];
+    isException =
+      searchParams[searchParamException] === null ||
+      searchParams[searchParamException] !== 'false';
   }
 
   return (

--- a/src/helpers/signed-out-fallback.js
+++ b/src/helpers/signed-out-fallback.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import compose from 'recompose/compose';
+import queryString from 'query-string';
 import { withCurrentUser } from 'src/components/withCurrentUser';
 import AuthViewHandler from 'src/views/authViewHandler';
 
@@ -10,16 +11,8 @@ const Switch = props => {
 
   if (searchParamException) {
     const searchParamsString = (props.location && props.location.search) || '';
-    const searchParams = new Map(
-      searchParamsString
-        .substring(1)
-        .split('&')
-        .map(kv => kv.split('='))
-    );
-
-    isException =
-      searchParams.has(searchParamException) &&
-      searchParams.get(searchParamException) !== 'false';
+    const searchParams = queryString.parse(searchParamsString);
+    isException = !!searchParams[searchParamException];
   }
 
   return (

--- a/src/routes.js
+++ b/src/routes.js
@@ -138,7 +138,8 @@ const HomeFallback = signedOutFallback(Dashboard, () => <Redirect to="/" />);
 const LoginFallback = signedOutFallback(() => <Redirect to="/" />, Login);
 const CommunityLoginFallback = signedOutFallback(
   props => <Redirect to={`/${props.match.params.communitySlug}`} />,
-  CommunityLoginView
+  CommunityLoginView,
+  'preview'
 );
 const NewCommunityFallback = signedOutFallback(NewCommunity, () => (
   <Login redirectPath={`${CLIENT_URL}/new/community`} />

--- a/src/views/communitySettings/components/brandedLogin.js
+++ b/src/views/communitySettings/components/brandedLogin.js
@@ -145,7 +145,7 @@ class BrandedLogin extends React.Component<Props, State> {
                 </Button>
 
                 <Link
-                  to={`/${community.slug}/login`}
+                  to={`/${community.slug}/login?preview`}
                   style={{ marginRight: '8px' }}
                 >
                   <OutlineButton


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Closes #4861 

I guess this is a simple enough solution, if there is a `?preview` on the end of `/:communitySlug/login` the user will be able to see the page without being redirected.