### PR TITLE
Add margin to the anchor instead of inner button

### DIFF
--- a/src/views/pages/pricing/style.js
+++ b/src/views/pages/pricing/style.js
@@ -267,9 +267,9 @@ export const PlanSection = styled.div`
   a {
     display: inline-block;
     align-self: center;
+    margin-top: 24px;
 
     button {
-      margin-top: 24px;
       padding: 8px 16px;
       font-size: 16px;
     }


### PR DESCRIPTION
A tiny change, there's no difference in how website looks, but now instead of the button its the anchor that has a top margin which lets us avoid the invisible clickable area.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)


**Related issues (delete if you don't know of any)**
Closes #5276

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->
<img width="1680" alt="Zrzut ekranu 2019-10-5 o 01 07 52" src="https://user-images.githubusercontent.com/23037261/66245229-c60ee700-e70c-11e9-8367-5b1129ab409e.png">
<img width="378" alt="Zrzut ekranu 2019-10-5 o 01 08 06" src="https://user-images.githubusercontent.com/23037261/66245230-c6a77d80-e70c-11e9-8b35-6f9cb12abbee.png">

