### PR TITLE
Fix external images breaking while editing

### DIFF
--- a/shared/imgix/signThread.js
+++ b/shared/imgix/signThread.js
@@ -34,12 +34,14 @@ const signBody = (body?: string, expires?: number): string => {
 
     // transform the body inline with signed image urls
     const imageUrlStoredAsSigned =
-      src && src.indexOf('https://spectrum.imgix.net') >= 0;
+      src &&
+      (src.indexOf('https://spectrum.imgix.net') >= 0 ||
+        src.indexOf('https://spectrum-proxy.imgix.net') >= 0);
     // if the image was stored in the db as a signed url (eg. after the plaintext update to the thread editor)
     // we need to remove all query params from the src, then re-sign in order to avoid duplicate signatures
     // or sending down a url with an expired signature
     if (imageUrlStoredAsSigned) {
-      const pathname = url.parse(src).pathname;
+      const pathname = url.parse(src).pathname.replace(/^\//, '');
       // always attempt to use the parsed pathname, but fall back to the original src
       const sanitized = decodeURIComponent(pathname || src);
       returnBody.entityMap[key].data.src = signImageUrl(sanitized, { expires });

--- a/shared/imgix/signThread.js
+++ b/shared/imgix/signThread.js
@@ -41,9 +41,11 @@ const signBody = (body?: string, expires?: number): string => {
     // we need to remove all query params from the src, then re-sign in order to avoid duplicate signatures
     // or sending down a url with an expired signature
     if (imageUrlStoredAsSigned) {
-      const pathname = url.parse(src).pathname.replace(/^\//, '');
+      const { pathname } = url.parse(src);
       // always attempt to use the parsed pathname, but fall back to the original src
-      const sanitized = decodeURIComponent(pathname || src);
+      const sanitized = decodeURIComponent(
+        pathname ? pathname.replace(/^\//, '') : src
+      );
       returnBody.entityMap[key].data.src = signImageUrl(sanitized, { expires });
     } else {
       returnBody.entityMap[key].data.src = signImageUrl(src, { expires });


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api

They were being double-signed on edit

To reproduce, create a new thread with this markdown:

```markdown
![](https://i.imgur.com/nhItZTT.png)
```

Then publish it. You should see an image. Then edit the thread, and
without changing anything save it.

The image will be broken.

After this change, it won't be! :tada: