### PR TITLE
fix mobile UI overflow

### DIFF
--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -174,7 +174,7 @@ export const PrimaryColumn = styled.section`
     border-right: 0;
     border-bottom: 0;
     grid-column-start: 1;
-    max-width: 100%;
+    max-width: 100vw;
     height: calc(100vh - ${TITLEBAR_HEIGHT}px);
   }
 `;

--- a/src/reset.css.js
+++ b/src/reset.css.js
@@ -112,7 +112,7 @@ export default createGlobalStyle`
 
   .markdown pre {
     font-size: 15px;
-    white-space: pre-wrap;
+    white-space: pre;
   }
 
   .markdown p {
@@ -227,7 +227,7 @@ export default createGlobalStyle`
   .markdown pre code {
     padding: 8px 16px;
     display: block;
-    white-space: pre-wrap;
+    white-space: pre;
     position: relative;
     margin: 0;
     border: none;

--- a/src/views/thread/style.js
+++ b/src/views/thread/style.js
@@ -828,6 +828,8 @@ export const Stretch = styled.div`
   align-items: center;
   flex-direction: column;
   width: 100%;
+  min-width: 1px;
+  max-width: inherit;
   position: relative;
   ${props =>
     props.isModal &&


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge**
- hyperion (frontend)

_I **think** it's hyperion... ?  I'm not sure; I didn't touch any of the `hyperion` code.  Just the code under `src/**/*`._

**Related issues**
Closes #4857 

---

There has been some existing issues with the UI on mobile.  If there were code-fences in the OP, it would cause the post to overflow horizontally; and since horizontal overflow was hidden, it would mean that content was inaccessible.  It would basically force you to switch to landscape view to try to see the content, and in landscape the view jumps around something fierce.  In all, it was a very unpleasant experience.

This PR does a couple of things:

* Turn off `pre-wrap` for code fences.  Trying to read code that has been force-wrapped is much harder to follow.  IMO, it's better to let the code-fence scroll horizontally, so you can read it the same way it was formatted.
* Turning off `pre-wrap` on the code-fences causes issues with the container bounds in both tablet view, and mobile.  To fix them, a lower bound **must** be set.
* Fix additional mobile UI horizontal overflow by inheriting the primary column's `max-width`.

### Original issue example
As you can see from these photos, the content overflows to the right, and an unfortunate amount of it is cut off.

<table>
<tr><td>

![image](https://user-images.githubusercontent.com/1935258/79039429-f2546600-7b7c-11ea-8713-a784cf91939e.png)

</td><td>

![image](https://user-images.githubusercontent.com/1935258/79039440-fed8be80-7b7c-11ea-8af2-38e87469e889.png)

</td></tr>
</table>

### Fix results

These images show the effect the fix has.  You can see how much of the content was cut off (almost full sentences, sometimes!).  They also show how the code looks without the wrapping being done to it.

<table>
<tr><td>

![image](https://user-images.githubusercontent.com/1935258/79039499-5bd47480-7b7d-11ea-907a-d325e806785f.png)

</td><td>

![image](https://user-images.githubusercontent.com/1935258/79039511-6d1d8100-7b7d-11ea-8eb7-9d49a04a433b.png)

</td><tr><td>

![image](https://user-images.githubusercontent.com/1935258/79039521-7dcdf700-7b7d-11ea-9575-94c5f9435357.png)

</td></tr>
</table>

## Additional information

I have tested this with Chrome and Firefox on Linux.  I have cycled through all of the breakpoints, to make sure everything fits like it should on a desktop browser.  The only mobile device I have to test with is an iPhone, though; I can say that the changes work well on it, both in Chrome and Safari.

If anybody else is able to help out with additional testing, I would really appreciate it.

---

I had to make quite a few changes to the repo just to make it capable of serving the app to my local network, so that I could test it with my iPhone.  Is there a good place to talk about that kind of stuff? 