### PR TITLE
Add default alt text to img

### DIFF
--- a/shared/clients/draft-js/renderer/index.js
+++ b/shared/clients/draft-js/renderer/index.js
@@ -168,7 +168,7 @@ export const createRenderer = (options: Options) => {
         children: Array<Node>,
         data: { src?: string, alt?: string },
         { key }: KeyObj
-      ) => <img key={key} src={data.src} alt={data.alt} />,
+      ) => <img key={key} src={data.src} alt={data.alt || 'Image'} />,
       embed: (children: Array<Node>, data: Object, { key }: KeyObj) => (
         <Embed key={key} {...data} />
       ),


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Closes #4812 

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->

When user uploads the image, the system already automatically set image alt by file name. But for some edge cases there might not have alt text and we need to set a default value, otherwise it breaks the layout. You can find more details on the issue: [Weird image failed rendering in thread body](https://github.com/withspectrum/spectrum/issues/4812)

Before:
![螢幕快照 2019-03-21 下午9 45 37](https://user-images.githubusercontent.com/2755720/54756382-14eaa880-4c23-11e9-9ffa-8a042d21cd4b.png)

After:
![螢幕快照 2019-03-21 下午9 45 56](https://user-images.githubusercontent.com/2755720/54756398-1f0ca700-4c23-11e9-980a-b733c09dd498.png)
