### PR TITLE
Short term fix for broken chat input in thread modals

### DIFF
--- a/src/components/inboxThread/index.js
+++ b/src/components/inboxThread/index.js
@@ -23,6 +23,7 @@ import { ErrorBoundary } from 'src/components/error';
 import { withCurrentUser } from 'src/components/withCurrentUser';
 import getSnippet from 'shared/clients/draft-js/utils/getSnippet';
 import truncate from 'shared/truncate';
+import { MEDIA_BREAK } from 'src/components/layout';
 
 type Props = {
   active: boolean,
@@ -75,7 +76,7 @@ class InboxThread extends React.Component<Props> {
           <InboxLinkWrapper
             to={{
               pathname: getThreadLink(thread),
-              state: { modal: true },
+              state: { modal: !!window && window.innerWidth > MEDIA_BREAK },
             }}
           />
 


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

Testing locally, SSR on community profiles *already* doesn't work, so this has no impact. Importantly, it fixes mobile behavior because the thread modals on mobile break entirely, making it impossible to use the chat input. 

The solution here is to go back to the drawing board on our modal views to make these work on mobile, and at some point go back to the drawing board on mobile layout in general to handle fixed position chat inputs. 