### PR TITLE
Improve thread headers

### DIFF
--- a/src/components/badges/style.js
+++ b/src/components/badges/style.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Gradient } from 'src/components/globals';
 
 export const Span = styled.span`
-  display: flex;
+  display: inline-flex;
   color: ${theme.text.reverse};
   background-color: ${theme.text.alt};
   text-transform: uppercase;

--- a/src/components/entities/listItems/style.js
+++ b/src/components/entities/listItems/style.js
@@ -65,7 +65,8 @@ export const Label = styled.div`
   font-size: 15px;
   font-weight: 600;
   line-height: 1.2;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   ${Truncate};
 
   .icon {

--- a/src/components/entities/listItems/user.js
+++ b/src/components/entities/listItems/user.js
@@ -89,7 +89,10 @@ const User = (props: Props) => {
           {name && (
             <Label title={name}>
               {name}
-              {badges && badges.map((b, i) => <Badge key={i} type={b} />)}
+              {badges &&
+                badges.map((b, i) => (
+                  <Badge style={{ marginLeft: '8px' }} key={i} type={b} />
+                ))}
             </Label>
           )}
 

--- a/src/views/thread/components/stickyHeader.js
+++ b/src/views/thread/components/stickyHeader.js
@@ -3,14 +3,10 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import { Link } from 'react-router-dom';
-import {
-  CommunityHoverProfile,
-  ChannelHoverProfile,
-} from 'src/components/hoverProfile';
+import { UserHoverProfile } from 'src/components/hoverProfile';
 import { LikeButton } from 'src/components/threadLikes';
 import { convertTimestampToDate } from 'shared/time-formatting';
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
-import { CommunityAvatar } from 'src/components/avatar';
 import getThreadLink from 'src/helpers/get-thread-link';
 import { useAppScroller } from 'src/hooks/useAppScroller';
 import {
@@ -39,23 +35,16 @@ const StickyHeader = (props: Props) => {
     <StickyHeaderContainer>
       <StickyHeaderContent onClick={scrollToTop}>
         <CommunityHeaderMeta>
-          <CommunityAvatar community={community} size={32} />
           <CommunityHeaderMetaCol>
             <CommunityHeaderName>{thread.content.title}</CommunityHeaderName>
             <CommunityHeaderSubtitle>
-              <CommunityHoverProfile id={community.id}>
-                <Link to={`/${community.slug}`}>{community.name}</Link>
-              </CommunityHoverProfile>
-              <span>/</span>
-              <ChannelHoverProfile id={channel.id}>
-                <Link to={`/${community.slug}/${channel.slug}`}>
-                  {channel.name}
+              <UserHoverProfile username={thread.author.user.username}>
+                <Link to={`/users/${thread.author.user.username}`}>
+                  {thread.author.user.name} (@{thread.author.user.username})
                 </Link>
-              </ChannelHoverProfile>
-              <Link to={getThreadLink(thread)}>
-                &nbsp;
-                {`· ${timestamp}`}
-              </Link>
+              </UserHoverProfile>
+              &nbsp;·&nbsp;
+              <Link to={getThreadLink(thread)}>{timestamp}</Link>
             </CommunityHeaderSubtitle>
           </CommunityHeaderMetaCol>
         </CommunityHeaderMeta>

--- a/src/views/thread/components/stickyHeader.js
+++ b/src/views/thread/components/stickyHeader.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import compose from 'recompose/compose';
 import { Link } from 'react-router-dom';
 import { UserHoverProfile } from 'src/components/hoverProfile';
+import { UserAvatar } from 'src/components/avatar';
 import { LikeButton } from 'src/components/threadLikes';
 import { convertTimestampToDate } from 'shared/time-formatting';
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
@@ -35,6 +36,11 @@ const StickyHeader = (props: Props) => {
     <StickyHeaderContainer>
       <StickyHeaderContent onClick={scrollToTop}>
         <CommunityHeaderMeta>
+          <UserAvatar
+            showHoverProfile
+            showOnlineStatus
+            username={thread.author.user.username}
+          />
           <CommunityHeaderMetaCol>
             <CommunityHeaderName>{thread.content.title}</CommunityHeaderName>
             <CommunityHeaderSubtitle>

--- a/src/views/thread/components/stickyHeader.js
+++ b/src/views/thread/components/stickyHeader.js
@@ -26,7 +26,7 @@ type Props = {
 const StickyHeader = (props: Props) => {
   const { thread } = props;
   const { scrollToTop } = useAppScroller();
-  const { channel, community } = thread;
+  const { channel } = thread;
 
   const createdAt = new Date(thread.createdAt).getTime();
   const timestamp = convertTimestampToDate(createdAt);

--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -439,6 +439,7 @@ class ThreadDetailPure extends React.Component<Props, State> {
                   name={author.user.name}
                   username={author.user.username}
                   profilePhoto={author.user.profilePhoto}
+                  badges={author.roles}
                   isCurrentUser={
                     currentUser && author.user.id === currentUser.id
                   }

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -564,7 +564,6 @@ export const CommunityHeaderMetaCol = styled.div`
   flex-wrap: nowrap;
   align-items: flex-start;
   align-self: flex-start;
-  margin-left: 12px;
   max-width: 100%;
   padding-right: 64px;
 `;

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -564,6 +564,7 @@ export const CommunityHeaderMetaCol = styled.div`
   flex-wrap: nowrap;
   align-items: flex-start;
   align-self: flex-start;
+  margin-left: 12px;
   max-width: 100%;
   padding-right: 64px;
 `;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Changes:

- Show badges next to author information on threads (not sure why this was removed)
- Remove duplicated community information from sticky header (we already have the sidebar that shows all of that information), and instead show the author information

Before:

![Screenshot 2019-03-25 at 11 21 21](https://user-images.githubusercontent.com/7525670/54912097-2ae0bd80-4ef0-11e9-837d-6055c6cf6077.png)

After:

![Screenshot 2019-03-25 at 11 26 12](https://user-images.githubusercontent.com/7525670/54912396-d5f17700-4ef0-11e9-98e4-d6427e8a3392.png)
