### PR TITLE
Fix overflow buttons login page

### DIFF
--- a/src/components/loginButtonSet/style.js
+++ b/src/components/loginButtonSet/style.js
@@ -17,6 +17,9 @@ export const Container = styled.div`
 export const A = styled.a`
   display: flex;
   grid-column: ${props => (props.githubOnly ? '1 / 3' : 'auto')};
+  @media (min-width: ${MEDIA_BREAK}px) {
+    grid-column: 1 / 2 span;
+  }
 `;
 
 export const SigninButton = styled.div`

--- a/src/views/login/style.js
+++ b/src/views/login/style.js
@@ -201,6 +201,9 @@ export const FullscreenContent = styled.div`
   flex-direction: column;
   padding: 32px 16px;
   flex: 1 0 auto;
+  @media (min-width: ${MEDIA_BREAK}px) {
+    padding-top: 40px;
+  }
 `;
 
 export const CodeOfConduct = styled.p`


### PR DESCRIPTION
The buttons on login page (https://spectrum.chat/login) were overflow on mobile: 

![61350302-7ad1fe80-a8aa-11e9-8016-bb3b40fcebc2](https://user-images.githubusercontent.com/49662698/63957687-4469d080-ca5f-11e9-958b-3ed46d4d55f4.png)

So, I did  a few adjusts using media query for fix this. Now:

![61351529-4fe9a980-a8ae-11e9-8923-2e21bc6da79f](https://user-images.githubusercontent.com/49662698/63957728-5cd9eb00-ca5f-11e9-9a0c-d072950a6ba9.png)
