### PR TITLE
fix(ToggleChannelNotifications): improve toggle notification icon consistency

### DIFF
--- a/src/components/entities/listItems/channel.js
+++ b/src/components/entities/listItems/channel.js
@@ -151,10 +151,9 @@ const Channel = (props: Props) => {
           <Tooltip content={tipText}>
             <span style={{ marginLeft: '8px', display: 'flex' }}>
               <OutlineButton
-                disabled={isLoading}
                 onMouseEnter={() => setIsHoveringNotifications(true)}
                 onMouseLeave={() => setIsHoveringNotifications(false)}
-                style={{ padding: '4px' }}
+                style={{ padding: '4px', opacity: isLoading ? 0.6 : 1 }}
                 size={'small'}
               >
                 <Icon


### PR DESCRIPTION
<!-- FILL OUT THE BELOW FORM OR YOUR PR WILL BE AUTOMATICALLY CLOSED -->
**Status**
- [ ] WIP
- [x] Ready for review
- [ ] Needs testing

**Deploy after merge (delete what needn't be deployed)**
- hyperion (frontend)

**Problem description**
The problem is that a disabled button doesn't fire the `onMouseLeave` event ([more here][mouseleave]), preventing `isHoveringNotifications` being set to `false`.

**Related issues (delete if you don't know of any)**
Closes #5369

[mouseleave]: https://github.com/facebook/react/issues/4251