### PR TITLE
Add actions dropdown to thread sticky header

### DIFF
--- a/cypress/integration/channel/view/membership_spec.js
+++ b/cypress/integration/channel/view/membership_spec.js
@@ -25,20 +25,26 @@ const QUIET_USER_ID = constants.QUIET_USER_ID;
 
 const leave = () => {
   cy.get('[data-cy="channel-leave-button"]')
+    .last()
     .should('be.visible')
     .contains('Member');
 
-  cy.get('[data-cy="channel-leave-button"]').click();
+  cy.get('[data-cy="channel-leave-button"]')
+    .last()
+    .click();
 
   cy.get('[data-cy="channel-join-button"]').contains(`Join channel`);
 };
 
 const join = () => {
   cy.get('[data-cy="channel-join-button"]')
+    .last()
     .should('be.visible')
     .contains('Join channel');
 
-  cy.get('[data-cy="channel-join-button"]').click();
+  cy.get('[data-cy="channel-join-button"]')
+    .last()
+    .click();
 
   cy.get('[data-cy="channel-leave-button"]').contains(`Member`);
 };

--- a/cypress/integration/thread/action_bar_spec.js
+++ b/cypress/integration/thread/action_bar_spec.js
@@ -29,26 +29,36 @@ const memberInChannelUser = data.users.find(u => u.id === constants.BRYN_ID);
 const lockThread = () => {
   // lock the thread
   cy.get('[data-cy="thread-dropdown-lock"]').contains('Lock chat');
-  cy.get('[data-cy="thread-dropdown-lock"]').click();
+  cy.get('[data-cy="thread-dropdown-lock"]')
+    .first()
+    .click();
   cy.get('[data-cy="thread-dropdown-lock"]').contains('Unlock chat');
 
   // unlock the thread
-  cy.get('[data-cy="thread-dropdown-lock"]').click();
+  cy.get('[data-cy="thread-dropdown-lock"]')
+    .first()
+    .click();
   cy.get('[data-cy="thread-dropdown-lock"]').contains('Lock chat');
 };
 
 const pinThread = () => {
   // pin the thread
-  cy.get('[data-cy="thread-dropdown-pin"]').click();
+  cy.get('[data-cy="thread-dropdown-pin"]')
+    .first()
+    .click();
   cy.get('[data-cy="thread-dropdown-pin"]').contains('Unpin');
 
   // unpin the thread
-  cy.get('[data-cy="thread-dropdown-pin"]').click();
+  cy.get('[data-cy="thread-dropdown-pin"]')
+    .first()
+    .click();
   cy.get('[data-cy="thread-dropdown-pin"]').contains('Pin');
 };
 
 const triggerThreadDelete = () => {
-  cy.get('[data-cy="thread-dropdown-delete"]').click();
+  cy.get('[data-cy="thread-dropdown-delete"]')
+    .first()
+    .click();
   cy.get('[data-cy="delete-button"]').should('be.visible');
   cy.get('div.ReactModal__Overlay')
     .should('be.visible')
@@ -56,7 +66,9 @@ const triggerThreadDelete = () => {
 };
 
 const triggerMovingThread = () => {
-  cy.get('[data-cy="thread-dropdown-move"]').click();
+  cy.get('[data-cy="thread-dropdown-move"]')
+    .first()
+    .click();
   cy.get('[data-cy="move-thread-modal"]').should('be.visible');
   cy.get('div.ReactModal__Overlay')
     .should('be.visible')
@@ -65,8 +77,9 @@ const triggerMovingThread = () => {
 
 const openSettingsDropdown = () => {
   cy.get('[data-cy="thread-actions-dropdown-trigger"]')
+    .last()
     .should('be.visible')
-    .click();
+    .click({ force: true });
 };
 
 describe('action bar renders', () => {

--- a/src/views/thread/components/actionBar.js
+++ b/src/views/thread/components/actionBar.js
@@ -35,7 +35,6 @@ type Props = {
   toggleEdit: Function,
   saveEdit: Function,
   pinThread: Function,
-  triggerDelete: Function,
   threadLock: Function,
   isSavingEdit: boolean,
   title: string,
@@ -177,7 +176,6 @@ class ActionBar extends React.Component<Props> {
               lockThread={this.props.threadLock}
               isLockingThread={this.props.isLockingThread}
               isPinningThread={this.props.isPinningThread}
-              triggerDelete={this.props.triggerDelete}
             />
           </div>
         </ActionBarContainer>

--- a/src/views/thread/components/actionBar.js
+++ b/src/views/thread/components/actionBar.js
@@ -10,7 +10,6 @@ import compose from 'recompose/compose';
 import { PrimaryOutlineButton, TextButton } from 'src/components/button';
 import { LikeButton } from 'src/components/threadLikes';
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
-import toggleThreadNotificationsMutation from 'shared/graphql/mutations/thread/toggleThreadNotifications';
 import { track, events } from 'src/helpers/analytics';
 import getThreadLink from 'src/helpers/get-thread-link';
 import type { Dispatch } from 'redux';
@@ -33,10 +32,8 @@ type Props = {
   currentUser: Object,
   isEditing: boolean,
   dispatch: Dispatch<Object>,
-  toggleThreadNotifications: Function,
   toggleEdit: Function,
   saveEdit: Function,
-  togglePinThread: Function,
   pinThread: Function,
   triggerDelete: Function,
   threadLock: Function,
@@ -180,7 +177,6 @@ class ActionBar extends React.Component<Props> {
               lockThread={this.props.threadLock}
               isLockingThread={this.props.isLockingThread}
               isPinningThread={this.props.isPinningThread}
-              togglePinThread={this.props.togglePinThread}
               triggerDelete={this.props.triggerDelete}
             />
           </div>
@@ -190,7 +186,4 @@ class ActionBar extends React.Component<Props> {
   }
 }
 
-export default compose(
-  connect(),
-  toggleThreadNotificationsMutation
-)(ActionBar);
+export default compose(connect())(ActionBar);

--- a/src/views/thread/components/actionsDropdown.js
+++ b/src/views/thread/components/actionsDropdown.js
@@ -20,7 +20,6 @@ type Props = {
   toggleEdit: Function,
   isLockingThread: boolean,
   lockThread: Function,
-  triggerDelete: Function,
   // Injected
   currentUser: Object,
   dispatch: Function,
@@ -38,7 +37,6 @@ const ActionsDropdown = (props: Props) => {
     pinThread,
     isLockingThread,
     lockThread,
-    triggerDelete,
   } = props;
   if (!currentUser) return null;
 
@@ -136,6 +134,41 @@ const ActionsDropdown = (props: Props) => {
         setIsPinningThread(false);
         dispatch(addToastWithTimeout('error', err.message));
       });
+  };
+
+  const triggerDelete = e => {
+    e.preventDefault();
+
+    let message;
+
+    if (isCommunityOwner && !thread.isAuthor) {
+      message = `You are about to delete another person's thread. As the owner of the ${
+        thread.community.name
+      } community, you have permission to do this. The thread author will be notified that this thread was deleted.`;
+    } else if (isChannelOwner && !thread.isAuthor) {
+      message = `You are about to delete another person's thread. As the owner of the ${
+        thread.channel.name
+      } channel, you have permission to do this. The thread author will be notified that this thread was deleted.`;
+    } else {
+      message = 'Are you sure you want to delete this thread?';
+    }
+
+    track(events.THREAD_DELETED_INITED, {
+      thread: transformations.analyticsThread(thread),
+      channel: transformations.analyticsChannel(thread.channel),
+      community: transformations.analyticsCommunity(thread.community),
+    });
+
+    return dispatch(
+      openModal('DELETE_DOUBLE_CHECK_MODAL', {
+        id: thread.id,
+        entity: 'thread',
+        message,
+        extraProps: {
+          thread,
+        },
+      })
+    );
   };
 
   const [flyoutOpen, setFlyoutOpen] = useState(false);

--- a/src/views/thread/components/stickyHeader.js
+++ b/src/views/thread/components/stickyHeader.js
@@ -53,15 +53,7 @@ const StickyHeader = (props: Props) => {
 
       {channel.channelPermissions.isMember && (
         <StickyHeaderActionsContainer>
-          <ActionsDropdown
-            thread={thread}
-            // toggleEdit={this.props.toggleEdit}
-            // lockThread={this.props.threadLock}
-            // isLockingThread={this.props.isLockingThread}
-            // isPinningThread={this.props.isPinningThread}
-            // togglePinThread={this.props.togglePinThread}
-            // triggerDelete={this.props.triggerDelete}
-          />
+          <ActionsDropdown thread={thread} />
           <LikeButton thread={thread} />
         </StickyHeaderActionsContainer>
       )}

--- a/src/views/thread/components/stickyHeader.js
+++ b/src/views/thread/components/stickyHeader.js
@@ -10,6 +10,7 @@ import { convertTimestampToDate } from 'shared/time-formatting';
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
 import getThreadLink from 'src/helpers/get-thread-link';
 import { useAppScroller } from 'src/hooks/useAppScroller';
+import ActionsDropdown from './actionsDropdown';
 import {
   StickyHeaderContent,
   CommunityHeaderName,
@@ -52,6 +53,15 @@ const StickyHeader = (props: Props) => {
 
       {channel.channelPermissions.isMember && (
         <StickyHeaderActionsContainer>
+          <ActionsDropdown
+            thread={thread}
+            // toggleEdit={this.props.toggleEdit}
+            // lockThread={this.props.threadLock}
+            // isLockingThread={this.props.isLockingThread}
+            // isPinningThread={this.props.isPinningThread}
+            // togglePinThread={this.props.togglePinThread}
+            // triggerDelete={this.props.triggerDelete}
+          />
           <LikeButton thread={thread} />
         </StickyHeaderActionsContainer>
       )}

--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -140,46 +140,6 @@ class ThreadDetailPure extends React.Component<Props, State> {
       });
   };
 
-  triggerDelete = e => {
-    e.preventDefault();
-    const { thread, dispatch } = this.props;
-
-    const threadId = thread.id;
-    const isChannelOwner = thread.channel.channelPermissions.isOwner;
-    const isCommunityOwner = thread.community.communityPermissions.isOwner;
-
-    let message;
-
-    if (isCommunityOwner && !thread.isAuthor) {
-      message = `You are about to delete another person's thread. As the owner of the ${
-        thread.community.name
-      } community, you have permission to do this. The thread author will be notified that this thread was deleted.`;
-    } else if (isChannelOwner && !thread.isAuthor) {
-      message = `You are about to delete another person's thread. As the owner of the ${
-        thread.channel.name
-      } channel, you have permission to do this. The thread author will be notified that this thread was deleted.`;
-    } else {
-      message = 'Are you sure you want to delete this thread?';
-    }
-
-    track(events.THREAD_DELETED_INITED, {
-      thread: transformations.analyticsThread(thread),
-      channel: transformations.analyticsChannel(thread.channel),
-      community: transformations.analyticsCommunity(thread.community),
-    });
-
-    return dispatch(
-      openModal('DELETE_DOUBLE_CHECK_MODAL', {
-        id: threadId,
-        entity: 'thread',
-        message,
-        extraProps: {
-          thread,
-        },
-      })
-    );
-  };
-
   toggleEdit = () => {
     const { isEditing } = this.state;
     const { thread } = this.props;
@@ -451,7 +411,6 @@ class ThreadDetailPure extends React.Component<Props, State> {
             saveEdit={this.saveEdit}
             isSavingEdit={isSavingEdit}
             threadLock={this.threadLock}
-            triggerDelete={this.triggerDelete}
             isEditing={isEditing}
             title={this.state.title}
             isLockingThread={isLockingThread}

--- a/src/views/thread/components/threadDetail.js
+++ b/src/views/thread/components/threadDetail.js
@@ -11,7 +11,6 @@ import { addToastWithTimeout } from 'src/actions/toasts';
 import setThreadLockMutation from 'shared/graphql/mutations/thread/lockThread';
 import deleteThreadMutation from 'shared/graphql/mutations/thread/deleteThread';
 import editThreadMutation from 'shared/graphql/mutations/thread/editThread';
-import pinThreadMutation from 'shared/graphql/mutations/community/pinCommunityThread';
 import uploadImageMutation from 'shared/graphql/mutations/uploadImage';
 import type { GetThreadType } from 'shared/graphql/queries/thread/getThread';
 import ThreadRenderer from 'src/components/threadRenderer';
@@ -48,7 +47,6 @@ type State = {
 type Props = {
   thread: GetThreadType,
   setThreadLock: Function,
-  pinThread: Function,
   editThread: Function,
   dispatch: Dispatch<Object>,
   currentUser: ?Object,
@@ -362,42 +360,6 @@ class ThreadDetailPure extends React.Component<Props, State> {
       });
   };
 
-  togglePinThread = () => {
-    const { pinThread, thread, dispatch } = this.props;
-    const isPinned = thread.community.pinnedThreadId === thread.id;
-    const communityId = thread.community.id;
-
-    if (thread.channel.isPrivate) {
-      return dispatch(
-        addToastWithTimeout(
-          'error',
-          'Only threads in public channels can be pinned.'
-        )
-      );
-    }
-
-    this.setState({
-      isPinningThread: true,
-    });
-
-    return pinThread({
-      threadId: thread.id,
-      communityId,
-      value: isPinned ? null : thread.id,
-    })
-      .then(() => {
-        this.setState({
-          isPinningThread: false,
-        });
-      })
-      .catch(err => {
-        this.setState({
-          isPinningThread: false,
-        });
-        dispatch(addToastWithTimeout('error', err.message));
-      });
-  };
-
   render() {
     const { currentUser, thread } = this.props;
 
@@ -487,7 +449,6 @@ class ThreadDetailPure extends React.Component<Props, State> {
             currentUser={currentUser}
             thread={thread}
             saveEdit={this.saveEdit}
-            togglePinThread={this.togglePinThread}
             isSavingEdit={isSavingEdit}
             threadLock={this.threadLock}
             triggerDelete={this.triggerDelete}
@@ -507,7 +468,6 @@ const ThreadDetail = compose(
   setThreadLockMutation,
   deleteThreadMutation,
   editThreadMutation,
-  pinThreadMutation,
   uploadImageMutation,
   withRouter
 )(ThreadDetailPure);


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Related issues (delete if you don't know of any)**
Closes #4949

Makes it possible to mute/unmute and do all other actions from the sticky bar without having to scroll to the top of the messages!

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->