### PR TITLE
Let community team members edit threads

### DIFF
--- a/api/models/thread.js
+++ b/api/models/thread.js
@@ -588,9 +588,11 @@ export const editThread = (input: EditThreadInput, userId: string, shouldUpdate:
       {
         content: input.content,
         modifiedAt: shouldUpdate ? new Date() : null,
+        editedBy: userId,
         edits: db.row('edits').append({
           content: db.row('content'),
           timestamp: new Date(),
+          editedBy: db.row('editedBy').default(db.row('creatorId'))
         }),
       },
       { returnChanges: 'always' }

--- a/api/mutations/thread/editThread.js
+++ b/api/mutations/thread/editThread.js
@@ -64,13 +64,15 @@ export default requireAuth(async (_: any, args: Input, ctx: GraphQLContext) => {
     getUserPermissionsInChannel(threadToEvaluate.channelId, user.id),
   ]);
 
+  const canEdit =
+    !channelPermissions.isBlocked &&
+    !communityPermissions.isBlocked &&
+    (threadToEvaluate.creatorId === user.id ||
+      communityPermissions.isModerator ||
+      communityPermissions.isOwner);
   // only the thread creator can edit the thread
   // also prevent deletion if the user was blocked
-  if (
-    threadToEvaluate.creatorId !== user.id ||
-    channelPermissions.isBlocked ||
-    communityPermissions.isBlocked
-  ) {
+  if (!canEdit) {
     trackQueue.add({
       userId: user.id,
       event: events.THREAD_EDITED_FAILED,

--- a/api/queries/thread/editedBy.js
+++ b/api/queries/thread/editedBy.js
@@ -1,0 +1,47 @@
+// @flow
+import type { GraphQLContext } from '../../';
+import type { DBThread } from 'shared/types';
+
+export default async (
+  { editedBy, communityId, channelId }: DBThread,
+  _: any,
+  { loaders }: GraphQLContext
+) => {
+  if (!editedBy) return null;
+  let [
+    user,
+    communityPermissions = {},
+    channelPermissions = {},
+  ] = await Promise.all([
+    loaders.user.load(editedBy),
+    loaders.userPermissionsInCommunity.load([editedBy, communityId]),
+    loaders.userPermissionsInChannel.load([editedBy, channelId]),
+  ]);
+
+  if (!communityPermissions) communityPermissions = {};
+  if (!channelPermissions) channelPermissions = {};
+
+  const isMember = communityPermissions.isMember || channelPermissions.isMember;
+  const isOwner = communityPermissions.isOwner;
+  const isModerator =
+    communityPermissions.isModerator || channelPermissions.isModerator;
+  const isBlocked =
+    channelPermissions.isBlocked || communityPermissions.isBlocked;
+  const reputation = communityPermissions.reputation;
+
+  const roles = [];
+  if (isModerator) roles.push('moderator');
+  if (isOwner) roles.push('admin');
+  if (isBlocked) roles.push('blocked');
+
+  return {
+    id: communityPermissions.id,
+    user,
+    isOwner,
+    isModerator,
+    isBlocked,
+    isMember,
+    reputation,
+    roles,
+  };
+};

--- a/api/queries/thread/index.js
+++ b/api/queries/thread/index.js
@@ -16,6 +16,7 @@ import currentUserLastSeen from './currentUserLastSeen';
 import content from './content';
 import reactions from './reactions';
 import metaImage from './metaImage';
+import editedBy from './editedBy';
 
 import type { DBThread } from 'shared/types';
 
@@ -40,5 +41,6 @@ module.exports = {
     reactions,
     metaImage,
     messageCount: ({ messageCount }: DBThread) => messageCount || 0,
+    editedBy,
   },
 };

--- a/api/types/Thread.js
+++ b/api/types/Thread.js
@@ -29,6 +29,7 @@ const Thread = /* GraphQL */ `
   type Edit {
     timestamp: Date!
     content: ThreadContent!
+    # editedBy: User!
   }
 
   enum ThreadType {
@@ -46,6 +47,7 @@ const Thread = /* GraphQL */ `
     id: ID!
     createdAt: Date!
     modifiedAt: Date
+    editedBy: ThreadParticipant @cost(complexity: 2)
     channel: Channel!
     community: Community! @cost(complexity: 1)
     isPublished: Boolean!

--- a/cypress/integration/thread/action_bar_spec.js
+++ b/cypress/integration/thread/action_bar_spec.js
@@ -230,9 +230,9 @@ describe('action bar renders', () => {
       cy.get('[data-cy="thread-actions-dropdown"]').should('be.visible');
 
       // dropdown controls
-      cy.get('[data-cy="thread-dropdown-edit"]').should('not.be.visible');
       cy.get('[data-cy="thread-dropdown-pin"]').should('not.be.visible');
       cy.get('[data-cy="thread-dropdown-move"]').should('not.be.visible');
+      cy.get('[data-cy="thread-dropdown-edit"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-lock"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-delete"]').should('be.visible');
     });
@@ -271,9 +271,9 @@ describe('action bar renders', () => {
       cy.get('[data-cy="thread-actions-dropdown"]').should('be.visible');
 
       // dropdown controls
-      cy.get('[data-cy="thread-dropdown-edit"]').should('not.be.visible');
       cy.get('[data-cy="thread-dropdown-pin"]').should('not.be.visible');
       cy.get('[data-cy="thread-dropdown-move"]').should('not.be.visible');
+      cy.get('[data-cy="thread-dropdown-edit"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-lock"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-delete"]').should('be.visible');
     });
@@ -312,11 +312,11 @@ describe('action bar renders', () => {
       cy.get('[data-cy="thread-actions-dropdown"]').should('be.visible');
 
       // dropdown controls
-      cy.get('[data-cy="thread-dropdown-edit"]').should('not.be.visible');
       cy.get('[data-cy="thread-dropdown-pin"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-move"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-lock"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-delete"]').should('be.visible');
+      cy.get('[data-cy="thread-dropdown-edit"]').should('be.visible');
     });
 
     it('should lock the thread', () => {
@@ -367,11 +367,11 @@ describe('action bar renders', () => {
       cy.get('[data-cy="thread-actions-dropdown"]').should('be.visible');
 
       // dropdown controls
-      cy.get('[data-cy="thread-dropdown-edit"]').should('not.be.visible');
       cy.get('[data-cy="thread-dropdown-pin"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-move"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-lock"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-delete"]').should('be.visible');
+      cy.get('[data-cy="thread-dropdown-edit"]').should('be.visible');
     });
 
     it('should lock the thread', () => {

--- a/shared/graphql/fragments/thread/threadInfo.js
+++ b/shared/graphql/fragments/thread/threadInfo.js
@@ -25,6 +25,9 @@ export type ThreadInfoType = {
   lastActive: ?string,
   receiveNotifications: boolean,
   currentUserLastSeen: ?string,
+  editedBy?: {
+    ...$Exact<ThreadParticipantType>,
+  },
   author: {
     ...$Exact<ThreadParticipantType>,
   },
@@ -63,6 +66,9 @@ export default gql`
     lastActive
     receiveNotifications
     currentUserLastSeen
+    editedBy {
+      ...threadParticipant
+    }
     author {
       ...threadParticipant
     }

--- a/shared/types.js
+++ b/shared/types.js
@@ -240,6 +240,7 @@ export type DBThread = {
   isLocked: boolean,
   lockedBy?: string,
   lockedAt?: Date,
+  editedBy?: string,
   lastActive: Date,
   modifiedAt?: Date,
   deletedAt?: string,

--- a/src/components/inboxThread/header/threadHeader.js
+++ b/src/components/inboxThread/header/threadHeader.js
@@ -25,7 +25,15 @@ class Header extends React.Component<HeaderProps> {
     const {
       active,
       viewContext,
-      thread: { author, community, channel, id, watercooler, isLocked },
+      thread: {
+        author,
+        community,
+        channel,
+        id,
+        watercooler,
+        isLocked,
+        editedBy,
+      },
     } = this.props;
 
     const isPinned = id === community.pinnedThreadId;

--- a/src/views/thread/components/actionBar.js
+++ b/src/views/thread/components/actionBar.js
@@ -154,8 +154,20 @@ class ActionBar extends React.Component<Props, State> {
   };
 
   shouldRenderEditThreadAction = () => {
-    const { isThreadAuthor } = this.getThreadActionPermissions();
-    return isThreadAuthor;
+    const {
+      isThreadAuthor,
+      isChannelModerator,
+      isCommunityModerator,
+      isChannelOwner,
+      isCommunityOwner,
+    } = this.getThreadActionPermissions();
+    return (
+      isThreadAuthor ||
+      isChannelModerator ||
+      isCommunityModerator ||
+      isChannelOwner ||
+      isCommunityOwner
+    );
   };
 
   shouldRenderMoveThreadAction = () => {

--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -466,6 +466,9 @@ class ThreadDetailPure extends React.Component<Props, State> {
                         Date.now(),
                         editedTimestamp
                       ).toLowerCase()}
+                      {thread.editedBy &&
+                        thread.editedBy.user.id !== thread.author.user.id &&
+                        ` by @${thread.editedBy.user.username}`}
                       )
                     </React.Fragment>
                   )}


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

**Release notes for users (delete if codebase-only change)**
- Community team members can now edit threads of users posted in their community!

**Related issues (delete if you don't know of any)**
Closes #4856

![Imgur](https://i.imgur.com/3oUEvHR.png)

Note that this does not do any blocking of users editing threads that were edited by team members. I think we do not need that for the first version.