### PR TITLE
Fix editing messages with automatic embeds

### DIFF
--- a/shared/clients/draft-js/links-decorator/core.js
+++ b/shared/clients/draft-js/links-decorator/core.js
@@ -38,7 +38,15 @@ const createLinksDecorator = (
         );
       }, callback);
     }
-    linkStrategy(contentBlock, callback);
+    linkStrategy(contentBlock, (start, end) => {
+      if (
+        contentBlock.entityRanges.find(
+          range => range.offset === start && range.length === end - start
+        )
+      )
+        return;
+      callback(start, end);
+    });
   },
   component: ({
     decoratedText,

--- a/shared/draft-utils/add-embeds-to-draft-js.js
+++ b/shared/draft-utils/add-embeds-to-draft-js.js
@@ -78,17 +78,20 @@ export const addEmbedsToEditorState = (
         mutability: 'MUTABLE',
         type: 'embed',
       };
-      const regexp = new RegExp(REGEXPS[embed.type], 'i');
+      const regexp = new RegExp(REGEXPS[embed.type], 'ig');
+      const text = block.text;
       var match;
-      while ((match = regexp.exec(block.text)) !== null) {
-        // Replace the URL with a space
-        newBlocks[blockIndex].text = `${newBlocks[blockIndex].text.substr(
-          0,
-          match.index
-        )} ${newBlocks[blockIndex].text.substr(match.index + match[0].length)}`;
+      while ((match = regexp.exec(text)) !== null) {
+        const offset = match.index;
+        const length = match[0].length;
+        newBlocks[blockIndex].entityRanges = newBlocks[
+          blockIndex
+        ].entityRanges.filter(
+          entity => entity.offset !== offset || entity.length !== length
+        );
         newBlocks[blockIndex].entityRanges.push({
-          offset: match.index,
-          length: 1,
+          offset,
+          length,
           key: entityKey,
         });
       }

--- a/shared/draft-utils/test/__snapshots__/add-embeds-to-draft-js.test.js.snap
+++ b/shared/draft-utils/test/__snapshots__/add-embeds-to-draft-js.test.js.snap
@@ -9,13 +9,13 @@ Object {
       "entityRanges": Array [
         Object {
           "key": 0,
-          "length": 1,
+          "length": 33,
           "offset": 0,
         },
       ],
       "inlineStyleRanges": Array [],
       "key": "g0000",
-      "text": " ",
+      "text": "https://simplecast.com/s/a1f11d11",
       "type": "unstyled",
     },
   ],
@@ -43,23 +43,64 @@ Object {
       "entityRanges": Array [
         Object {
           "key": 0,
-          "length": 1,
+          "length": 33,
           "offset": 13,
         },
         Object {
           "key": 0,
-          "length": 1,
-          "offset": 33,
+          "length": 33,
+          "offset": 65,
         },
       ],
       "inlineStyleRanges": Array [],
       "key": "g0000",
-      "text": "New podcast!   it is really cool  ",
+      "text": "New podcast! https://simplecast.com/s/a1f11d11 it is really cool https://simplecast.com/s/a1f11d11",
       "type": "unstyled",
     },
   ],
   "entityMap": Object {
     "0": Object {
+      "data": Object {
+        "height": 200,
+        "src": "https://embed.simplecast.com/a1f11d11",
+        "type": "simplecast",
+        "url": "https://embed.simplecast.com/a1f11d11",
+      },
+      "mutability": "MUTABLE",
+      "type": "embed",
+    },
+  },
+}
+`;
+
+exports[`should remove link entities 1`] = `
+Object {
+  "blocks": Array [
+    Object {
+      "data": Object {},
+      "depth": 0,
+      "entityRanges": Array [
+        Object {
+          "key": 1,
+          "length": 33,
+          "offset": 0,
+        },
+      ],
+      "inlineStyleRanges": Array [],
+      "key": "g0000",
+      "text": "https://simplecast.com/s/a1f11d11",
+      "type": "unstyled",
+    },
+  ],
+  "entityMap": Object {
+    "0": Object {
+      "data": Object {
+        "href": "https://simplecast.com/s/a1f11d11",
+      },
+      "mutability": "MUTABLE",
+      "type": "link",
+    },
+    "1": Object {
       "data": Object {
         "height": 200,
         "src": "https://embed.simplecast.com/a1f11d11",

--- a/shared/draft-utils/test/add-embeds-to-draft-js.test.js
+++ b/shared/draft-utils/test/add-embeds-to-draft-js.test.js
@@ -548,3 +548,35 @@ it('should add multiple embeds to text', () => {
   };
   expect(addEmbedsToEditorState(input)).toMatchSnapshot();
 });
+
+it('should remove link entities', () => {
+  const input = {
+    blocks: [
+      {
+        type: 'unstyled',
+        key: 'g0000',
+        data: {},
+        depth: 0,
+        inlineStyleRanges: [],
+        entityRanges: [
+          {
+            offset: 0,
+            length: 33,
+            key: 0,
+          },
+        ],
+        text: 'https://simplecast.com/s/a1f11d11',
+      },
+    ],
+    entityMap: {
+      0: {
+        type: 'link',
+        mutability: 'MUTABLE',
+        data: {
+          href: 'https://simplecast.com/s/a1f11d11',
+        },
+      },
+    },
+  };
+  expect(addEmbedsToEditorState(input)).toMatchSnapshot();
+});


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

In v3 we hid the links that were embedded, but when editing threads or messages with those hidden links we did not show them again.

Together with a patch to `draft-js-export-markdown` that is live on `convert.spectrum.chat` this now works again for both normal embeds and internal embeds :tada: