### PR TITLE
fix(ThreadView): double/unnecessary loading in server rendered page

### DIFF
--- a/src/views/thread/index.js
+++ b/src/views/thread/index.js
@@ -19,4 +19,6 @@ const getLoading = () => ({ error, pastDelay }) => {
 export const ThreadView = Loadable({
   loader,
   loading: getLoading(),
+  modules: ['./container'],
+  webpack: () => [require.resolveWeak('./container')],
 });

--- a/src/views/thread/index.js
+++ b/src/views/thread/index.js
@@ -20,5 +20,4 @@ export const ThreadView = Loadable({
   loader,
   loading: getLoading(),
   modules: ['./container'],
-  webpack: () => [require.resolveWeak('./container')],
 });


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
## Description

I was investigating the cause of the unnecessary load or page flicker when a user visits `/:communitySlug/:channelSlug/threadId` route from an external page or reloads the page.

**Example 1**

![screen-capture](https://user-images.githubusercontent.com/14029371/73607619-710daf80-45de-11ea-8596-144d1c4f5f30.gif)

**Example 2**

![screen-capture-2](https://user-images.githubusercontent.com/14029371/73607688-5425ac00-45df-11ea-899d-50efcc4a2719.gif)

As seen above the page is server rendered correctly but it goes on to load the dynamic modules while rehydration causing either a double load or a page flicker based on the network.

### Cause
The issue seems to be arising from [`React-Loadable`](https://github.com/jamiebuilds/react-loadable#------------server-side-rendering) not being able to identify which dynamic modules were rendered which can be proved from hyperion debug logs

```bash
  hyperion:renderer server-side render /spectrum/general/tenetur-dolorem-inventore~a72e3d42-ddde-469a-be00-4168fd297d78 +3m
  hyperion:renderer querying API at https://localhost/api +0ms
  hyperion:renderer get data from tree +7ms
  hyperion:renderer got data from tree +638ms
  hyperion:renderer write header +0ms
  hyperion:renderer bundles used:  +2ms
```

Notice the blank `bundle used:  `

### Fix
The problem should not have arisen at the first place as the code correctly follows all steps to correctly configure  [`React-Loadable`](https://github.com/jamiebuilds/react-loadable#------------server-side-rendering). Anyho, it seems `react-loadable/babel` plugin doesn't work as described in our case and we have to manually specify the `opts.modules` and `opts.webpack` properties to get it to work.

```diff
export const ThreadView = Loadable({
  loader,
  loading: getLoading(),
+  modules: ['./container'],
+  webpack: () => [require.resolveWeak('./container')],
});
```

And the logs now correctly print which bundles were rendered i.e. Loadable now knows about the rendered dynamic modules.

```bash
  hyperion Hyperion, the server-side renderer, running at http://localhost:3006 +175ms
  hyperion:renderer server-side render /spectrum/general/tenetur-dolorem-inventore~a72e3d42-ddde-469a-be00-4168fd297d78 +8s
  hyperion:renderer querying API at https://localhost/api +1ms
  hyperion:renderer get data from tree +6ms
  hyperion:renderer got data from tree +673ms
  hyperion:renderer write header +0ms
  hyperion:renderer bundles used: /static/js/Thread.chunk.js +3ms
```

Happily ever after...

![screen-capture-3](https://user-images.githubusercontent.com/14029371/73607992-4a05ac80-45e3-11ea-9205-5d83cc668baa.gif)

**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge**

- hyperion (frontend)

**Fixes**

#5298
