### PR TITLE
Serve fake JS file that hard refreshes page if old JS bundle is fetched

### DIFF
--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -61,6 +61,16 @@ if (process.env.NODE_ENV === 'development') {
   );
 }
 
+// If a file in /static/js is requested, but express.static does not have it,
+// that means the user is on an old version of the app.
+// Serve a piece of JavaScript that hard-reloads the page they are on
+app.get('/static/js/:name', (req, res) => {
+  res.set('Content-Type', 'text/javascript');
+  res.send(
+    'window.alert("You are on an old version of Spectrum. Upgrading!"); window.location.reload(true);'
+  );
+});
+
 app.use(
   rateLimiter({
     max: 13,

--- a/hyperion/index.js
+++ b/hyperion/index.js
@@ -64,6 +64,7 @@ if (process.env.NODE_ENV === 'development') {
 // If a file in /static/js is requested, but express.static does not have it,
 // that means the user is on an old version of the app.
 // Serve a piece of JavaScript that hard-reloads the page they are on
+// $FlowIssue
 app.get('/static/js/:name', (req, res) => {
   res.set('Content-Type', 'text/javascript');
   res.send(


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [ ] Ready for review
- [x] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

This might fix our caching issues where folks app breaks after a new deploy. Gotta test on alpha though for sure!
!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->