### PR TITLE
Fix the mobile view on login screen

### DIFF
--- a/src/components/loginButtonSet/style.js
+++ b/src/components/loginButtonSet/style.js
@@ -2,24 +2,18 @@
 import theme from 'shared/theme';
 import styled from 'styled-components';
 import { zIndex } from 'src/components/globals';
-import { MEDIA_BREAK } from 'src/components/layout';
 
 export const Container = styled.div`
   display: grid;
   grid-gap: 16px;
   align-items: flex-end;
   padding: 16px 0;
-  @media (min-width: ${MEDIA_BREAK}px) {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  grid-template-columns: repeat(2, 1fr);
 `;
 
 export const A = styled.a`
   display: flex;
-  grid-column: ${props => (props.githubOnly ? '1 / 3' : 'auto')};
-  @media (min-width: ${MEDIA_BREAK}px) {
-    grid-column: 1 / 2 span;
-  }
+  grid-column: 1 / 2 span;
 `;
 
 export const SigninButton = styled.div`


### PR DESCRIPTION
Closes #5197

Login page looks broken on Iphone X as buttons overflow the width of the screen. Using the same styles for mobile as for web (buttons are stacked) fixes this issue and looks perfectly fine.

<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->

Before:
<img width="377" alt="Zrzut ekranu 2019-10-5 o 01 23 43" src="https://user-images.githubusercontent.com/23037261/66245738-0e7bd400-e710-11e9-9c72-20a5b820d2de.png">

After:
<img width="381" alt="Zrzut ekranu 2019-10-5 o 01 23 56" src="https://user-images.githubusercontent.com/23037261/66245739-0e7bd400-e710-11e9-8019-9367e0a79460.png">
