### PR TITLE
Fix apps page styling

### DIFF
--- a/src/views/pages/apps/index.js
+++ b/src/views/pages/apps/index.js
@@ -2,11 +2,10 @@
 import * as React from 'react';
 import Section from 'src/components/themedSection';
 import PageFooter from '../components/footer';
-import { Wrapper } from '../style';
 import { Heading, Copy } from '../pricing/style';
 import { PrimaryButton } from 'src/components/button';
 import Icon from 'src/components/icon';
-import { Intro, ActionsContainer, TextContent } from './style';
+import { Intro, ActionsContainer, TextContent, PageWrapper } from './style';
 import type { ContextRouter } from 'react-router';
 import { track, events } from 'src/helpers/analytics';
 import Head from 'src/components/head';
@@ -27,7 +26,7 @@ class Features extends React.Component<Props, State> {
 
   render() {
     return (
-      <Wrapper data-cy="apps-page">
+      <PageWrapper data-cy="apps-page">
         <Head
           title={'Spectrum · Apps'}
           description={'Download Spectrum for Mac and Windows'}
@@ -54,7 +53,7 @@ class Features extends React.Component<Props, State> {
           </Intro>
         </Section>
         <PageFooter />
-      </Wrapper>
+      </PageWrapper>
     );
   }
 }

--- a/src/views/pages/apps/style.js
+++ b/src/views/pages/apps/style.js
@@ -1,5 +1,10 @@
 // @flow
 import styled from 'styled-components';
+import { Wrapper } from '../style';
+
+export const PageWrapper = styled(Wrapper)`
+  min-height: 100vh;
+`;
 
 export const Intro = styled.div`
   display: grid;


### PR DESCRIPTION
Hi, I spotted a small styling bug on the website -> [apps page](https://spectrum.chat/apps).
The screen doesn't have full height. It looks like this now:
![screencapture-spectrum-chat-apps-2019-08-30-13_09_51](https://user-images.githubusercontent.com/28235413/64016581-a68e0880-cb27-11e9-9371-7db9faf44e71.png)

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->

![desktop](https://user-images.githubusercontent.com/28235413/64016362-1780f080-cb27-11e9-8748-48f61f81ed06.png)

![mobile](https://user-images.githubusercontent.com/28235413/64016367-1cde3b00-cb27-11e9-88a3-e40cada36dfe.png)

