### PR TITLE
Fix edit thread UI

### DIFF
--- a/src/views/thread/container/index.js
+++ b/src/views/thread/container/index.js
@@ -105,6 +105,7 @@ const ThreadContainer = (props: Props) => {
   const [mentionSuggestions, setMentionSuggestions] = useState([
     thread.author.user,
   ]);
+  const [isEditing, setEditing] = useState(false);
   const updateMentionSuggestions = (thread: GetThreadType) => {
     const { messageConnection, author } = thread;
 
@@ -213,60 +214,71 @@ const ThreadContainer = (props: Props) => {
                 <StickyHeader thread={thread} />
               </ErrorBoundary>
 
-              <ThreadDetail thread={thread} />
-
-              <MessagesSubscriber
-                id={thread.id}
+              <ThreadDetail
                 thread={thread}
-                isWatercooler={thread.watercooler} // used in the graphql query to always fetch the latest messages
-                onMessagesLoaded={updateMentionSuggestions}
+                toggleEdit={() => setEditing(!isEditing)}
               />
 
-              {canChat && (
-                <ChatInputWrapper>
-                  <ChatInput
-                    threadType="story"
-                    threadId={thread.id}
-                    participants={mentionSuggestions}
+              {!isEditing && (
+                <React.Fragment>
+                  <MessagesSubscriber
+                    id={thread.id}
+                    thread={thread}
+                    isWatercooler={thread.watercooler} // used in the graphql query to always fetch the latest messages
+                    onMessagesLoaded={updateMentionSuggestions}
                   />
-                </ChatInputWrapper>
-              )}
 
-              {!canChat && !isLocked && (
-                <ChatInputWrapper>
-                  <JoinCommunity
-                    community={community}
-                    render={({ isLoading }) => (
+                  {canChat && (
+                    <ChatInputWrapper>
+                      <ChatInput
+                        threadType="story"
+                        threadId={thread.id}
+                        participants={mentionSuggestions}
+                      />
+                    </ChatInputWrapper>
+                  )}
+
+                  {!canChat && !isLocked && (
+                    <ChatInputWrapper>
+                      <JoinCommunity
+                        community={community}
+                        render={({ isLoading }) => (
+                          <LockedMessages>
+                            <PrimaryOutlineButton
+                              isLoading={isLoading}
+                              icon={'door-enter'}
+                              data-cy="join-community-chat-upsell"
+                            >
+                              {isLoading
+                                ? 'Joining...'
+                                : 'Join community to chat'}
+                            </PrimaryOutlineButton>
+                          </LockedMessages>
+                        )}
+                      />
+                    </ChatInputWrapper>
+                  )}
+
+                  {isLocked && (
+                    <ChatInputWrapper>
                       <LockedMessages>
-                        <PrimaryOutlineButton
-                          isLoading={isLoading}
-                          icon={'door-enter'}
-                          data-cy="join-community-chat-upsell"
-                        >
-                          {isLoading ? 'Joining...' : 'Join community to chat'}
-                        </PrimaryOutlineButton>
+                        <Icon glyph={'private'} size={24} />
+                        <LockedText>
+                          This conversation has been locked
+                        </LockedText>
                       </LockedMessages>
-                    )}
-                  />
-                </ChatInputWrapper>
-              )}
+                    </ChatInputWrapper>
+                  )}
 
-              {isLocked && (
-                <ChatInputWrapper>
-                  <LockedMessages>
-                    <Icon glyph={'private'} size={24} />
-                    <LockedText>This conversation has been locked</LockedText>
-                  </LockedMessages>
-                </ChatInputWrapper>
-              )}
-
-              {channel.isArchived && (
-                <ChatInputWrapper>
-                  <LockedMessages>
-                    <Icon glyph={'private'} size={24} />
-                    <LockedText>This channel has been archived</LockedText>
-                  </LockedMessages>
-                </ChatInputWrapper>
+                  {channel.isArchived && (
+                    <ChatInputWrapper>
+                      <LockedMessages>
+                        <Icon glyph={'private'} size={24} />
+                        <LockedText>This channel has been archived</LockedText>
+                      </LockedMessages>
+                    </ChatInputWrapper>
+                  )}
+                </React.Fragment>
               )}
             </Stretch>
           </PrimaryColumn>


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

The chat input would overlay the editing inputs, causing people to think they had to press "Send" to save the edit even though that would send a message.

This fixes it by hiding the messages and chat input while editing.

**Before**

<img width="602" alt="Screenshot 2019-03-23 at 10 44 06" src="https://user-images.githubusercontent.com/7525670/54864513-a60f6b80-4d58-11e9-847f-d9ee3faf52f3.png">

**After**

<img width="602" alt="Screenshot 2019-03-23 at 10 43 19" src="https://user-images.githubusercontent.com/7525670/54864516-a871c580-4d58-11e9-9415-61a3ca783e17.png">


<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->