### PR TITLE
Removes redundant word on README.md folders structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ spectrum/
 ├── docs
 ├── email-templates
 ├── hermes     # Worker server (email sending)
-├── hyperion   # Server rendering server
+├── hyperion   # Rendering server
 ├── mercury    # Worker server (reputation)
 ├── public     # Public files used on the frontend
 ├── shared     # Shared JavaScript code


### PR DESCRIPTION
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

Just removing what I think, a redundant word inside the folder structure.