### PR TITLE
Fetch community metadata for user community connection

### DIFF
--- a/cypress/integration/channel/settings/private_invite_link_spec.js
+++ b/cypress/integration/channel/settings/private_invite_link_spec.js
@@ -13,9 +13,7 @@ const enable = () => {
 
   cy.get('[data-cy="login-with-token-settings"]').scrollIntoView();
 
-  cy.get('[data-cy="toggle-token-link-invites-unchecked"]')
-    .should('be.visible')
-    .click();
+  cy.get('[data-cy="toggle-token-link-invites-unchecked"]').click();
 
   cy.get('[data-cy="join-link-input"]').should('be.visible');
 };
@@ -51,9 +49,7 @@ describe('private channel invite link settings', () => {
       });
 
     // disable
-    cy.get('[data-cy="toggle-token-link-invites-checked"]')
-      .should('be.visible')
-      .click();
+    cy.get('[data-cy="toggle-token-link-invites-checked"]').click();
 
     cy.get('[data-cy="join-link-input"]').should('not.be.visible');
   });

--- a/cypress/integration/thread/action_bar_spec.js
+++ b/cypress/integration/thread/action_bar_spec.js
@@ -95,7 +95,6 @@ describe('action bar renders', () => {
 
     it('should render', () => {
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
       cy.get('[data-cy="thread-facebook-button"]').should('be.visible');
       cy.get('[data-cy="thread-tweet-button"]').should('be.visible');
       cy.get('[data-cy="thread-copy-link-button"]').should('be.visible');
@@ -114,7 +113,6 @@ describe('action bar renders', () => {
 
     it('should render', () => {
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
       cy.get('[data-cy="thread-facebook-button"]').should('be.visible');
       cy.get('[data-cy="thread-tweet-button"]').should('be.visible');
       cy.get('[data-cy="thread-copy-link-button"]').should('be.visible');
@@ -133,7 +131,6 @@ describe('action bar renders', () => {
 
     it('should render', () => {
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
       cy.get('[data-cy="thread-facebook-button"]').should('not.be.visible');
       cy.get('[data-cy="thread-tweet-button"]').should('not.be.visible');
       cy.get('[data-cy="thread-copy-link-button"]').should('be.visible');
@@ -152,7 +149,6 @@ describe('action bar renders', () => {
 
     it('should render', () => {
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
       cy.get('[data-cy="thread-facebook-button"]').should('be.visible');
       cy.get('[data-cy="thread-tweet-button"]').should('be.visible');
       cy.get('[data-cy="thread-copy-link-button"]').should('be.visible');
@@ -167,6 +163,7 @@ describe('action bar renders', () => {
       cy.get('[data-cy="thread-dropdown-move"]').should('not.be.visible');
       cy.get('[data-cy="thread-dropdown-lock"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-delete"]').should('be.visible');
+      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
     });
 
     it('should lock the thread', () => {
@@ -220,7 +217,6 @@ describe('action bar renders', () => {
 
     it('should render', () => {
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
       cy.get('[data-cy="thread-facebook-button"]').should('be.visible');
       cy.get('[data-cy="thread-tweet-button"]').should('be.visible');
       cy.get('[data-cy="thread-copy-link-button"]').should('be.visible');
@@ -235,6 +231,7 @@ describe('action bar renders', () => {
       cy.get('[data-cy="thread-dropdown-edit"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-lock"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-delete"]').should('be.visible');
+      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
     });
 
     it('should lock the thread', () => {
@@ -261,7 +258,6 @@ describe('action bar renders', () => {
 
     it('should render', () => {
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
       cy.get('[data-cy="thread-facebook-button"]').should('be.visible');
       cy.get('[data-cy="thread-tweet-button"]').should('be.visible');
       cy.get('[data-cy="thread-copy-link-button"]').should('be.visible');
@@ -276,6 +272,7 @@ describe('action bar renders', () => {
       cy.get('[data-cy="thread-dropdown-edit"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-lock"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-delete"]').should('be.visible');
+      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
     });
 
     it('should lock the thread', () => {
@@ -302,7 +299,6 @@ describe('action bar renders', () => {
 
     it('should render', () => {
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
       cy.get('[data-cy="thread-facebook-button"]').should('be.visible');
       cy.get('[data-cy="thread-tweet-button"]').should('be.visible');
       cy.get('[data-cy="thread-copy-link-button"]').should('be.visible');
@@ -317,6 +313,7 @@ describe('action bar renders', () => {
       cy.get('[data-cy="thread-dropdown-lock"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-delete"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-edit"]').should('be.visible');
+      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
     });
 
     it('should lock the thread', () => {
@@ -357,7 +354,6 @@ describe('action bar renders', () => {
 
     it('should render', () => {
       cy.get('[data-cy="thread-view"]').should('be.visible');
-      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
       cy.get('[data-cy="thread-facebook-button"]').should('be.visible');
       cy.get('[data-cy="thread-tweet-button"]').should('be.visible');
       cy.get('[data-cy="thread-copy-link-button"]').should('be.visible');
@@ -372,6 +368,7 @@ describe('action bar renders', () => {
       cy.get('[data-cy="thread-dropdown-lock"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-delete"]').should('be.visible');
       cy.get('[data-cy="thread-dropdown-edit"]').should('be.visible');
+      cy.get('[data-cy="thread-notifications-toggle"]').should('be.visible');
     });
 
     it('should lock the thread', () => {

--- a/shared/graphql/fragments/user/userCommunityConnection.js
+++ b/shared/graphql/fragments/user/userCommunityConnection.js
@@ -1,11 +1,14 @@
 // @flow
 import gql from 'graphql-tag';
 import communityInfoFragment from '../community/communityInfo';
+import communityMetaDataFragment from '../community/communityMetaData';
 import type { CommunityInfoType } from '../community/communityInfo';
+import type { CommunityMetaDataType } from '../community/communityMetaData';
 
 type Edge = {
   node: {
     ...$Exact<CommunityInfoType>,
+    ...$Exact<CommunityMetaDataType>,
     contextPermissions: {
       communityId: string,
       isOwner: boolean,
@@ -35,6 +38,7 @@ export default gql`
       edges {
         node {
           ...communityInfo
+          ...communityMetaData
           contextPermissions {
             communityId
             isOwner
@@ -45,5 +49,6 @@ export default gql`
       }
     }
   }
+  ${communityMetaDataFragment}
   ${communityInfoFragment}
 `;

--- a/shared/graphql/queries/user/getUserCommunityConnection.js
+++ b/shared/graphql/queries/user/getUserCommunityConnection.js
@@ -47,7 +47,7 @@ const getUserCommunityConnectionOptions = {
 export const getCurrentUserCommunityConnection = graphql(
   getCurrentUserCommunityConnectionQuery,
   {
-    options: { fetchPolicy: 'cache-and-network' },
+    options: { fetchPolicy: 'cache-first' },
     props: props => ({
       ...props,
       subscribeToUpdatedCommunities: communityIds => {


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

We used to not fetch the community metadata for the user community connection because we did not display any of it unless you visited a community page, which was not very common, and it was quite expensive to calculate.

Now, we actually do display this everywhere and it is cached for a long time so it's not expensive to fetch. By also fetching this from the community connection, the frontend won't do another request to load the community data when switching between communities, heavily reducing the number of API requests we are seeing.