### PR TITLE
Upsell open chat for team members

### DIFF
--- a/src/views/community/components/communityFeeds.js
+++ b/src/views/community/components/communityFeeds.js
@@ -22,6 +22,8 @@ import { withCurrentUser } from 'src/components/withCurrentUser';
 import JoinCommunity from 'src/components/joinCommunityWrapper';
 import LockedMessages from 'src/views/thread/components/lockedMessages';
 import { FeedsContainer, SidebarSection, InfoContainer } from '../style';
+import OpenChatUpsell from './openChatUpsell';
+import Badge from 'src/components/badges';
 
 type Props = {
   community: CommunityInfoType,
@@ -51,7 +53,12 @@ const Feeds = (props: Props) => {
       changeTab(defaultTab);
     }
 
-    if (tab === 'chat' && !community.watercoolerId) {
+    if (
+      tab === 'chat' &&
+      !community.watercoolerId &&
+      (!community.communityPermissions.isModerator &&
+        !community.communityPermissions.isOwner)
+    ) {
       changeTab('posts');
     }
   };
@@ -63,7 +70,15 @@ const Feeds = (props: Props) => {
   const renderFeed = () => {
     switch (tab) {
       case 'chat': {
-        if (!community.watercoolerId) return null;
+        if (!community.watercoolerId) {
+          if (
+            !community.communityPermissions.isModerator &&
+            !community.communityPermissions.isOwner
+          )
+            return null;
+
+          return <OpenChatUpsell community={community} />;
+        }
         return (
           <React.Fragment>
             <MessagesSubscriber isWatercooler id={community.watercoolerId} />
@@ -172,7 +187,14 @@ const Feeds = (props: Props) => {
   }, []);
 
   const segments = ['posts', 'members', 'info'];
-  if (community.watercoolerId) segments.unshift('chat');
+  if (community.watercoolerId) {
+    segments.unshift('chat');
+  } else if (
+    community.communityPermissions.isModerator ||
+    community.communityPermissions.isOwner
+  ) {
+    segments.splice(1, 0, 'chat');
+  }
 
   // if the community being viewed changes, and the previous community had
   // a watercooler but the next one doesn't, select the posts tab on the new one

--- a/src/views/community/components/communityFeeds.js
+++ b/src/views/community/components/communityFeeds.js
@@ -187,15 +187,13 @@ const Feeds = (props: Props) => {
   }, []);
 
   const segments = ['posts', 'members', 'info'];
-  if (community.watercoolerId) {
-    segments.unshift('chat');
-  } else if (
+  if (
+    community.watercoolerId ||
     community.communityPermissions.isModerator ||
     community.communityPermissions.isOwner
   ) {
-    segments.splice(1, 0, 'chat');
+    segments.unshift('chat');
   }
-
   // if the community being viewed changes, and the previous community had
   // a watercooler but the next one doesn't, select the posts tab on the new one
   useEffect(() => {

--- a/src/views/community/components/openChatUpsell.js
+++ b/src/views/community/components/openChatUpsell.js
@@ -1,0 +1,52 @@
+// @flow
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { FeedsContainer } from '../style';
+import { NullCard } from 'src/components/upsell';
+import {
+  Title,
+  Subtitle,
+  Actions,
+  LargeEmoji,
+} from 'src/components/upsell/style';
+import { PrimaryButton } from 'src/components/button';
+import enableCommunityWatercooler from 'shared/graphql/mutations/community/enableCommunityWatercooler';
+import type { CommunityInfoType } from 'shared/graphql/fragments/community/communityInfo';
+
+type Props = {
+  community: CommunityInfoType,
+  enableCommunityWatercooler: Function,
+};
+
+const OpenChatUpsell = (props: Props) => {
+  const enable = evt => {
+    evt.preventDefault();
+    props.enableCommunityWatercooler({
+      id: props.community.id,
+    });
+  };
+  return (
+    <FeedsContainer
+      style={{ justifyContent: 'center', alignItems: 'center', height: '100%' }}
+    >
+      <NullCard>
+        <LargeEmoji css={{ padding: 0 }}>
+          <span role="img" aria-label="Howdy!">
+            💬
+          </span>
+        </LargeEmoji>
+        <Title>Enable Open Chat</Title>
+        <Subtitle>
+          Show a chat room here where your community can hang out together.
+        </Subtitle>
+        <Actions>
+          <Link to={`/${props.community.slug}/settings`} onClick={enable}>
+            <PrimaryButton>Enable Open Chat</PrimaryButton>
+          </Link>
+        </Actions>
+      </NullCard>
+    </FeedsContainer>
+  );
+};
+
+export default enableCommunityWatercooler(OpenChatUpsell);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

To make sure a higher percentage of communities enable the chat tab, this upsells it to team members of communities that currently have it disabled.

Essentially, it shows the Chat tab as the second tab, and when you click on it it has a big fat button to ernable it properly.