### PR TITLE
Use clientside routing for spectrum urls

### DIFF
--- a/shared/clients/draft-js/links-decorator/index.js
+++ b/shared/clients/draft-js/links-decorator/index.js
@@ -1,11 +1,21 @@
 // @flow
 import React from 'react';
+import { Link } from 'react-router-dom';
 import createLinksDecorator, {
   type LinksDecoratorComponentProps,
 } from './core';
+import { SPECTRUM_URLS } from 'shared/regexps';
 
-export default createLinksDecorator((props: LinksDecoratorComponentProps) => (
-  <a href={props.href} target="_blank" rel="noopener noreferrer">
-    {props.children}
-  </a>
-));
+export default createLinksDecorator((props: LinksDecoratorComponentProps) => {
+  const regexp = new RegExp(SPECTRUM_URLS, 'ig');
+  const match = regexp.exec(props.href);
+
+  if (match && match[0] && match[1])
+    return <Link to={match[1]}>{props.children}</Link>;
+
+  return (
+    <a href={props.href} target={'_blank'} rel={'noopener noreferrer'}>
+      {props.children}
+    </a>
+  );
+});

--- a/shared/clients/draft-js/renderer/index.js
+++ b/shared/clients/draft-js/renderer/index.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Highlight, { defaultProps } from 'prism-react-renderer';
 import { Line, Paragraph, BlockQuote } from 'src/components/message/style';
 import {
@@ -13,6 +14,7 @@ import { hasStringElements } from '../utils/hasStringElements';
 import mentionsDecorator from '../mentions-decorator';
 import linksDecorator from '../links-decorator';
 import type { Node } from 'react';
+import { SPECTRUM_URLS } from 'shared/regexps';
 import type { KeyObj, KeysObj, DataObj } from '../message/types';
 import type {
   EmbedData,
@@ -159,16 +161,23 @@ export const createRenderer = (options: Options) => {
       ),
     },
     entities: {
-      LINK: (children: Array<Node>, data: DataObj, { key }: KeyObj) => (
-        <a
-          key={key}
-          href={data.url || data.href}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {children}
-        </a>
-      ),
+      LINK: (children: Array<Node>, data: DataObj, { key }: KeyObj) => {
+        const regexp = new RegExp(SPECTRUM_URLS, 'ig');
+        const match = regexp.exec(data.url || data.href);
+        if (match && match[0] && match[1])
+          return <Link to={match[1]}>{children}</Link>;
+
+        return (
+          <a
+            key={key}
+            href={data.url || data.href}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {children}
+          </a>
+        );
+      },
       IMAGE: (
         children: Array<Node>,
         data: { src?: string, alt?: string },

--- a/shared/clients/draft-js/renderer/index.js
+++ b/shared/clients/draft-js/renderer/index.js
@@ -162,21 +162,21 @@ export const createRenderer = (options: Options) => {
     },
     entities: {
       LINK: (children: Array<Node>, data: DataObj, { key }: KeyObj) => {
-        const regexp = new RegExp(SPECTRUM_URLS, 'ig');
-        const match = regexp.exec(data.url || data.href);
-        if (match && match[0] && match[1])
-          return <Link to={match[1]}>{children}</Link>;
+        const link = data.url || data.href;
 
-        return (
-          <a
-            key={key}
-            href={data.url || data.href}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {children}
-          </a>
-        );
+        if (typeof link !== 'string') {
+          return (
+            <a key={key} href={link} target="_blank" rel="noopener noreferrer">
+              {children}
+            </a>
+          );
+        }
+
+        const regexp = new RegExp(SPECTRUM_URLS, 'ig');
+        const match = regexp.exec(link);
+        if (match && match[0] && match[1]) {
+          return <Link to={match[1]}>{children}</Link>;
+        }
       },
       IMAGE: (
         children: Array<Node>,

--- a/shared/regexps.js
+++ b/shared/regexps.js
@@ -3,3 +3,4 @@
 module.exports.MENTIONS = /\/?\B@[a-z0-9._-]+[a-z0-9_-]/gi;
 module.exports.URL = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/=]*)/gi;
 module.exports.RELATIVE_URL = /^\/([^\/].*|$)/g;
+module.exports.SPECTRUM_URLS = /(?:(?:https?:\/\/)?|\B)(?:spectrum\.chat|localhost:3000)(\/[A-Za-z0-9\-\._~:\/\?#\[\]@!$&'\(\)\*\+,;\=]*)?/gi;


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Closes #4912 

@mxstbr will definitely need your eye on this, but in my initial testing this is a really nice quality of life improvement. On-site links don't open in new tabs and use the `<Link>` component for fast clientside routing.