### PR TITLE
fix code fence newline truncation

### DIFF
--- a/shared/clients/draft-js/renderer/index.js
+++ b/shared/clients/draft-js/renderer/index.js
@@ -72,6 +72,11 @@ const Embed = (props: EmbedData) => {
   return <ExternalEmbed {...props} />;
 };
 
+const EMPTY_THEME = {
+  plain: {},
+  styles: [],
+};
+
 type Options = {
   headings: boolean,
 };
@@ -108,7 +113,7 @@ export const createRenderer = (options: Options) => {
             {...defaultProps}
             code={getStringElements(child).join('\n')}
             language={Array.isArray(data) && data[0].language}
-            theme={undefined}
+            theme={EMPTY_THEME}
             key={keys[index]}
           >
             {({ className, style, tokens, getLineProps, getTokenProps }) => (


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge**
- hyperion (frontend) _???_

_Not sure if this is the correct answer here._ :confused: 

**Related issues**

Closes #5165

<!-- If there are UI changes please share mobile-responsive and desktop screenshots or recordings. -->

---

This uses an empty theme in place of `undefined` for `prism-react-renderer`, so that it will correctly identify newlines inside of code fences.  The relevant code that makes this identification is [here](https://github.com/FormidableLabs/prism-react-renderer/blob/master/src/components/Highlight.js#L87), which will be skipped if the theme is `undefined`.  I haven't noticed any adverse effects by defining an empty theme, but perhaps somebody who is more familiar with that package will have more insight into how far reaching this change could be?

If I were familiar in the least with `prism-react-renderer`, I might even look into setting up an actual theme, instead of using an empty one.  This seems to fix the issue rather effectively, though.


### Before

![image](https://user-images.githubusercontent.com/1935258/79041232-d60af600-7b89-11ea-834b-a07670d7a98b.png)

### After

![image](https://user-images.githubusercontent.com/1935258/79041234-db684080-7b89-11ea-810b-2a8aa1e57c7a.png)
