### PR TITLE
Delete users messages on ban

### DIFF
--- a/src/views/newUserOnboarding/index.js
+++ b/src/views/newUserOnboarding/index.js
@@ -39,7 +39,12 @@ class NewUserOnboarding extends React.Component<Props> {
   };
 
   render() {
-    const { currentUser } = this.props;
+    const { currentUser, history } = this.props;
+
+    if (!currentUser) {
+      history.replace('/');
+      return null;
+    }
 
     if (currentUser && currentUser.username) {
       this.saveUsername();


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- api
- hyperion (frontend)

99% of all our bans are for spam. We should automatically delete all published threads and sent messages from banned users so that their spam posts don't linger and put the burden on community mods to clean up.

Tested locally and this works out, deleting everything the user ever created.