### PR TITLE
Add white-space: pre-wrap to Paragraph component to preserve new line

### DIFF
--- a/src/components/message/style.js
+++ b/src/components/message/style.js
@@ -332,6 +332,8 @@ export const Line = styled.pre`
 `;
 
 export const Paragraph = styled.p`
+  white-space: pre-wrap;
+  
   &:not(:empty) ~ &:not(:empty) {
     margin-top: 8px;
   }


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Closes #4885 

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->

This PR should solve this issue: [new line character (\n) has been ignore and not rendered #4885
](https://github.com/withspectrum/spectrum/issues/4885) by adding `white-space: pre-wrap` to `.markdown`. You can find more details in the issue.

Before the fix, `\n` has been rendered as a space:
![螢幕快照 2019-03-20 下午11 11 40](https://user-images.githubusercontent.com/2755720/54695846-aeec1b80-4b65-11e9-89e4-ea0ba44d1f76.png)

After the fix, `\n` correctly rendered as new line:
![螢幕快照 2019-03-20 下午11 11 25](https://user-images.githubusercontent.com/2755720/54695886-c4614580-4b65-11e9-860c-12c17e451110.png)

Please let me know if there is any issues, thanks!